### PR TITLE
Change testpackage script on sisu to use the "current" symlink by default

### DIFF
--- a/testpackage/small_test_sisu.sh
+++ b/testpackage/small_test_sisu.sh
@@ -50,8 +50,9 @@ create_verification_files=0
 
 #folder for all reference data 
 reference_dir="/proj/vlasiato/testpackage/"
-#compare agains which revision
-reference_revision="c36241b84ce8179f7491ebf2a94c377d7279e8c9__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER"
+#compare agains which revision. This can be a proper version string, or "current", which should be a symlink to the
+#proper most recent one
+reference_revision="current"
 
 
 


### PR DESCRIPTION
Previously, it tended to be weird that the script's default comparison version was pointing to one from may 2015, even though newer ones existed. Which one was the proper reference? Should it be updated?

Now there is a "current" symlink on sisu, that *should* always be pointing to the correct version.