### PR TITLE
New DCCRG

### DIFF
--- a/MAKE/Makefile.arto
+++ b/MAKE/Makefile.arto
@@ -4,23 +4,21 @@ LNK = mpic++
 LIBRARY_PREFIX = $(HOME)/libraries
 FLAGS =
 
-
-CXXFLAGS = -I$(LIBRARY_PREFIX)/include -O3 -funroll-loops -std=c++0x -fopenmp -fabi-version=0 -mavx
+CXXFLAGS = -I$(LIBRARY_PREFIX)/include -O3 -funroll-loops -std=c++11 -fopenmp -fabi-version=0 -mavx -Wno-literal-suffix
 MATHFLAGS = -ffast-math
 LDFLAGS = -L$(LIBRARY_PREFIX)/lib
 LIB_MPI = -lgomp 
 
+INC_EIGEN = -I/usr/local/include/eigen3
 
-INC_EIGEN = -I/usr/include/eigen3
+INC_BOOST = -I/usr/local/include
+LIB_BOOST = -L/usr/local/lib -lboost_program_options
 
-INC_BOOST =
-LIB_BOOST = -lboost_program_options
-
-
+INC_ZOLTAN = -I/usr/local/include
 LIB_ZOLTAN = -lzoltan
 
-INC_VLSV = -I/home/sandroos/Codes/vlsv
-LIB_VLSV = -L/home/sandroos/Codes/vlsv -lvlsv
+INC_VLSV = -I/home/sandroos/codes/vlsv
+LIB_VLSV = -L/home/sandroos/codes/vlsv -lvlsv
 
 INC_SILO = 
 LIB_SILO = -lsilo
@@ -28,10 +26,9 @@ LIB_SILO = -lsilo
 INC_JEMALLOC = 
 LIB_JEMALLOC = -ljemalloc
 
-INC_DCCRG = -I/home/sandroos/Codes/dccrg
+INC_DCCRG = -I/home/sandroos/codes/dccrg
 
-LIB_PROFILE = -L/home/sandroos/Codes/phiprof/lib -lphiprof
-INC_PROFILE = -I/home/sandroos/Codes/phiprof/include
+LIB_PROFILE = -L/home/sandroos/codes/phiprof/lib -lphiprof
+INC_PROFILE = -I/home/sandroos/codes/phiprof/include
 
-
-INC_VECTORCLASS = -I/home/sandroos/Codes/vectorclass
+INC_VECTORCLASS = -I/home/sandroos/codes/vectorclass

--- a/grid.cpp
+++ b/grid.cpp
@@ -67,7 +67,7 @@ void initializeGrid(
    MPI_Comm comm = MPI_COMM_WORLD;
    int neighborhood_size = max(FS_STENCIL_WIDTH, VLASOV_STENCIL_WIDTH); 
 
-   const boost::array<uint64_t, 3> grid_length = {{P::xcells_ini, P::ycells_ini, P::zcells_ini}};
+   const std::array<uint64_t, 3> grid_length = {{P::xcells_ini, P::ycells_ini, P::zcells_ini}};
    dccrg::Cartesian_Geometry::Parameters geom_params;
    geom_params.start[0] = P::xmin;
    geom_params.start[1] = P::ymin;
@@ -216,8 +216,8 @@ void initSpatialCellCoordinates(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geomet
    vector<uint64_t> cells = mpiGrid.get_cells();
    #pragma omp parallel for
    for (uint i=0; i<cells.size(); ++i) {
-      boost::array<double, 3> cell_min = mpiGrid.geometry.get_min(cells[i]);
-      boost::array<double, 3> cell_length = mpiGrid.geometry.get_length(cells[i]);
+      std::array<double, 3> cell_min = mpiGrid.geometry.get_min(cells[i]);
+      std::array<double, 3> cell_length = mpiGrid.geometry.get_length(cells[i]);
       
       mpiGrid[cells[i]]->parameters[CellParams::XCRD] = cell_min[0];
       mpiGrid[cells[i]]->parameters[CellParams::YCRD] = cell_min[1];
@@ -255,10 +255,10 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
    mpiGrid.initialize_balance_load(true);
    phiprof::stop("dccrg.initialize_balance_load");
    
-   const boost::unordered_set<uint64_t>& incoming_cells = mpiGrid.get_cells_added_by_balance_load();
+   const std::unordered_set<uint64_t>& incoming_cells = mpiGrid.get_cells_added_by_balance_load();
    std::vector<uint64_t> incoming_cells_list (incoming_cells.begin(),incoming_cells.end()); 
 
-   const boost::unordered_set<uint64_t>& outgoing_cells = mpiGrid.get_cells_removed_by_balance_load();
+   const std::unordered_set<uint64_t>& outgoing_cells = mpiGrid.get_cells_removed_by_balance_load();
    std::vector<uint64_t> outgoing_cells_list (outgoing_cells.begin(),outgoing_cells.end()); 
    
    /*transfer cells in parts to preserve memory*/

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -7,7 +7,6 @@
 #include <ctime>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include "boost/array.hpp"
 #include "ioread.h"
 #include "phiprof.hpp"
 #include "parameters.h"
@@ -995,8 +994,8 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
 
    //set cell coordinates based on cfg (mpigrid) information
    for(uint i=0;i<gridCells.size();i++){
-      boost::array<double, 3> cell_min = mpiGrid.geometry.get_min(gridCells[i]);
-      boost::array<double, 3> cell_length = mpiGrid.geometry.get_length(gridCells[i]);
+      std::array<double, 3> cell_min = mpiGrid.geometry.get_min(gridCells[i]);
+      std::array<double, 3> cell_length = mpiGrid.geometry.get_length(gridCells[i]);
       
       mpiGrid[gridCells[i]]->parameters[CellParams::XCRD] = cell_min[0];
       mpiGrid[gridCells[i]]->parameters[CellParams::YCRD] = cell_min[1];

--- a/spatial_cell.hpp
+++ b/spatial_cell.hpp
@@ -8,19 +8,19 @@ Copyright 2011 Finnish Meteorological Institute
 #ifndef VLASIATOR_SPATIAL_CELL_HPP
 #define VLASIATOR_SPATIAL_CELL_HPP
 
-#include "algorithm"
-#include "boost/array.hpp"
-#include "boost/unordered_map.hpp"
-//#include "boost/unordered_set.hpp"
-#include "boost/lexical_cast.hpp"
-#include "cmath"
-#include "fstream"
-#include "iostream"
-#include "mpi.h"
-#include "limits"
-#include "stdint.h"
-#include "vector"
-#include "set"
+#include <algorithm>
+#include <boost/array.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/lexical_cast.hpp>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <mpi.h>
+#include <limits>
+#include <stdint.h>
+#include <vector>
+#include <set>
+#include <tuple>
 
 #include "memoryallocation.h"
 
@@ -218,7 +218,7 @@ namespace spatial_cell {
       vmesh::GlobalID velocity_block_has_grandparent(const vmesh::GlobalID& blockGID) const;
       
       // Following functions are related to MPI //
-      boost::tuple<void*, int, MPI_Datatype> get_mpi_datatype(const CellID cellID,const int sender_rank,const int receiver_rank,
+      std::tuple<void*, int, MPI_Datatype> get_mpi_datatype(const CellID cellID,const int sender_rank,const int receiver_rank,
                                                               const bool receiving,const int neighborhood);
       static uint64_t get_mpi_transfer_type(void);
       static void set_mpi_transfer_type(const uint64_t type,bool atSysBoundaries=false);
@@ -1302,7 +1302,7 @@ namespace spatial_cell {
    }
    
    /*! get mpi datatype for sending the cell data. */
-   inline boost::tuple<void*, int, MPI_Datatype> SpatialCell::get_mpi_datatype(
+   inline std::tuple<void*, int, MPI_Datatype> SpatialCell::get_mpi_datatype(
       const CellID cellID/*cell_id*/,
       const int sender_rank/*sender*/,
       const int receiver_rank/*receiver*/,
@@ -1498,7 +1498,7 @@ namespace spatial_cell {
          datatype = MPI_BYTE;
       }
 
-      return boost::make_tuple(address,count,datatype);
+      return std::make_tuple(address,count,datatype);
    }
 
    /*!

--- a/sysboundary/sysboundary.h
+++ b/sysboundary/sysboundary.h
@@ -12,7 +12,7 @@ Copyright 2010, 2011, 2012, 2013 Finnish Meteorological Institute
 #include <map>
 #include <list>
 #include <vector>
-#include "mpi.h"
+#include <mpi.h>
 #include <dccrg.hpp>
 #include <dccrg_cartesian_geometry.hpp>
 #include "../parameters.h"


### PR DESCRIPTION
Changed a few Boost containers (datatypes) to std containers (datatypes) so that Vlasiator compiles with newer dccrg versions.

Compiles and runs with the newest dccrg from github.

Test package results are interesting:

```
Running ./vlasiator on 20 mpi tasks, with 4 threads per task on 2 nodes (2 threads per physical core)
running acctest_2_maxw_500k_100k_20kms_10deg 
Application 10137859 resources: utime ~137s, stime ~10s, Rss ~15952, inblocks ~37236, outblocks ~91228
--------------------------------------------------------------------------------------------
acctest_2_maxw_500k_100k_20kms_10deg  -  Verifying 6ee0f2a457e2a71b1a7ee460c3596a6e2e39ae47___DVEC8F_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF against 2cb0d
8d92b338aecb357861ac3feac6b0086a0ca__DVEC4D_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-perf     |   new-perf       |  speedup                |
------------------------------------------------------------
4.243e+06        6.971e+06         1.64294
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
rho_0                1.28662                 3.21652e-07    
rho_v_0                6.1424e+07                 0.30023    
rho_v_1                9.83369e+06                 0.0171912    
rho_v_2                2.46922e+07                 0.0487697    
B_0                0                 0    
B_1                0                 0    
B_2                0                 0    
E_0                0                 -1    
E_1                0                 -1    
E_2                0                 -1    

--------------------------------------------------------------------------------------------
   Distribution function diff                                                               
--------------------------------------------------------------------------------------------
INFO Reading in two files.
File names: /stornext/field/vlasiator/test_package_data/2cb0d8d92b338aecb357861ac3feac6b0086a0ca__DVEC4D_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF/acctest_2
_maxw_500k_100k_20kms_10deg/fullf.0000001.vlsv & /lustre/tmp/sandroos/vlasiator/test_package_dccrg/run/acctest_2_maxw_500k_100k_20kms_10deg/fullf.0000001.vlsv
NonIdenticalBlocks:      5
IdenticalBlocks:         1567
Absolute_Error:          1.67616e-10
Mean-Absolute-Error:     5.68692e-15
Max-Absolute-Error:      6.24343e-13
Absolute-log-Error:      234.774
Mean-Absolute-log-Error: 0.00796547
--------------------------------------------------------------------------------------------
running transtest_2_maxw_500k_100k_20kms_20x20 
Application 10137863 resources: utime ~2191s, stime ~162s, Rss ~119776, inblocks ~189806, outblocks ~942777
--------------------------------------------------------------------------------------------
transtest_2_maxw_500k_100k_20kms_20x20  -  Verifying 6ee0f2a457e2a71b1a7ee460c3596a6e2e39ae47___DVEC8F_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF against 2cb
0d8d92b338aecb357861ac3feac6b0086a0ca__DVEC4D_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-perf     |   new-perf       |  speedup                |
------------------------------------------------------------
6.642e+06        8.504e+06         1.28034
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
rho_0                0.551068                 5.51041e-07    
rho_v_0                287721                 5.75413e-07    
rho_v_1                285139                 5.70249e-07    
rho_v_2                19260.1                 2.47579e+08    
B_0                0                 0    
B_1                0                 0    
B_2                0                 0    
E_0                0                 -1    
E_1                0                 -1    
E_2                0                 -1    

--------------------------------------------------------------------------------------------
   Distribution function diff                                                               
--------------------------------------------------------------------------------------------
INFO Reading in two files.
File names: /stornext/field/vlasiator/test_package_data/2cb0d8d92b338aecb357861ac3feac6b0086a0ca__DVEC4D_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF/transtest
_2_maxw_500k_100k_20kms_20x20/fullf.0000001.vlsv & /lustre/tmp/sandroos/vlasiator/test_package_dccrg/run/transtest_2_maxw_500k_100k_20kms_20x20/fullf.0000001.vlsv
NonIdenticalBlocks:      0
IdenticalBlocks:         423200
Absolute_Error:          2.37076e-10
Mean-Absolute-Error:     2.64594e-17
Max-Absolute-Error:      5.47758e-15
Absolute-log-Error:      379.801
Mean-Absolute-log-Error: 4.23885e-05
--------------------------------------------------------------------------------------------
running Magnetosphere_small 
Parameter data file (sw1.dat) has 1 values
Application 10137896 resources: utime ~2497s, stime ~107s, Rss ~68448, inblocks ~470627, outblocks ~99491
--------------------------------------------------------------------------------------------
Magnetosphere_small  -  Verifying 6ee0f2a457e2a71b1a7ee460c3596a6e2e39ae47___DVEC8F_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF against 2cb0d8d92b338aecb35786
1ac3feac6b0086a0ca__DVEC4D_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-perf     |   new-perf       |  speedup                |
------------------------------------------------------------
6.808e+06        9.398e+06         1.38043
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
rho_0                18.2818                 1.78619e-05    
rho_v_0                2.13455e+07                 4.26904e-05    
rho_v_1                1.47502e+07                 0.000748798    
rho_v_2                3.93307e+06                 0.00244584    
B_0                2.34462e-14                 5.87659e-06    
B_1                2.4179e-14                 6.00142e-06    
B_2                4.47885e-13                 2.68731e-08    
E_0                7.70148e-07                 0.000345443    
E_1                7.62492e-07                 0.000118873    
E_2                5.7887e-08                 3.24329e-05    
--------------------------------------------------------------------------------------------
   Distribution function diff                                                               
--------------------------------------------------------------------------------------------
INFO Reading in two files.
File names: /stornext/field/vlasiator/test_package_data/2cb0d8d92b338aecb357861ac3feac6b0086a0ca__DVEC4D_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF/Magnetosp
here_small/bulk.0000001.vlsv & /lustre/tmp/sandroos/vlasiator/test_package_dccrg/run/Magnetosphere_small/bulk.0000001.vlsv
NonIdenticalBlocks:      3
IdenticalBlocks:         3321
Absolute_Error:          2.6323e-11
Mean-Absolute-Error:     1.05473e-15
Max-Absolute-Error:      3.7448e-13
Absolute-log-Error:      260.969
Mean-Absolute-log-Error: 0.0104567
--------------------------------------------------------------------------------------------
running acctest_1_maxw_500k_30kms_1deg 
Application 10137914 resources: utime ~495s, stime ~19s, Rss ~15976, inblocks ~37239, outblocks ~90005
--------------------------------------------------------------------------------------------
acctest_1_maxw_500k_30kms_1deg  -  Verifying 6ee0f2a457e2a71b1a7ee460c3596a6e2e39ae47___DVEC8F_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF against 2cb0d8d92b3
38aecb357861ac3feac6b0086a0ca__DVEC4D_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-perf     |   new-perf       |  speedup                |
------------------------------------------------------------
4.23e+06        7.099e+06         1.67825
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
rho_0                4.96455                 2.48228e-06    
rho_v_0                1.60101e+07                 0.0196354    
rho_v_1                4.98435e+08                 0.000494803    
rho_v_2                1.55278e+08                 0.126879    
B_0                0                 0    
B_1                0                 0    
B_2                0                 0    
E_0                0                 -1    
E_1                0                 -1    
E_2                0                 -1    
--------------------------------------------------------------------------------------------
   Distribution function diff                                                               
--------------------------------------------------------------------------------------------
INFO Reading in two files.
File names: /stornext/field/vlasiator/test_package_data/2cb0d8d92b338aecb357861ac3feac6b0086a0ca__DVEC4D_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF/acctest_1
_maxw_500k_30kms_1deg/fullf.0000001.vlsv & /lustre/tmp/sandroos/vlasiator/test_package_dccrg/run/acctest_1_maxw_500k_30kms_1deg/fullf.0000001.vlsv
NonIdenticalBlocks:      7
IdenticalBlocks:         692
Absolute_Error:          3.4394e-10
Mean-Absolute-Error:     3.04264e-14
Max-Absolute-Error:      2.54945e-12
Absolute-log-Error:      497.194
Mean-Absolute-log-Error: 0.0439839
--------------------------------------------------------------------------------------------
```

I ran this with DP DPF, speedup of 38% ?
