### PR TITLE
Updated library paths to compile on hazelhen again.

### DIFF
--- a/MAKE/Makefile.hornet_gcc
+++ b/MAKE/Makefile.hornet_gcc
@@ -22,7 +22,7 @@ FLAGS =
 
 #GNU flags:
 CC_BRAND = gcc
-CC_BRAND_VERSION = 4.9.2
+CC_BRAND_VERSION = 5.2.0
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++0x -W -Wall -Wno-unused -fabi-version=0 -mavx2 
 #CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++0x -W -Wall -Wno-unused -fabi-version=0 -mavx
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
@@ -37,7 +37,7 @@ BOOST_VERSION = 1.56.0
 MPT_VERSION = 7.1.3
 ZOLTAN_VERSION = 3.8
 SILO_VERSION = 4.9.1
-JEMALLOC_VERSION = 3.6.0
+JEMALLOC_VERSION = 4.0.4
 LIBRARY_PREFIX = /zhome/academic/HLRS/pri/iprurgan/vlasiator/libraries
 
 
@@ -60,6 +60,7 @@ LIB_VLSV = -L$(LIBRARY_PREFIX)/mpich2/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERS
 
 
 LIB_PROFILE = -L$(LIBRARY_PREFIX)/mpich2/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/phiprof/lib -lphiprof
+#LIB_PROFILE = $(LIBRARY_PREFIX)/mpich2/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/phiprof/lib/libphiprof.a
 INC_PROFILE = -I$(LIBRARY_PREFIX)/mpich2/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/phiprof/include
 
 #header libraries


### PR DESCRIPTION
Re-built libraries with GCC 5.2.0 (the default on hazelhen), now it compiles and links again.
