### PR TITLE
Report memory consumption just before starting to propagate.

### DIFF
--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -391,7 +391,6 @@ int main(int argn,char* args[]) {
    if (myRank == MASTER_RANK) logFile << "(MAIN): Starting main simulation loop." << endl << writeVerbose;
    
    report_process_memory_consumption();
-   logFile << writeVerbose;
    
    unsigned int computedCells=0;
    unsigned int computedTotalCells=0;


### PR DESCRIPTION
My take for #199. It does what it should, i.e.

```
Tue Nov 24 13:55:25 2015 
(MAIN) Starting simulation with 20 MPI processes and 20 OpenMP threads per process

Tue Nov 24 13:55:25 2015 
         Zoltan 3.6 initialized successfully

Tue Nov 24 13:55:25 2015 
(INIT): Starting initial load balance.

Tue Nov 24 13:55:25 2015 
(INIT): Set initial state.

Tue Nov 24 13:55:26 2015 
(MAIN): Starting main simulation loop.

Tue Nov 24 13:55:26 2015 
(MEM) PAPI Resident (avg, min, max): 2.78053e+07 2.36339e+07 2.94707e+07
(MEM) PAPI High water mark (avg, min, max): 2.79806e+07 2.62922e+07 2.94707e+07
(MEM) Node free memory (avg, min, max): 6.56877e+10 6.56838e+10 6.57041e+10

Tue Nov 24 13:55:26 2015 

Tue Nov 24 13:55:26 2015 
---------- tstep = 0 t = 0 dt = 0.01 FS cycles = 1 ----------
```

and

```
Tue Nov 24 13:57:48 2015 
(MAIN) Starting simulation with 20 MPI processes and 20 OpenMP threads per process

Tue Nov 24 13:57:48 2015 
         Zoltan 3.6 initialized successfully

Tue Nov 24 13:57:48 2015 
(INIT): Starting initial load balance.

Tue Nov 24 13:57:49 2015 
(INIT): Set initial state.

Tue Nov 24 13:57:49 2015 
Restart from restart.0000000.vlsv

Tue Nov 24 13:57:49 2015 
(MAIN): Starting main simulation loop.

Tue Nov 24 13:57:49 2015 
(MEM) PAPI Resident (avg, min, max): 1.52218e+07 1.42336e+07 1.74531e+07
(MEM) PAPI High water mark (avg, min, max): 1.52218e+07 1.42336e+07 1.74531e+07
(MEM) Node free memory (avg, min, max): 6.59115e+10 6.59065e+10 6.59294e+10

Tue Nov 24 13:57:49 2015 

Tue Nov 24 13:57:49 2015 
---------- tstep = 11 t = 0.11 dt = 0.01 FS cycles = 1 ----------
```
