### PR TITLE
Removing the rho step in Magnetosphere.

### DIFF
--- a/projects/Magnetosphere/Magnetosphere.cfg
+++ b/projects/Magnetosphere/Magnetosphere.cfg
@@ -132,8 +132,6 @@ minValue = 1.0e-13
 [Magnetosphere]
 T = 100000.0
 rho  = 1.0e4
-rhoTransitionCenter = 1.0e8
-rhoTransitionWidth = 1.8e7
 
 VX0 = -1.0e5
 VY0 = 0.0

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -34,8 +34,6 @@ namespace projects {
       RP::add("Magnetosphere.constBgBY", "Constant flat By component in the whole simulation box. Default is none.", 0.0);
       RP::add("Magnetosphere.constBgBZ", "Constant flat Bz component in the whole simulation box. Default is none.", 0.0);
       RP::add("Magnetosphere.noDipoleInSW", "If set to 1, the dipole magnetic field is not set in the solar wind inflow cells. Default 0.", 0.0);
-      RP::add("Magnetosphere.rhoTransitionCenter", "Abscissa in GSE around which the background magnetospheric density transitions to a 10 times higher value (m)", 0.0);
-      RP::add("Magnetosphere.rhoTransitionWidth", "Width of the magnetospheric background density (m)", 0.0);
       RP::add("Magnetosphere.nSpaceSamples", "Number of sampling points per spatial dimension", 2);
       RP::add("Magnetosphere.nVelocitySamples", "Number of sampling points per velocity dimension", 5);
       RP::add("Magnetosphere.dipoleScalingFactor","Scales the field strength of the magnetic dipole compared to Earths.", 1.0);
@@ -50,14 +48,6 @@ namespace projects {
       MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
       typedef Readparameters RP;
       if(!RP::get("Magnetosphere.rho", this->tailRho)) {
-         if(myRank == MASTER_RANK) cerr << __FILE__ << ":" << __LINE__ << " ERROR: This option has not been added!" << endl;
-         exit(1);
-      }
-      if(!RP::get("Magnetosphere.rhoTransitionCenter", this->rhoTransitionCenter)) {
-         if(myRank == MASTER_RANK) cerr << __FILE__ << ":" << __LINE__ << " ERROR: This option has not been added!" << endl;
-         exit(1);
-      }
-      if(!RP::get("Magnetosphere.rhoTransitionWidth", this->rhoTransitionWidth)) {
          if(myRank == MASTER_RANK) cerr << __FILE__ << ":" << __LINE__ << " ERROR: This option has not been added!" << endl;
          exit(1);
       }
@@ -336,8 +326,6 @@ namespace projects {
             initRho = this->ionosphereRho;
          }
       }
-      
-      initRho *= 1.0 + 9.0 * 0.5 * (1.0 + tanh((x-this->rhoTransitionCenter) / this->rhoTransitionWidth));
       
       return initRho * pow(physicalconstants::MASS_PROTON / (2.0 * M_PI * physicalconstants::K_B * this->T), 1.5) *
       exp(- physicalconstants::MASS_PROTON * ((vx-initV0[0])*(vx-initV0[0]) + (vy-initV0[1])*(vy-initV0[1]) + (vz-initV0[2])*(vz-initV0[2])) / (2.0 * physicalconstants::K_B * this->T));

--- a/projects/Magnetosphere/Magnetosphere.h
+++ b/projects/Magnetosphere/Magnetosphere.h
@@ -47,8 +47,6 @@ namespace projects {
          Real ionosphereV0[3];
          Real constBgB[3];
          bool noDipoleInSW;
-         Real rhoTransitionCenter;
-         Real rhoTransitionWidth;
          Real ionosphereRho;
          Real ionosphereRadius;
          Real ionosphereTaperRadius;


### PR DESCRIPTION
Any further comments? This fixes #161.

```
transtest_2_maxw_500k_100k_20kms_20x20  -  Verifying 0d01005ae4985e6e1564b1c9465630036c539aac___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 0a8be8ac087c2da56556e4f56fcb3e5826aa6f38__DVEC4D_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
39.79        20.64         1.92781
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
rho_0                1.16415e-09                 1.16409e-15    
rho_v_0                0.000610352                 1.22064e-15    
rho_v_1                0.000549316                 1.09858e-15    
rho_v_2                5.54211e-05                 0.712409    
B_0                0                 0    
B_1                0                 0    
B_2                0                 0    
E_0                0                 -1    
E_1                0                 -1    
E_2                0                 -1    
--------------------------------------------------------------------------------------------
   Distribution function diff                                                               
--------------------------------------------------------------------------------------------
INFO Reading in two files.
File names: /stornext/field/vlasiator/test_package_data/0a8be8ac087c2da56556e4f56fcb3e5826aa6f38__DVEC4D_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF/transtest_2_maxw_500k_100k_20kms_20x20/fullf.0000001.vlsv & /lustre/tmp/yann/testpackage/run/transtest_2_maxw_500k_100k_20kms_20x20/fullf.0000001.vlsv
NonIdenticalBlocks:      0
IdenticalBlocks:         423200
Absolute_Error:          4.72687e-19
Mean-Absolute-Error:     5.27553e-26
Max-Absolute-Error:      2.62371e-23
Absolute-log-Error:      4.0747e-08
Mean-Absolute-log-Error: 4.54766e-15
--------------------------------------------------------------------------------------------
running Magnetosphere_small 
Parameter data file (sw1.dat) has 1 values
Application 12292204 resources: utime ~3345s, stime ~110s, Rss ~71340, inblocks ~462592, outblocks ~114225
--------------------------------------------------------------------------------------------
Magnetosphere_small  -  Verifying 0d01005ae4985e6e1564b1c9465630036c539aac___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 0a8be8ac087c2da56556e4f56fcb3e5826aa6f38__DVEC4D_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
52.62        48.13         1.09329
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
rho_0                0                 0    
rho_v_0                0                 0    
rho_v_1                0                 0    
rho_v_2                0                 0    
B_0                0                 0    
B_1                0                 0    
B_2                0                 0    
E_0                0                 0    
E_1                0                 0    
E_2                0                 0    
--------------------------------------------------------------------------------------------
   Distribution function diff                                                               
--------------------------------------------------------------------------------------------
INFO Reading in two files.
File names: /stornext/field/vlasiator/test_package_data/0a8be8ac087c2da56556e4f56fcb3e5826aa6f38__DVEC4D_AGNER__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF/Magnetosphere_small/bulk.0000001.vlsv & /lustre/tmp/yann/testpackage/run/Magnetosphere_small/bulk.0000001.vlsv
NonIdenticalBlocks:      0
IdenticalBlocks:         3324
Absolute_Error:          0
Mean-Absolute-Error:     0
Max-Absolute-Error:      0
Absolute-log-Error:      0
Mean-Absolute-log-Error: 0
--------------------------------------------------------------------------------------------
```
