### PR TITLE
Errors in particle param parsing were not handled and led to strange crashes.

### DIFF
--- a/particles/particle_post_pusher.cpp
+++ b/particles/particle_post_pusher.cpp
@@ -25,7 +25,10 @@ int main(int argc, char** argv) {
    Readparameters parameters(argc, argv, MPI_COMM_WORLD);
    ParticleParameters::addParameters();
    parameters.parse(false);  // Parse parameters and don't require run_config
-   ParticleParameters::getParameters();
+   if(!ParticleParameters::getParameters()) {
+      std::cerr << "Parsing parameters failed, aborting." << std::endl;
+      return 1;
+   }
 
    /* Read starting fields from specified input file */
    std::string filename_pattern = ParticleParameters::input_filename_pattern;

--- a/particles/particleparameters.cpp
+++ b/particles/particleparameters.cpp
@@ -114,6 +114,7 @@ bool ParticleParameters::getParameters() {
    Readparameters::get("particles.end_time",P::end_time);
    Readparameters::get("particles.num_particles",P::num_particles);
    if(P::dt == 0 || P::end_time <= P::start_time) {
+      std::cerr << "Error end_time <= start_time! Won't do anything (and will probably crash now)." << std::endl;
       return false;
    }
 


### PR DESCRIPTION
This was riku's first attempt at using the particle pusher. Of course he found new bugs. :)
