### PR TITLE
Improved mem reporting

### DIFF
--- a/memoryallocation.cpp
+++ b/memoryallocation.cpp
@@ -123,7 +123,7 @@ void report_process_memory_consumption(){
       double sum_mem_papi[2];
       double min_mem_papi[2];
       double max_mem_papi[2];
-      /*PAPI returns memory in KB units, transform to GiB*/
+      /*PAPI returns memory in KB units, transform to bytes*/
       mem_papi[0] = dmem.high_water_mark * 1024;
       mem_papi[1] = dmem.resident * 1024;
       //sum node mem


### PR DESCRIPTION
In this pull request the memory reports are made more useful by including: 
- per node statistics
- Sensible units (GiB per node, TiB total)
- Only high water mark

Old mem report looked like this:

```
(MEM) PAPI Resident (avg, min, max): 4.68314e+07 4.42286e+07 5.05528e+07
(MEM) PAPI High water mark (avg, min, max): 4.68314e+07 4.42286e+07 5.05528e+07
(MEM) Node free memory (avg, min, max): 6.44987e+10 6.44839e+10 6.45149e+10
```

New one looks like this:

```
(MEM) High water mark per node (GiB) avg: 0.348455 max: 0.34594 min: 0.350971 sum (TiB): 0.000680577 on 2 nodes
```
