### PR TITLE
Remove extra ;

### DIFF
--- a/velocity_blocks.h
+++ b/velocity_blocks.h
@@ -263,6 +263,6 @@ namespace vblock {
        return (k/2)*4 + (j/2)*2 + (i/2);
    }
 
-}; // namespace vblock
+} // namespace vblock
 
 #endif


### PR DESCRIPTION
I get a lot of warnings about extra ; at end of namespace, this should fix that.
