### PR TITLE
Improved velocity distribution extraction

### DIFF
--- a/tools/vlsvextract.cpp
+++ b/tools/vlsvextract.cpp
@@ -2,11 +2,9 @@
 /*
 This file is part of Vlasiator.
 
-Copyright 2010, 2011, 2012, 2013 Finnish Meteorological Institute
+Copyright 2010-2015 Finnish Meteorological Institute
  */
 
-
-#include <cstdlib>
 #include <iostream>
 
 #include <limits>
@@ -17,22 +15,19 @@ Copyright 2010, 2011, 2012, 2013 Finnish Meteorological Institute
 #include <dirent.h>
 #include <stdio.h>
 
-#include "definitions.h"
-#include "vlsv_reader.h"
-#include "vlsv_writer.h"
-#include "vlsvreaderinterface.h"
-#include <vlsv_amr.h>
+#include <unordered_set>
 
-#include <array> //std::array is from here
-#include <unordered_set> //std::unordered_set from here
+#include <vlsv_reader.h>
+#include <vlsv_writer.h>
+#include <vlsv_amr.h>
 #include <boost/program_options.hpp>
 #include <Eigen/Dense>
+#include <phiprof.hpp>
 
-#include "phiprof.hpp"
-
+#include "vlsvreaderinterface.h"
+#include "vlsvextract.h"
 
 using namespace std;
-
 using namespace Eigen;
 using namespace vlsv;
 namespace po = boost::program_options;
@@ -40,114 +35,35 @@ namespace po = boost::program_options;
 // If set to true, vlsvextract writes some debugging info to stderr
 static bool runDebug = false;
 
-template<typename REAL> struct NodeCrd {
-   static REAL EPS;
-   REAL x;
-   REAL y;
-   REAL z;
+bool NodeComp::operator()(const NodeCrd<double>& a, const NodeCrd<double>& b) const {
+   double EPS = 0.5e-3 * (fabs(a.z) + fabs(b.z));
+   if (a.z > b.z + EPS) return false;
+   if (a.z < b.z - EPS) return true;
 
-   NodeCrd(const REAL& x, const REAL& y, const REAL& z) : x(x), y(y), z(z) {
-   }
+   EPS = 0.5e-3 * (fabs(a.y) + fabs(b.y));
+   if (a.y > b.y + EPS) return false;
+   if (a.y < b.y - EPS) return true;
 
-   bool comp(const NodeCrd<REAL>& n) const {
-      REAL EPS1, EPS2, EPS;
-      EPS1 = 1.0e-6 * fabs(x);
-      EPS2 = 1.0e-6 * fabs(n.x);
-      if (x == 0.0) EPS1 = 1.0e-7;
-      if (n.x == 0.0) EPS2 = 1.0e-7;
-      EPS = max(EPS1, EPS2);
-      if (fabs(x - n.x) > EPS) return false;
+   EPS = 0.5e-3 * (fabs(a.x) + fabs(b.x));
+   if (a.x > b.x + EPS) return false;
+   if (a.x < b.x - EPS) return true;
+   return false;
+}
 
-      EPS1 = 1.0e-6 * fabs(y);
-      EPS2 = 1.0e-6 * fabs(n.y);
-      if (y == 0.0) EPS1 = 1.0e-7;
-      if (n.y == 0.0) EPS2 = 1.0e-7;
-      EPS = max(EPS1, EPS2);
-      if (fabs(y - n.y) > EPS) return false;
+bool NodeComp::operator()(const NodeCrd<float>& a,const NodeCrd<float>& b) const {
+   float EPS = 0.5e-3 * (fabs(a.z) + fabs(b.z));
+   if (a.z > b.z + EPS) return false;
+   if (a.z < b.z - EPS) return true;
 
-      EPS1 = 1.0e-6 * fabs(z);
-      EPS2 = 1.0e-6 * fabs(n.z);
-      if (z == 0.0) EPS1 = 1.0e-7;
-      if (n.z == 0.0) EPS2 = 1.0e-7;
-      EPS = max(EPS1, EPS2);
-      if (fabs(z - n.z) > EPS) return false;
-      return true;
-   }
-};
+   EPS = 0.5e-3 * (fabs(a.y) + fabs(b.y));
+   if (a.y > b.y + EPS) return false;
+   if (a.y < b.y - EPS) return true;
 
-struct NodeComp {
-
-   bool operator()(const NodeCrd<double>& a, const NodeCrd<double>& b) const {
-      double EPS = 0.5e-3 * (fabs(a.z) + fabs(b.z));
-      if (a.z > b.z + EPS) return false;
-      if (a.z < b.z - EPS) return true;
-
-      EPS = 0.5e-3 * (fabs(a.y) + fabs(b.y));
-      if (a.y > b.y + EPS) return false;
-      if (a.y < b.y - EPS) return true;
-
-      EPS = 0.5e-3 * (fabs(a.x) + fabs(b.x));
-      if (a.x > b.x + EPS) return false;
-      if (a.x < b.x - EPS) return true;
-      return false;
-   }
-
-   bool operator()(const NodeCrd<float>& a, const NodeCrd<float>& b) const {
-      float EPS = 0.5e-3 * (fabs(a.z) + fabs(b.z));
-      if (a.z > b.z + EPS) return false;
-      if (a.z < b.z - EPS) return true;
-
-      EPS = 0.5e-3 * (fabs(a.y) + fabs(b.y));
-      if (a.y > b.y + EPS) return false;
-      if (a.y < b.y - EPS) return true;
-
-      EPS = 0.5e-3 * (fabs(a.x) + fabs(b.x));
-      if (a.x > b.x + EPS) return false;
-      if (a.x < b.x - EPS) return true;
-      return false;
-   }
-};
-
-
-//A struct for holding info on cell structure (the grid)
-struct CellStructure {
-   uint64_t cell_bounds[3];     /**< The number of cells in x, y, z direction (initialized somewhere in read parameters).*/
-   Real cell_length[3];         /**< Length of a cell in x, y, z direction. */
-   Real min_coordinates[3];     /**< x_min, y_min, z_min are stored here.*/
-   uint64_t vcell_bounds[3];    /**< The number of cells in x, y, z direction (initialized somewhere in read parameters).*/
-   Real vblock_length[3];       /**< Size (dvx,dvy,dvz) of a velocity block in vx, vy, vz directions.*/
-   Real min_vcoordinates[3];    /**< vx_min, vy_min, vz_min are stored here.*/
-   uint32_t maxVelRefLevel;     /**< Maximum refinement level of velocity meshes.*/
-
-   int slicedCoords[3];
-   Real slicedCoordValues[3];
-};
-
-//A class for holding user options
-class UserOptions {
-public:
-   bool getCellIdFromLine;
-   bool getCellIdFromInput;
-   bool getCellIdFromCoordinates;
-   bool rotateVectors;
-   bool plasmaFrame;
-   uint64_t cellId;
-   uint32_t numberOfCoordinatesInALine;
-   vector<string> outputDirectoryPath;
-   array<Real, 3> coordinates;
-   array<Real, 3> point1;
-   array<Real, 3> point2;
-   UserOptions() {
-      getCellIdFromLine = false;
-      getCellIdFromInput = false;
-      getCellIdFromCoordinates = false;
-      rotateVectors = false;
-      cellId = numeric_limits<uint64_t>::max();
-      numberOfCoordinatesInALine = 0;
-   }
-   ~UserOptions() {}
-};
-
+   EPS = 0.5e-3 * (fabs(a.x) + fabs(b.x));
+   if (a.x > b.x + EPS) return false;
+   if (a.x < b.x - EPS) return true;
+   return false;
+}
 
 uint64_t convUInt(const char* ptr, const datatype::type & dataType, const uint64_t& dataSize) {
    if (dataType != datatype::type::UINT) {
@@ -172,35 +88,16 @@ uint64_t convUInt(const char* ptr, const datatype::type & dataType, const uint64
    return 0;
 }
 
-//Outputs the velocity block indices of some given block into indices
-//Input:
-//[0] cellStruct -- some cell structure that has been constructed properly
-//[1] block -- some velocity block id
-//Output:
-//[0] indices -- the array where to store the indices
-void getVelocityBlockCoordinates(const CellStructure & cellStruct, const uint64_t block, array<Real, 3> & coordinates ) {
-   //First get indices:
-   array<uint64_t, 3> blockIndices;
-   blockIndices[0] = block % cellStruct.vcell_bounds[0];
-   blockIndices[1] = (block / cellStruct.vcell_bounds[0]) % cellStruct.vcell_bounds[1];
-   blockIndices[2] = block / (cellStruct.vcell_bounds[0] * cellStruct.vcell_bounds[1]);
-   //Store the coordinates:
-   for( int i = 0; i < 3; ++i ) {
-      coordinates[i] = cellStruct.min_vcoordinates[i] + cellStruct.vblock_length[i] * blockIndices[i];
-   }
-   return;
-}
-
 bool convertSlicedVelocityMesh(vlsvinterface::Reader& vlsvReader,const string& fname,const string& meshName,
-                               CellStructure& cellStruct) {
+                               CellStructure& cellStruct,const std::string& popName) {
    bool success = true;
-   
+
    // TEST
    cellStruct.slicedCoords[0] = 2;
    cellStruct.slicedCoords[1] = 4;
    cellStruct.slicedCoords[2] = 5;
    cellStruct.slicedCoordValues[0] = 1e3;
-   cellStruct.slicedCoordValues[1] = 5e3;
+   cellStruct.slicedCoordValues[1] = -5e3;
    cellStruct.slicedCoordValues[2] = 5e3;
 
    string outputMeshName = "VelSlice";
@@ -274,8 +171,6 @@ bool convertSlicedVelocityMesh(vlsvinterface::Reader& vlsvReader,const string& f
       if (cellCrds[cellStruct.slicedCoords[0]] > cellStruct.slicedCoordValues[0]) continue;
       if (cellCrds[cellStruct.slicedCoords[0]+3] < cellStruct.slicedCoordValues[0]) continue;
 
-      cerr << "accept " << cellId << endl;
-      
       // Buffer all velocity mesh variables
       vector<char*> varBuffer(blockVarNames.size());
       int counter=0;
@@ -304,7 +199,7 @@ bool convertSlicedVelocityMesh(vlsvinterface::Reader& vlsvReader,const string& f
       if (varInfo.size() > variables.size()) variables.resize(varInfo.size());
 
       vector<uint64_t> blockIDs;
-      if (vlsvReader.getBlockIds(cellIDs[cell],blockIDs) == false) {         
+      if (vlsvReader.getBlockIds(cellIDs[cell],blockIDs,popName) == false) {
          for (size_t v=0; v<varBuffer.size(); ++v) delete [] varBuffer[v];
          continue;
       }
@@ -748,21 +643,24 @@ bool convertVelocityBlocks2(
                             vlsvinterface::Reader& vlsvReader,
                             const string& fname,
                             const string& meshName,
-                            const CellStructure& cellStruct,
+                            CellStructure& cellStruct,
                             const uint64_t& cellID,
                             const bool rotate,
-                            const bool plasmaFrame
+                            const bool plasmaFrame,
+                            vlsv::Writer& out,
+                            const std::string& popName
                            ) {
    bool success = true;
    
-   string outputMeshName = "VelGrid";
-   int cellsInBlocksPerDirection = 4;
-
-   vlsv::Writer out;
-   if (out.open(fname,MPI_COMM_SELF,0) == false) {
-      cerr << "ERROR, failed to open output file with vlsv::Writer at " << __FILE__ << " " << __LINE__ << endl;
+   // Read velocity mesh metadata for this population
+   if (setVelocityMeshVariables(vlsvReader,cellStruct,popName) == false) {
+      cerr << "ERROR, failed to read velocity mesh metadata for species '";
+      cerr << popName << "'" << endl;
       return false;
    }
+
+   string outputMeshName = "VelGrid_" + popName;
+   int cellsInBlocksPerDirection = 4;
    
    // Transformation (translation + rotation) matrix, defaults 
    // to identity matrix. Modified if rotate and/or plasmaFrame are true.
@@ -795,7 +693,7 @@ bool convertVelocityBlocks2(
 
    // Read velocity block global IDs and write them out
    vector<uint64_t> blockIds;
-   if (vlsvReader.getBlockIds(cellID,blockIds) == false ) {
+   if (vlsvReader.getBlockIds(cellID,blockIds,popName) == false ) {
       cerr << "ERROR, FAILED TO READ BLOCK IDS AT " << __FILE__ << " " << __LINE__ << endl;
       return false;
    }
@@ -812,9 +710,20 @@ bool convertVelocityBlocks2(
 
    if (out.writeArray("MESH",attributes,blockIds.size(),1,&(blockIds[0])) == false) success = false;
    
-   attributes["name"] = "VelBlocks";
+   attributes["name"] = "VelBlocks_" + popName;
    if (out.writeArray("MESH",attributes,blockIds.size(),1,&(blockIds[0])) == false) success = false;
    
+   attributes.clear();
+
+   // Create array of phase-space mesh cell IDs, this is needed to make 
+   // vlsvdiff work with extracted velocity meshes
+   vector<uint64_t> cellIDs(blockIds.size()*64);
+   for (size_t b=0; b<blockIds.size(); ++b) {
+      for (int c=0; c<64; ++c) cellIDs[b*64+c] = blockIds[b]*64+c;
+   }
+   attributes["mesh"] = outputMeshName;
+   attributes["name"] = "CellID";
+   if (out.writeArray("VARIABLE",attributes,cellIDs.size(),1,&(cellIDs[0])) == false) success = false;
    attributes.clear();
 
    // Make domain size array
@@ -823,7 +732,11 @@ bool convertVelocityBlocks2(
    domainSize[1] = 0;
    attributes["mesh"] = outputMeshName;
    if (out.writeArray("MESH_DOMAIN_SIZES",attributes,1,2,domainSize) == false) success = false;
-   attributes["mesh"] = "VelBlocks";
+     {
+        vector<uint64_t> ().swap(blockIds);
+     }
+   
+   attributes["mesh"] = "VelBlocks_" + popName;
    if (out.writeArray("MESH_DOMAIN_SIZES",attributes,1,2,domainSize) == false) success = false;
 
    // Make bounding box array
@@ -835,7 +748,7 @@ bool convertVelocityBlocks2(
    bbox[3] = 1;
    bbox[4] = 1;
    bbox[5] = 1;
-   attributes["mesh"] = "VelBlocks";
+   attributes["mesh"] = "VelBlocks_" + popName;
    if (out.writeArray("MESH_BBOX",attributes,6,1,bbox) == false) success = false;
    
    bbox[3] = cellsInBlocksPerDirection;
@@ -870,7 +783,10 @@ bool convertVelocityBlocks2(
       }
 
       attributes["mesh"] = outputMeshName;
-      if (out.writeArray(arrayName,attributes,coords.size(),1,&(coords[0])) == false) success = false;
+      if (out.writeArray(arrayName,attributes,coords.size(),1,&(coords[0])) == false) {
+         cerr << "ERROR, failed to write velocity grid coordinates in " << __FILE__ << ":" << __LINE__ << endl;
+         success = false;
+      }
    }
      {
         vector<float> ().swap(coords);
@@ -888,8 +804,11 @@ bool convertVelocityBlocks2(
       else if (crd == 1) arrayName = "MESH_NODE_CRDS_Y";
       else if (crd == 2) arrayName = "MESH_NODE_CRDS_Z";
       
-      attributes["mesh"] = "VelBlocks";
-      if (out.writeArray(arrayName,attributes,coords.size(),1,&(coords[0])) == false) success = false;
+      attributes["mesh"] = "VelBlocks_" + popName;
+      if (out.writeArray(arrayName,attributes,coords.size(),1,&(coords[0])) == false) {
+         cerr << "ERROR, failed to write velocity block coordinates in " << __FILE__ << ":" << __LINE__ << endl;
+         success = false;
+      }
    }
      {
         vector<float> ().swap(coords);
@@ -898,38 +817,54 @@ bool convertVelocityBlocks2(
    // Write dummy ghost zone data (not applicable here):
    uint64_t dummy;
    attributes["mesh"] = outputMeshName;
-   if (out.writeArray("MESH_GHOST_LOCALIDS",attributes,domainSize[1],1,&dummy) == false) success = false;
-   if (out.writeArray("MESH_GHOST_DOMAINS",attributes,domainSize[1],1,&dummy) == false) success = false;
+   if (out.writeArray("MESH_GHOST_LOCALIDS",attributes,domainSize[1],1,&dummy) == false) {
+      cerr << "ERROR, failed to write ghost cell local IDs in " << __FILE__ << ":" << __LINE__ << endl;
+      success = false;
+   }
+   if (out.writeArray("MESH_GHOST_DOMAINS",attributes,domainSize[1],1,&dummy) == false) {
+      cerr << "ERROR, failed to write ghost cell domains in " << __FILE__ << ":" << __LINE__ << endl;
+      success = false;
+   }
    
-   attributes["mesh"] = "VelBlocks";
-   if (out.writeArray("MESH_GHOST_LOCALIDS",attributes,domainSize[1],1,&dummy) == false) success = false;
-   if (out.writeArray("MESH_GHOST_DOMAINS",attributes,domainSize[1],1,&dummy) == false) success = false;
+   attributes["mesh"] = "VelBlocks_" + popName;
+   if (out.writeArray("MESH_GHOST_LOCALIDS",attributes,domainSize[1],1,&dummy) == false) {
+      cerr << "ERROR, failed to write ghost cell local IDs in " << __FILE__ << ":" << __LINE__ << endl;
+      success = false;
+   }
+   if (out.writeArray("MESH_GHOST_DOMAINS",attributes,domainSize[1],1,&dummy) == false) {
+      cerr << "ERROR, failed to write ghost cell domains in " << __FILE__ << ":" << __LINE__ << endl;
+      success = false;
+   }
 
    // ***** Convert variables ***** //
    
-   //Get the name of variables:
+   // Get the names of velocity mesh variables. NOTE: This will find _all_ particle populations
+   // which are stored in their separate meshes.
    set<string> blockVarNames;
    const string attributeName = "name";
    if (vlsvReader.getUniqueAttributeValues( "BLOCKVARIABLE", attributeName, blockVarNames) == false) {
       cerr << "ERROR, FAILED TO GET UNIQUE ATTRIBUTE VALUES AT " << __FILE__ << " " << __LINE__ << endl;
    }
-   
+
    //Writing VLSV file
    if (success == true) {
       for (set<string>::iterator it = blockVarNames.begin(); it != blockVarNames.end(); ++it) {
+         // Only accept the population that belongs to this mesh
+         if (*it != popName) continue;
+
          list<pair<string, string> > attribs;
          attribs.push_back(make_pair("name", *it));
          attribs.push_back(make_pair("mesh", meshName));
          datatype::type dataType;
          uint64_t arraySize, vectorSize, dataSize;
          if (vlsvReader.getArrayInfo("BLOCKVARIABLE", attribs, arraySize, vectorSize, dataType, dataSize) == false) {
-            cerr << "Could not read BLOCKVARIABLE array info" << endl;
+            cerr << "Could not read BLOCKVARIABLE array info in " << __FILE__ << ":" << __LINE__ << endl;
             return false;
          }
 	 
          char* buffer = new char[N_blocks * vectorSize * dataSize];
          if (vlsvReader.readArray("BLOCKVARIABLE", attribs, vlsvReader.getBlockOffset(cellID), N_blocks, buffer) == false) {
-            cerr << "ERROR could not read block variable" << endl;
+            cerr << "ERROR could not read block variable in " << __FILE__ << ":" << __LINE__ << endl;
             delete[] buffer;
             return success;
          }
@@ -946,25 +881,11 @@ bool convertVelocityBlocks2(
          
          delete [] buffer; buffer = NULL;
       }
-      
-      // Write velocity cell IDs:
-      vector<uint64_t> cellIDs(blockIds.size()*64);
-      for (size_t b=0; b<blockIds.size(); ++b) {
-         for (size_t c=0; c<64; ++c) {
-            cellIDs[b*64+c] = blockIds[b]*64 + c;
-         }
-      }
-      
-      attributes["name"] = "CellID";
-      if (out.writeArray("VARIABLE",attributes,cellIDs.size(),1,&(cellIDs[0])) == false) success = false;
    }
    
    vlsvReader.clearCellsWithBlocks();
-   out.close();
    return success;   
 }
-
-
 
 //Creates a cell id list of type std::unordered set and saves it in the input parameters
 //Input:
@@ -1027,7 +948,51 @@ bool createCellIdList( T & vlsvReader, unordered_set<uint64_t> & cellIdList ) {
    return true;
 }
 
+/** Driver function for convertVelocityBlocks. Reads the names of 
+ * existing particle species and calls convertVelocityBlocks2 for 
+ * each of them.
+ * @param vlsvReader VLSV file reader that has input file open.
+ * @param fname Name of the input file.
+ * @param meshName Name of the spatial mesh.
+ * @param cellStruct Struct containing mesh metadata.
+ * @param cellID ID of the spatial cell whose distribution function(s) are to be extracted.
+ * @param rotate If true, distribution function(s) are rotated so that the magnetic field points 
+ * along +vz axis.
+ * @param plasmaFrame If true, distribution function(s) are translated to local plasma rest frame.
+ * @return If true, all distributions were extracted successfully.*/
+bool convertVelocityBlocks2(
+                            vlsvinterface::Reader& vlsvReader,
+                            const string& fname,
+                            const string& meshName,
+                            CellStructure& cellStruct,
+                            const uint64_t& cellID,
+                            const bool rotate,
+                            const bool plasmaFrame
+                           ) {
+   // Read names of all existing particle species
+   set<string> popNames;
+   if (vlsvReader.getUniqueAttributeValues("BLOCKIDS","name",popNames) == false) {
+      cerr << "ERROR could not read population names in " << __FILE__ << ":" << __LINE__ << endl;
+      return false;
+   }
+   
+   // Open output file
+   vlsv::Writer out;
+   if (out.open(fname,MPI_COMM_SELF,0) == false) {
+      cerr << "ERROR, failed to open output file with vlsv::Writer at " << __FILE__ << " " << __LINE__ << endl;
+      return false;
+   }
+   
+   bool success = true;
+   for (set<string>::iterator it=popNames.begin(); it!=popNames.end(); ++it) {
+      if (runDebug == true) cerr << "Population '" << *it << "'" << endl;
+      if (vlsvReader.setCellsWithBlocks(meshName,*it) == false) {success = false; continue;}
+      if (convertVelocityBlocks2(vlsvReader,fname,meshName,cellStruct,cellID,rotate,plasmaFrame,out,*it) == false) success = false;
+   }
 
+   out.close();
+   return success;
+}
 
 //Calculates the cell coordinates and outputs into *coordinates 
 //NOTE: ASSUMING COORDINATES IS NOT NULL AND IS OF SIZE 3
@@ -1151,18 +1116,100 @@ uint64_t searchForBestCellId( const CellStructure & cellStruct,
           ) );
 }
 
+bool setVelocityMeshVariables(vlsv::Reader& vlsvReader,CellStructure& cellStruct,
+        const std::string& popName) {
+   bool success = true;
 
+   Real vx_min,vx_max,vy_min,vy_max,vz_min,vz_max;
 
-//Initalizes cellStruct
-//Input:
-//[0] vlsv::Reader vlsvReader -- some reader with a file open (used for loading parameters)
-//Output:
-//[0] CellStructure cellStruct -- Holds info on cellStruct. The members are given the correct values here (Note: CellStructure could be made into a class
-//instead of a struct with this as the constructor but since a geometry class has already been coded before, it would be a waste)
-void setCellVariables( Reader & vlsvReader, CellStructure & cellStruct ) {
-   //Get x_min, x_max, y_min, y_max, etc so that we know where the given cell id is in (loadParameter returns char*, hence the cast)
-   //Note: Not actually sure if these are Real valued or not
-   Real x_min, x_max, y_min, y_max, z_min, z_max, vx_min, vx_max, vy_min, vy_max, vz_min, vz_max;
+   // Read node coordinate arrays to figure out mesh extents
+   for (int crd=0; crd<3; ++crd) {
+      list<pair<string,string> > attribsIn;
+      attribsIn.push_back(make_pair("mesh",popName));
+      
+      string tagName;
+      if (crd == 0) tagName = "MESH_NODE_CRDS_X";
+      if (crd == 1) tagName = "MESH_NODE_CRDS_Y";
+      if (crd == 2) tagName = "MESH_NODE_CRDS_Z";
+
+      // Read node coordinate array info
+      map<string,string> attribsOut;
+      if (vlsvReader.getArrayAttributes(tagName,attribsIn,attribsOut) == false) {
+         success = false; continue;
+      }
+      
+      // Figure out the number of nodes in this coordinate direction
+      uint64_t N_nodes = 0;
+      map<string,string>::const_iterator it = attribsOut.find("arraysize");
+      if (it != attribsOut.end()) N_nodes = atol(it->second.c_str());      
+      
+      // Read node coordinates
+      Real* crds = NULL;
+      if (vlsvReader.read(tagName,attribsIn,0,N_nodes,crds,true) == false) success = false;
+      
+      if (crd == 0) { vx_min = crds[0]; vx_max = crds[N_nodes-1]; }
+      if (crd == 1) { vy_min = crds[0]; vy_max = crds[N_nodes-1]; }
+      if (crd == 2) { vz_min = crds[0]; vz_max = crds[N_nodes-1]; }
+      delete [] crds; crds = NULL;
+   }
+
+   // Read the velocity mesh bounding box
+   list<pair<string,string> > attribs;
+   attribs.push_back(make_pair("mesh",popName));
+   uint64_t velMeshBbox[6];
+   uint64_t* velMeshBbox_ptr = velMeshBbox;
+   if (vlsvReader.read("MESH_BBOX",attribs,0,6,velMeshBbox_ptr,false) == false) {
+      cerr << "Failed to read velocity mesh BBOX in " << __FILE__ << ":" << __LINE__ << endl;
+   }
+
+   //Set the cell structure properly:
+   for(int i = 0; i<3; ++i) {
+      cellStruct.vcell_bounds[i] = velMeshBbox[i];
+   }
+
+   //Calculate the velocity block physical size (in m/s)
+   Real vx_length = vx_max - vx_min;
+   Real vy_length = vy_max - vy_min;
+   Real vz_length = vz_max - vz_min;
+   cellStruct.vblock_length[0] = ( vx_length / (Real)(velMeshBbox[0]) );
+   cellStruct.vblock_length[1] = ( vy_length / (Real)(velMeshBbox[1]) );
+   cellStruct.vblock_length[2] = ( vz_length / (Real)(velMeshBbox[2]) );
+
+   //Calculate the minimum coordinates for velocity cells
+   cellStruct.min_vcoordinates[0] = vx_min;
+   cellStruct.min_vcoordinates[1] = vy_min;
+   cellStruct.min_vcoordinates[2] = vz_min;
+
+   if (runDebug == true) {
+      cerr << "Pop '" << popName << " mesh limits: ";
+      cerr << vx_min << '\t' << vx_max << '\t' << vy_min << '\t' << vy_max << '\t' << vz_min << '\t' << vz_max << endl;
+      cerr << "\t mesh bbox size: " << velMeshBbox[0] << ' ' << velMeshBbox[1] << ' ' << velMeshBbox[2] << endl;
+   }
+
+   // By default set an unrefined velocity mesh. Then check if the max refinement level 
+   // was actually given as a parameter.
+   uint32_t dummyUInt;
+   cellStruct.maxVelRefLevel = 0;
+   if (vlsvReader.readParameter("max_velocity_ref_level",dummyUInt) == true) {
+      cellStruct.maxVelRefLevel = dummyUInt;
+   }
+
+   return true;
+}
+
+/** Set correct spatial mesh variables to cellStruct. This function leaves the 
+ * velocity mesh-related variables untouched.
+ * @param vlsvReader VLSV file reader with input file open.
+ * @param cellStruct Struct where spatial mesh variables are written.
+ * @return If true, spatial mesh variables were read successfully.*/
+bool setSpatialCellVariables(Reader& vlsvReader,CellStructure& cellStruct) {
+   bool success = true;
+   
+   // Get x_min, x_max, y_min, y_max, etc so that we know where the given cell 
+   // id is in (loadParameter returns char*, hence the cast)
+   // Note: Not actually sure if these are Real valued or not
+   Real x_min,x_max,y_min,y_max,z_min,z_max;
+
    //Read in the parameter:
    if( vlsvReader.readParameter( "xmin", x_min ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
    if( vlsvReader.readParameter( "xmax", x_max ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
@@ -1170,27 +1217,13 @@ void setCellVariables( Reader & vlsvReader, CellStructure & cellStruct ) {
    if( vlsvReader.readParameter( "ymax", y_max ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
    if( vlsvReader.readParameter( "zmin", z_min ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
    if( vlsvReader.readParameter( "zmax", z_max ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
-
-   if( vlsvReader.readParameter( "vxmin", vx_min ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
-   if( vlsvReader.readParameter( "vxmax", vx_max ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
-   if( vlsvReader.readParameter( "vymin", vy_min ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
-   if( vlsvReader.readParameter( "vymax", vy_max ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
-   if( vlsvReader.readParameter( "vzmin", vz_min ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
-   if( vlsvReader.readParameter( "vzmax", vz_max ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
-
+   
    //Number of cells in x, y, z directions (used later for calculating where in the cell coordinates the given
    //coordinates are) (Done in getCellCoordinates)
    //There's x, y and z coordinates so the number of different coordinates is 3:
    const short int NumberOfCoordinates = 3;
    uint64_t cell_bounds[NumberOfCoordinates];
-   uint64_t vcell_bounds[NumberOfCoordinates];
-   //Get the number of velocity blocks in x,y,z direction from the file:
-   //x-direction
-   if( vlsvReader.readParameter( "vxblocks_ini", vcell_bounds[0] ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
-   //y-direction
-   if( vlsvReader.readParameter( "vyblocks_ini", vcell_bounds[1] ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
-   //z-direction
-   if( vlsvReader.readParameter( "vzblocks_ini", vcell_bounds[2] ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
+
    //Get the number of spatial cells in x,y,z direction from the file:
    //x-direction
    if( vlsvReader.readParameter( "xcells_ini", cell_bounds[0] ) == false ) cerr << "FAILED TO READ PARAMETER AT " << __FILE__ << " " << __LINE__ << endl;
@@ -1205,53 +1238,29 @@ void setCellVariables( Reader & vlsvReader, CellStructure & cellStruct ) {
    Real y_length = y_max - y_min;
    Real z_length = z_max - z_min;
 
-   Real vx_length = vx_max - vx_min;
-   Real vy_length = vy_max - vy_min;
-   Real vz_length = vz_max - vz_min;
    //Set the cell structure properly:
    for( int i = 0; i < NumberOfCoordinates; ++i ) {
       cellStruct.cell_bounds[i] = cell_bounds[i];
-      cellStruct.vcell_bounds[i] = vcell_bounds[i];
    }
-   //Calculate the cell length
+   //Calculate the spatial cell physical size (in m)
    cellStruct.cell_length[0] = ( x_length / (Real)(cell_bounds[0]) );
    cellStruct.cell_length[1] = ( y_length / (Real)(cell_bounds[1]) );
    cellStruct.cell_length[2] = ( z_length / (Real)(cell_bounds[2]) );
 
-   //Calculate the velocity cell length
-   cellStruct.vblock_length[0] = ( vx_length / (Real)(vcell_bounds[0]) );
-   cellStruct.vblock_length[1] = ( vy_length / (Real)(vcell_bounds[1]) );
-   cellStruct.vblock_length[2] = ( vz_length / (Real)(vcell_bounds[2]) );
    //Calculate the minimum coordinates
    cellStruct.min_coordinates[0] = x_min;
    cellStruct.min_coordinates[1] = y_min;
    cellStruct.min_coordinates[2] = z_min;
-   //Calculate the minimum coordinates for velocity cells
-   cellStruct.min_vcoordinates[0] = vx_min;
-   cellStruct.min_vcoordinates[1] = vy_min;
-   cellStruct.min_vcoordinates[2] = vz_min;
-
 
    for( int i = 0; i < 3; ++i ) {
-      if( cellStruct.cell_length[i] == 0 || cellStruct.cell_bounds[i] == 0 || cellStruct.vblock_length[i] == 0 || cellStruct.vcell_bounds[i] == 0 ) {
+      if( cellStruct.cell_length[i] == 0 || cellStruct.cell_bounds[i] == 0) {
          cerr << "ERROR, ZERO CELL LENGTH OR CELL_BOUNDS AT " << __FILE__ << " " << __LINE__ << endl;
          exit(1);
       }
    }
    
-   // By default set an unrefined velocity mesh. Then check if the max refinement level 
-   // was actually given as a parameter.
-   uint32_t dummyUInt;
-   cellStruct.maxVelRefLevel = 0;
-   if (vlsvReader.readParameter("max_velocity_ref_level",dummyUInt) == true) {
-      cellStruct.maxVelRefLevel = dummyUInt;
-   }
-   
-   return;
+   return success;
 }
-
-
-
 
 //Returns a cell id based on some given coordinates
 //Returns numeric_limits<uint64_t>::max(), if the distance from the coordinates to cell id is larger than max_distance
@@ -1607,6 +1616,7 @@ void extractDistribution( const string & fileName, const UserOptions & mainOptio
    const string tagName = "MESH";
    const string attributeName = "name";
    
+   // Get spatial mesh names
    if (vlsvReader.getMeshNames(meshNames) == false) {
       cout << "\t file '" << fileName << "' not compatible" << endl;
       vlsvReader.close();
@@ -1615,7 +1625,7 @@ void extractDistribution( const string & fileName, const UserOptions & mainOptio
    
    //Sets cell variables (for cell geometry) -- used in getCellIdFromCoords function
    CellStructure cellStruct;
-   setCellVariables( vlsvReader, cellStruct );
+   setSpatialCellVariables( vlsvReader, cellStruct );
 
    //Declare a vector for holding multiple cell ids (Note: Used only if we want to calculate the cell id along a line)
    vector<uint64_t> cellIdList;
@@ -1755,9 +1765,6 @@ void extractDistribution( const string & fileName, const UserOptions & mainOptio
 
       // Extract velocity grid from VLSV file, if possible, and write as vlsv file:
       bool velGridExtracted = true;
-      if( typeid(vlsvReader) == typeid(vlsvinterface::Reader) ) {
-         vlsvReader.setCellsWithBlocks();
-      }
       for (list<string>::const_iterator it2 = meshNames.begin(); it2 != meshNames.end(); ++it2) {
          //slice disabled by default, enable for specific testing. TODO: add command line interface for enabling it
          //convertSlicedVelocityMesh(vlsvReader,outputSliceName,*it2,cellStruct);
@@ -1779,7 +1786,6 @@ void extractDistribution( const string & fileName, const UserOptions & mainOptio
             }
          }
       }
-
 
       // If velocity grid was not extracted, delete the file:
       if (velGridExtracted == false) {

--- a/tools/vlsvextract.h
+++ b/tools/vlsvextract.h
@@ -1,0 +1,112 @@
+/* This file is part of Vlasiator.
+ * 
+ * File:   vlsvextract.h
+ * Author: sandroos
+ *
+ * Created on April 14, 2015, 2:08 PM
+ * 
+ * Copyright 2015 Finnish Meteorological Institute
+ */
+
+#ifndef VLSVEXTRACT_H
+#define	VLSVEXTRACT_H
+
+#include <cstdlib>
+#include <array>
+#include <vector>
+
+#include "definitions.h"
+
+//A struct for holding info on cell structure (the grid)
+struct CellStructure {
+   uint64_t cell_bounds[3];     /**< The number of cells in x, y, z direction.*/
+   Real cell_length[3];         /**< Length of a cell in x, y, z direction. */
+   Real min_coordinates[3];     /**< x_min, y_min, z_min are stored here.*/
+
+   uint64_t vcell_bounds[3];    /**< The number of cells in vx, vy, vz directions.*/
+   Real vblock_length[3];       /**< Size (dvx,dvy,dvz) of a velocity block in vx, vy, vz directions.*/
+   Real min_vcoordinates[3];    /**< vx_min, vy_min, vz_min are stored here.*/
+   uint32_t maxVelRefLevel;     /**< Maximum refinement level of velocity meshes.*/
+
+   int slicedCoords[3];
+   Real slicedCoordValues[3];
+};
+
+template<typename REAL>
+struct NodeCrd {
+   static REAL EPS;
+   REAL x;
+   REAL y;
+   REAL z;
+
+   NodeCrd(const REAL& x, const REAL& y, const REAL& z);
+   
+   bool comp(const NodeCrd<REAL>& n) const;
+};
+
+struct NodeComp {
+   bool operator()(const NodeCrd<double>& a, const NodeCrd<double>& b) const;
+   bool operator()(const NodeCrd<float>& a, const NodeCrd<float>& b) const;
+};
+
+//A class for holding user options
+class UserOptions {
+public:
+   bool getCellIdFromLine;
+   bool getCellIdFromInput;
+   bool getCellIdFromCoordinates;
+   bool rotateVectors;
+   bool plasmaFrame;
+   uint64_t cellId;
+   uint32_t numberOfCoordinatesInALine;
+   std::vector<std::string> outputDirectoryPath;
+   std::array<Real, 3> coordinates;
+   std::array<Real, 3> point1;
+   std::array<Real, 3> point2;
+
+   UserOptions() {
+      getCellIdFromLine = false;
+      getCellIdFromInput = false;
+      getCellIdFromCoordinates = false;
+      rotateVectors = false;
+      cellId = std::numeric_limits<uint64_t>::max();
+      numberOfCoordinatesInALine = 0;
+   }
+
+   ~UserOptions() {}
+};
+
+bool setVelocityMeshVariables(vlsv::Reader& vlsvReader,CellStructure& cellStruct,
+                              const std::string& popName);
+
+template<typename REAL> inline
+NodeCrd<REAL>::NodeCrd(const REAL& x,const REAL& y,const REAL& z): x(x),y(y),z(z) { }
+
+template<typename REAL> inline
+bool NodeCrd<REAL>::comp(const NodeCrd<REAL>& n) const {
+   REAL EPS1, EPS2, EPS;
+   EPS1 = 1.0e-6 * fabs(x);
+   EPS2 = 1.0e-6 * fabs(n.x);
+   if (x == 0.0) EPS1 = 1.0e-7;
+   if (n.x == 0.0) EPS2 = 1.0e-7;
+   EPS = max(EPS1, EPS2);
+   if (fabs(x - n.x) > EPS) return false;
+
+   EPS1 = 1.0e-6 * fabs(y);
+   EPS2 = 1.0e-6 * fabs(n.y);
+   if (y == 0.0) EPS1 = 1.0e-7;
+   if (n.y == 0.0) EPS2 = 1.0e-7;
+   EPS = max(EPS1, EPS2);
+   if (fabs(y - n.y) > EPS) return false;
+
+   EPS1 = 1.0e-6 * fabs(z);
+   EPS2 = 1.0e-6 * fabs(n.z);
+   if (z == 0.0) EPS1 = 1.0e-7;
+   if (n.z == 0.0) EPS2 = 1.0e-7;
+   EPS = max(EPS1, EPS2);
+   if (fabs(z - n.z) > EPS) return false;
+   return true;
+}
+
+#endif	// VLSVEXTRACT_H
+

--- a/tools/vlsvreaderinterface.cpp
+++ b/tools/vlsvreaderinterface.cpp
@@ -176,21 +176,21 @@ namespace vlsvinterface {
       return true;
    }
    
-   bool Reader:: setCellsWithBlocks() {
+   bool Reader::setCellsWithBlocks(const std::string& meshName,const std::string& popName) {
       if(cellsWithBlocksLocations.empty() == false) {
          cellsWithBlocksLocations.clear();
       }
-      const string meshName = "SpatialGrid";
       vlsv::datatype::type cwb_dataType;
       uint64_t cwb_arraySize, cwb_vectorSize, cwb_dataSize;
       list<pair<string, string> > attribs;
    
       //Get the mesh name for reading in data from the correct place
       attribs.push_back(make_pair("mesh", meshName));
+      attribs.push_back(make_pair("name", popName));
    
       //Get array info
       if (getArrayInfo("CELLSWITHBLOCKS", attribs, cwb_arraySize, cwb_vectorSize, cwb_dataType, cwb_dataSize) == false) {
-         cerr << "ERROR, COULD NOT FIND ARRAY CELLSWITHBLOCKS AT " << __FILE__ << " " << __LINE__ << endl;
+         cerr << "ERROR, COULD NOT FIND ARRAY CELLSWITHBLOCKS FOR POPULATION '" << popName << "' AT " << __FILE__ << ":" << __LINE__ << endl;
          return false;
       }
    
@@ -256,7 +256,7 @@ namespace vlsvinterface {
       return true;
    }
    
-   bool Reader::getBlockIds( const uint64_t & cellId, std::vector<uint64_t> & blockIds ) {
+   bool Reader::getBlockIds(const uint64_t& cellId,std::vector<uint64_t>& blockIds,const std::string& popName) {
       if( cellsWithBlocksSet == false ) {
          cerr << "ERROR, setCellsWithBlocks() NOT CALLED AT (CALL setCellsWithBlocks()) BEFORE CALLING getBlockIds " << __FILE__ << " " << __LINE__ << endl;
          return false;
@@ -274,13 +274,14 @@ namespace vlsvinterface {
    
       // Get some required info from VLSV file:
       list<pair<string, string> > attribs;
-   
+      attribs.push_back(make_pair("name",popName));
+      
       //READ BLOCK IDS:
       uint64_t blockIds_arraySize, blockIds_vectorSize, blockIds_dataSize;
       vlsv::datatype::type blockIds_dataType;
       //Input blockIds_arraySize, blockIds_vectorSize, blockIds_dataSize blockIds_dataType: (Returns false if fails)
       if (getArrayInfo("BLOCKIDS", attribs, blockIds_arraySize, blockIds_vectorSize, blockIds_dataType, blockIds_dataSize) == false) {
-         cerr << "ERROR, COULD NOT FIND BLOCKIDS AT " << __FILE__ << " " << __LINE__ << endl;
+         cerr << "ERROR, COULD NOT FIND BLOCKIDS FOR '" << popName << "' AT " << __FILE__ << " " << __LINE__ << endl;
          return false;
       }
       //Make sure blockid's datatype is correct:
@@ -350,5 +351,4 @@ namespace vlsvinterface {
       return true;
    }
 
-
-}
+} // namespace vlsvinterface

--- a/tools/vlsvreaderinterface.h
+++ b/tools/vlsvreaderinterface.h
@@ -30,13 +30,13 @@ namespace vlsvinterface {
       //Reads in a variable:
       template <typename T, size_t N>
       bool getVariable( const std::string & variableName, const uint64_t & cellId, std::array<T, N> & variable );
-      bool getBlockIds( const uint64_t & cellId, std::vector<uint64_t> & blockIds );
+      bool getBlockIds( const uint64_t& cellId,std::vector<uint64_t>& blockIds,const std::string& popName );
       bool setCellIds();
       inline void clearCellIds() {
          cellIdLocations.clear();
          cellIdsSet = false;
       }
-      bool setCellsWithBlocks();
+      bool setCellsWithBlocks(const std::string& meshName,const std::string& popName);
       inline void clearCellsWithBlocks() {
          cellsWithBlocksLocations.clear();
          cellsWithBlocksSet = false;


### PR DESCRIPTION
Copy-paste of vlsvextract from multipop_vlasov_solver:

vlsvextract now works with multiple particle species. In addition,
after writing a bit more velocity mesh metadata in iowrite.cpp it is
possible to use vlsvdiff to compare (extracted) distribution functions.

You can now extract distribution functions as usual,
`vlsvextract_DP bulk --cellid <cell id>`

And then use `vlsvdiff` to compare extracted distributions. For example,

```
./vlsvdiff_DP velgrid.1301.0000000.vlsv (different)velgrid.1301.0000000.vlsv avgs 0 --meshname=VelGrid_avgs --no-distrib --diff
```

writes out a difference file of the velocity distributions and dumps statistics to stdout.

Since the particle species has been called `avgs` for historical reasons and it is hard-coded into vlsvdiff that `avgs` denotes distribution function data, the `--no-distrib` option here explicitly tells `vlsvdiff`that it should treat `avgs` as a regular variable.
