### PR TITLE
version.cpp contains the diff again (stored as a hexdump now).

### DIFF
--- a/generate_version.sh
+++ b/generate_version.sh
@@ -47,6 +47,13 @@ module list 2>&1 | gawk '{printf("%s\"%s\"%s\n","    cout << ",$0," << endl;")}'
 echo "    cout << endl << \"----------- git status --------- \"<<endl;" >>version.cpp
 git status | sed 's/\"/\\"/g' | sed 's/\\\"/\\"/g'  |gawk '{printf("%s\"%s\"%s\n","    cout << ",$0," << endl;")}' >> version.cpp
 
+echo "    cout << endl << \"----------- git diff ---------- \"<<endl;" >>version.cpp
+
+echo "    const char diff_data[] = {" >> version.cpp
+git diff `git status -s |grep -v generate_version.sh |cut -b4-` | xxd -i >> version.cpp
+echo "    , 0 };" >> version.cpp
+echo "    cout << diff_data << endl;" >> version.cpp
+
 cat >> version.cpp <<EOF
   }
   return true;


### PR DESCRIPTION
git diff is piped through xxd -i to create a binary array, and that one
is just normally printed as a character string, thus getting rid of all
quoting problems.
(Only disadvantage is less pretty version.cpp code, but who reads that
anyway?)
