### PR TITLE
Fix vector expressions to work with the fallback-vectorclass.

### DIFF
--- a/vlasovsolver/cpu_slope_limiters.hpp
+++ b/vlasovsolver/cpu_slope_limiters.hpp
@@ -68,8 +68,8 @@ inline Vec slope_limiter_mc(const Vec& l,const Vec& m, const Vec& r) {
 inline Vec slope_limiter_minmod_amr(const Vec& l,const Vec& m, const Vec& r,const Vec& a,const Vec& b) {
    Vec J = r-l;
    Vec f = (m-l)/J;
-   f = min(1.0,f);
-   return min(f/(1+a),(1-f)/(1+b))*2*J;
+   f = min(Vec(1.0),f);
+   return min(f/(1+a),(Vec(1.)-f)/(1+b))*2*J;
 }
 
 inline Vec slope_limiter(const Vec& l,const Vec& m, const Vec& r) {
@@ -89,7 +89,7 @@ inline Vec slope_limiter_amr(const Vec& l,const Vec& m, const Vec& r,const Vec& 
 inline void slope_limiter(const Vec& l,const Vec& m, const Vec& r, Vec& slope_abs, Vec& slope_sign) {
    const Vec slope=slope_limiter(l,m,r);
    slope_abs=abs(slope);
-   slope_sign=select(slope > 0, 1.0, -1.0);
+   slope_sign=select(slope > 0, Vec(1.0), Vec(-1.0));
 }
 
 #endif

--- a/vlasovsolver/vec.h
+++ b/vlasovsolver/vec.h
@@ -90,9 +90,9 @@ typedef double Realv;
 #ifdef VEC4F_FALLBACK
 //user portable vectorclass
 #include "vectorclass_fallback.h"
-typedef Vec4Simple<float> Vec4;
-typedef Vec4Simple<bool> Vec4b;
-typedef Vec4Simple<int> Vec4i;
+typedef Vec4Simple<float> Vec;
+typedef Vec4Simple<bool> Vecb;
+typedef Vec4Simple<int> Veci;
 typedef float Realv;
 #define to_realv(v) to_float(v)
 #define VECL 4

--- a/vlasovsolver/vectorclass_fallback.h
+++ b/vlasovsolver/vectorclass_fallback.h
@@ -575,5 +575,8 @@ static inline Vec4Simple<float> to_float(Vec4Simple<T> const & a){
   return Vec4Simple<float>(a.val[0], a.val[1], a.val[2], a.val[3]);
 }
 
+// Dummy functions that Agner vectorclass has.
+// These are here to suppress compiler error messages only
+static void no_subnormals() {};
 
 #endif


### PR DESCRIPTION
In some places, the slope limiters relied on implicit type conversion
from scalars to vectors, which Agner Vectorclass can do, but our
fallback can't.

Also, a dummy no_subnormals() function was added to the fallback
vectorclass to supress compiler errors about them.
