### PR TITLE
Bugfix for #53. Now restart will write even if restart write interval < 0.

### DIFF
--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -485,12 +485,11 @@ int main(int argn,char* args[]) {
       int writeRestartNow;
       
       if (myRank == MASTER_RANK) {
-         if (P::saveRestartWalltimeInterval >=0.0 && (
-               P::saveRestartWalltimeInterval*wallTimeRestartCounter <=  MPI_Wtime()-initialWtime ||
-               P::tstep ==P::tstep_max ||
-               P::t >= P::t_max ||
-               (doBailout > 0 && P::bailout_write_restart)
-            )
+         if (  (P::saveRestartWalltimeInterval >=0.0
+            && (P::saveRestartWalltimeInterval*wallTimeRestartCounter <=  MPI_Wtime()-initialWtime
+               || P::tstep ==P::tstep_max
+               || P::t >= P::t_max))
+            || (doBailout > 0 && P::bailout_write_restart)
          ) {
             writeRestartNow = 1;
          }


### PR DESCRIPTION
Patch suggestion to get a restart upon bailout even when the restart walltime interval is not set/negative.
