### PR TITLE
Particles: Made the field operator() properly virtual and reverted Interpolated_Field commit.

### DIFF
--- a/particles/field.h
+++ b/particles/field.h
@@ -53,7 +53,7 @@ struct Field
    }
 
    // Round-Brace indexing: indexing by physical location, with interpolation
-   Vec3d operator()(Vec3d v) {
+   virtual Vec3d operator()(Vec3d v) {
       Vec3d vmin,vdx;
       double min[3] = { min[0] = dimension[0]->min, dimension[1]->min, dimension[2]->min};
       vmin.load(min);
@@ -119,7 +119,7 @@ struct Field
 
 // Linear Temporal interpolation between two input fields
 struct Interpolated_Field : Field{
-   Field& a,b;
+   Field &a, &b;
    double t;
 
    /* Constructor:
@@ -129,7 +129,7 @@ struct Interpolated_Field : Field{
    Interpolated_Field(Field& _a, Field& _b, float _t) : a(_a),b(_b),t(_t) {
    }
 
-   Vec3d operator()(Vec3d v) {
+   virtual Vec3d operator()(Vec3d v) {
       Vec3d aval=a(v);
       Vec3d bval=b(v);
 

--- a/particles/particle_post_pusher.cpp
+++ b/particles/particle_post_pusher.cpp
@@ -39,11 +39,11 @@ int main(int argc, char** argv) {
    std::cerr << "Loading first file with index " << ParticleParameters::start_time / ParticleParameters::input_dt
       << std::endl;
    snprintf(filename_buffer,256,filename_pattern.c_str(),input_file_counter-1);
-   readfields(filename_buffer,E[1],B[1],V);
-   E[0]=E[1]; B[0]=B[1];
    E[0].dimension[0] = E[1].dimension[0] = B[0].dimension[0] = B[1].dimension[0] = V.dimension[0] = ParticleParameters::boundary_behaviour_x;
    E[0].dimension[1] = E[1].dimension[1] = B[0].dimension[1] = B[1].dimension[1] = V.dimension[1] = ParticleParameters::boundary_behaviour_y;
    E[0].dimension[2] = E[1].dimension[2] = B[0].dimension[2] = B[1].dimension[2] = V.dimension[2] = ParticleParameters::boundary_behaviour_z;
+   readfields(filename_buffer,E[1],B[1],V);
+   E[0]=E[1]; B[0]=B[1];
 
    // Set boundary conditions based on sizes
    if(B[0].dimension[0]->cells <= 1) {

--- a/particles/scenario.cpp
+++ b/particles/scenario.cpp
@@ -16,7 +16,7 @@ std::vector<Particle> singleParticleScenario::initialParticles(Field& E, Field& 
 }
 
 void singleParticleScenario::afterPush(int step, double time, std::vector<Particle>& particles, 
-      Interpolated_Field& E, Interpolated_Field& B, Field& V) {
+      Field& E, Field& B, Field& V) {
 
    Vec3d& x = particles[0].x;
    Vec3d& v = particles[0].v;
@@ -55,7 +55,7 @@ std::vector<Particle> distributionScenario::initialParticles(Field& E, Field& B,
 }
 
 void distributionScenario::newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles,
-      Interpolated_Field& E, Interpolated_Field& B, Field& V) {
+      Field& E, Field& B, Field& V) {
 
    char filename_buffer[256];
 
@@ -68,7 +68,7 @@ void distributionScenario::finalize(std::vector<Particle>& particles, Field& E, 
 }
 
 void precipitationScenario::afterPush(int step, double time, std::vector<Particle>& particles,
-      Interpolated_Field& E, Interpolated_Field& B, Field& V) {
+      Field& E, Field& B, Field& V) {
 
    for(unsigned int i=0; i<particles.size(); i++) {
 
@@ -105,7 +105,7 @@ void precipitationScenario::afterPush(int step, double time, std::vector<Particl
 }
 
 void precipitationScenario::newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles,
-      Interpolated_Field& E, Interpolated_Field& B, Field& V) {
+      Field& E, Field& B, Field& V) {
 
    // Create particles along the negative x-axis, from inner boundary
    // up to outer one
@@ -160,7 +160,7 @@ std::vector<Particle> analysatorScenario::initialParticles(Field& E, Field& B, F
 }
 
 void analysatorScenario::newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles,
-      Interpolated_Field& E, Interpolated_Field& B, Field& V) {
+      Field& E, Field& B, Field& V) {
 
    for(unsigned int i=0; i< particles.size(); i++) {
       Vec3d& x = particles[i].x;
@@ -171,7 +171,7 @@ void analysatorScenario::newTimestep(int input_file_counter, int step, double ti
 }
 
 void shockReflectivityScenario::newTimestep(int input_file_counter, int step, double time,
-      std::vector<Particle>& particles, Interpolated_Field& E, Interpolated_Field& B, Field& V) {
+      std::vector<Particle>& particles, Field& E, Field& B, Field& V) {
 
    const int num_points = 200;
 
@@ -222,7 +222,7 @@ void shockReflectivityScenario::newTimestep(int input_file_counter, int step, do
 }
 
 void shockReflectivityScenario::afterPush(int step, double time, std::vector<Particle>& particles,
-      Interpolated_Field& E, Interpolated_Field& B, Field& V) {
+      Field& E, Field& B, Field& V) {
 
    for(unsigned int i=0; i<particles.size(); i++) {
 
@@ -320,7 +320,7 @@ std::vector<Particle> ipShockScenario::initialParticles(Field& E, Field& B, Fiel
 }
 
 void ipShockScenario::newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles,
-      Interpolated_Field& E, Interpolated_Field& B, Field& V) {
+      Field& E, Field& B, Field& V) {
 
    char filename_buffer[256];
 
@@ -329,7 +329,7 @@ void ipShockScenario::newTimestep(int input_file_counter, int step, double time,
 }
 
 void ipShockScenario::afterPush(int step, double time, std::vector<Particle>& particles,
-      Interpolated_Field& E, Interpolated_Field& B, Field& V) {
+      Field& E, Field& B, Field& V) {
   
   /* Perform transmission / reflection check for each particle */
    for(unsigned int i=0; i<particles.size(); i++) {

--- a/particles/scenario.h
+++ b/particles/scenario.h
@@ -18,14 +18,14 @@ struct Scenario {
 	virtual std::vector<Particle> initialParticles(Field& E, Field& B, Field& V) {return std::vector<Particle>();};
 
   // Do something when a new input timestep has been opened
-  virtual void newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles, Interpolated_Field& E,
-        Interpolated_Field& B, Field& V) {};
+  virtual void newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles, Field& E,
+        Field& B, Field& V) {};
 
   // Modify or analyze particle behaviour before they are moved by the particle pusher.
-  virtual void beforePush(std::vector<Particle>& particles, Interpolated_Field& E, Interpolated_Field& B, Field& V) {};
+  virtual void beforePush(std::vector<Particle>& particles, Field& E, Field& B, Field& V) {};
 
   // Modify or analzye particle behaviour after they are moved by the particle pusher
-  virtual void afterPush(int step, double time, std::vector<Particle>& particles, Interpolated_Field& E, Interpolated_Field& B, Field& V) {};
+  virtual void afterPush(int step, double time, std::vector<Particle>& particles, Field& E, Field& B, Field& V) {};
 
   // Analyze the final state and / or write output
   virtual void finalize(std::vector<Particle>& particles, Field& E, Field& B, Field& V) {};
@@ -45,7 +45,7 @@ struct Scenario {
 // Trace a single particle, it's initial position and velocity given in the parameter file
 struct singleParticleScenario : Scenario {
   std::vector<Particle> initialParticles(Field& E, Field& B, Field& V);
-  void afterPush(int step, double time, std::vector<Particle>& particles, Interpolated_Field& E, Interpolated_Field& B, Field& V);
+  void afterPush(int step, double time, std::vector<Particle>& particles, Field& E, Field& B, Field& V);
 
   singleParticleScenario() {needV = false;};
 };
@@ -53,7 +53,7 @@ struct singleParticleScenario : Scenario {
 // Sample a bunch of particles from a distribution, create them at a given point, then trace them
 struct distributionScenario : Scenario {
   std::vector<Particle> initialParticles(Field& E, Field& B, Field& V);
-  void newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles, Interpolated_Field& E, Interpolated_Field& B,
+  void newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles, Field& E, Field& B,
         Field& V);
   void finalize(std::vector<Particle>& particles, Field& E, Field& B, Field& V);
 
@@ -62,9 +62,9 @@ struct distributionScenario : Scenario {
 
 // Inject particles in the tail continuously, see where they precipitate
 struct precipitationScenario : Scenario {
-  void newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles, Interpolated_Field& E, Interpolated_Field& B,
+  void newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles, Field& E, Field& B,
         Field& V);
-  void afterPush(int step, double time, std::vector<Particle>& particles, Interpolated_Field& E, Interpolated_Field& B, Field& V);
+  void afterPush(int step, double time, std::vector<Particle>& particles, Field& E, Field& B, Field& V);
 
   precipitationScenario() {needV = true;};
 };
@@ -72,7 +72,7 @@ struct precipitationScenario : Scenario {
 // For interactive usage from analysator: read positions and velocities from stdin, push those particles.
 struct analysatorScenario : Scenario {
   std::vector<Particle> initialParticles(Field& E, Field& B, Field& V);
-  void newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles, Interpolated_Field& E, Interpolated_Field& B,
+  void newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles, Field& E, Field& B,
         Field& V);
   analysatorScenario() {needV = false;};
 };
@@ -83,9 +83,9 @@ struct shockReflectivityScenario : Scenario {
   LinearHistogram2D transmitted;
   LinearHistogram2D reflected;
 
-  void newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles, Interpolated_Field& E, Interpolated_Field& B,
+  void newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles, Field& E, Field& B,
         Field& V);
-  void afterPush(int step, double time, std::vector<Particle>& particles, Interpolated_Field& E, Interpolated_Field& B, Field& V);
+  void afterPush(int step, double time, std::vector<Particle>& particles, Field& E, Field& B, Field& V);
   void finalize(std::vector<Particle>& particles, Field& E, Field& B, Field& V);
 
   shockReflectivityScenario() :
@@ -103,9 +103,9 @@ struct ipShockScenario : Scenario {
   FILE * refFile;
 
   std::vector<Particle> initialParticles(Field& E, Field& B, Field& V);
-  void newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles, Interpolated_Field& E, Interpolated_Field& B,
+  void newTimestep(int input_file_counter, int step, double time, std::vector<Particle>& particles, Field& E, Field& B,
         Field& V);
-  void afterPush(int step, double time, std::vector<Particle>& particles, Interpolated_Field& E, Interpolated_Field& B, Field& V);
+  void afterPush(int step, double time, std::vector<Particle>& particles, Field& E, Field& B, Field& V);
   void finalize(std::vector<Particle>& particles, Field& E, Field& B, Field& V);
 
   ipShockScenario() {needV = true;};


### PR DESCRIPTION
This is no longer required, as the virtual functions' inheritance works properly now.
Also removed a warning about uninitialized boundaries at startup.

This is a direct followup to pull request #288 
