### PR TITLE
Changed fluxfunction dependencies to include all particle pusher objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -550,7 +550,7 @@ particle_post_pusher: ${OBJS_PARTICLES} ${DEPS_PARTICLES}  ${OBJS_VLSVREADERINTE
 fluxfunction.o:  tools/fluxfunction.cpp
 	${CMP} ${CXXFLAGS} ${FLAGS} -c tools/fluxfunction.cpp ${INC_VLSV} ${INC_VECTORCLASS} -I$(CURDIR)  -Itools -o $@
 
-fluxfunction: fluxfunction.o ${OBJS_VLSVREADERINTERFACE} particles/readfields.o
-	${LNK} -o $@ fluxfunction.o particles/readfields.o ${OBJS_VLSVREADERINTERFACE} ${LIBS} ${LDFLAGS}
+fluxfunction: fluxfunction.o ${OBJS_VLSVREADERINTERFACE} ${OBJS_PARTICLES} ${DEPS_PARTICLES}
+	${LNK} -o $@ fluxfunction.o ${OBJS_PARTICLES} ${OBJS_VLSVREADERINTERFACE} ${LIBS} ${LDFLAGS}
 
 # DO NOT DELETE


### PR DESCRIPTION
Required for compilation. (Or at least in need more than what was already included)
