### PR TITLE
Fix the version.cpp diff to also work with empty diffs, and on voima.

### DIFF
--- a/generate_version.sh
+++ b/generate_version.sh
@@ -50,8 +50,13 @@ git status | sed 's/\"/\\"/g' | sed 's/\\\"/\\"/g'  |gawk '{printf("%s\"%s\"%s\n
 echo "    cout << endl << \"----------- git diff ---------- \"<<endl;" >>version.cpp
 
 echo "    const char diff_data[] = {" >> version.cpp
-git diff `git diff --name-only |grep -v generate_version.sh` | xxd -i >> version.cpp
-echo "    , 0 };" >> version.cpp
+DIFF=$(git diff `git diff --name-only |grep -v generate_version.sh` | xxd -i)
+if [[ -n $DIFF ]]; then
+   echo -n $DIFF >> version.cpp
+   echo "    ,0 };" >> version.cpp
+else
+   echo "    0 };" >> version.cpp
+fi
 echo "    cout << diff_data << endl;" >> version.cpp
 
 cat >> version.cpp <<EOF


### PR DESCRIPTION
Voima's quite ancient git version did not actually support git status -s.
Also, if the diff was empty, generate_version.sh generated a syntactically incorrect file.

Now all of this has been tested properly. :)
