### PR TITLE
Added a safeguards against zero substeps passed to the field solver.

### DIFF
--- a/fieldsolver/ldz_main.cpp
+++ b/fieldsolver/ldz_main.cpp
@@ -244,7 +244,12 @@ bool propagateFields(
    creal& dt,
    cint& subcycles
 ) {
-
+   
+   if(subcycles == 0) {
+      cerr << "Field solver subcycles cannot be 0." << endl;
+      exit(1);
+   }
+   
    // Reserve memory for derivatives for all cells on this process:
    const vector<CellID>& localCells = getLocalCells();
 


### PR DESCRIPTION
This was effectively fixed with the fieldsolver-speedup package, where the default is not set to 0 but to 1 now. But it's safer to have that in here to avoid surprises while testing.
