### PR TITLE
Fluxfunction

### DIFF
--- a/tools/fluxfunction.cpp
+++ b/tools/fluxfunction.cpp
@@ -157,6 +157,14 @@ namespace Equatorialplane {
 
       long double tmp_flux=0.;
 
+      // Calculate flux-difference between bottom and top edge
+      // of +x boundary (so that values are consistent with computeFluxUp)
+      for(int y=3; y<B.dimension[1]->cells-4; y++) {
+         Vec3d bval = B.getCell(B.dimension[0]->cells-2,y,0);
+
+         tmp_flux -= bval[0]*B.dx[1];
+      }
+
       // First, fill the y=max - 4 cells
       for(int x=B.dimension[0]->cells-2; x>0; x--) {
          Vec3d bval = B.getCell(x,B.dimension[1]->cells-4,0);
@@ -188,7 +196,6 @@ namespace Equatorialplane {
       std::vector<double> flux(B.dimension[0]->cells * B.dimension[1]->cells * B.dimension[2]->cells);
 
       long double tmp_flux=0.;
-
       long double bottom_right_flux=0.;
 
       // Now, for each row, integrate in -y-direction.


### PR DESCRIPTION
While the fluxfunction tool did already get a patch to support equatorial plane runs, and one to support runs with non-fieldline upstream boundaries... it was still missing the code for equatorial plane runs which _also_ have non-fieldline upstream boundaries.

So fieldlines for ABC should now look more correct.
