### PR TITLE
Field solver Hall term rho interpolation

### DIFF
--- a/fieldsolver/ldz_electric_field.cpp
+++ b/fieldsolver/ldz_electric_field.cpp
@@ -408,7 +408,7 @@ void calculateEdgeElectricFieldX(
    creal* const derivs_NE = cache.cells[fs_cache::calculateNbrID(1  ,1-1,1-1)]->derivatives;
    creal* const derivs_NW = cache.cells[fs_cache::calculateNbrID(1  ,1  ,1-1)]->derivatives;
 
-   Real By_S, Bz_W, Bz_E, By_N, perBy_S, perBz_W, perBz_E, perBy_N;
+   Real By_S, Bz_W, Bz_E, By_N, perBy_S, perBz_W, perBz_E, perBy_N, rho_S;
    Real minRho = std::numeric_limits<Real>::max();
    Real maxRho = std::numeric_limits<Real>::min();
    if(RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
@@ -422,6 +422,7 @@ void calculateEdgeElectricFieldX(
       perBy_N = cp_NW[CellParams::PERBY];
       Vy0  = divideIfNonZero(cp_SW[CellParams::RHOVY], cp_SW[CellParams::RHO]);
       Vz0  = divideIfNonZero(cp_SW[CellParams::RHOVZ], cp_SW[CellParams::RHO]);
+      rho_S = FOURTH*(cp_SW[CellParams::RHO] + cp_SE[CellParams::RHO] + cp_NW[CellParams::RHO] + cp_NE[CellParams::RHO]);
       minRho = min(minRho,
                   min(cp_SW[CellParams::RHO],
                      min(cp_SE[CellParams::RHO],
@@ -449,6 +450,7 @@ void calculateEdgeElectricFieldX(
       perBy_N = cp_NW[CellParams::PERBY_DT2];
       Vy0  = divideIfNonZero(cp_SW[CellParams::RHOVY_DT2], cp_SW[CellParams::RHO_DT2]);
       Vz0  = divideIfNonZero(cp_SW[CellParams::RHOVZ_DT2], cp_SW[CellParams::RHO_DT2]);
+      rho_S = FOURTH*(cp_SW[CellParams::RHO_DT2] + cp_SE[CellParams::RHO_DT2] + cp_NW[CellParams::RHO_DT2] + cp_NE[CellParams::RHO_DT2]);
       minRho = min(minRho,
                   min(cp_SW[CellParams::RHO_DT2],
                      min(cp_SE[CellParams::RHO_DT2],
@@ -466,7 +468,8 @@ void calculateEdgeElectricFieldX(
                      )
                   );
    }
-
+   rho_S = (rho_S <= Parameters::hallMinimumRho) ? Parameters::hallMinimumRho : rho_S ;
+   
    creal dBydx_S = derivs_SW[fs::dPERBydx] + derivs_SW[fs::dBGBydx];
    creal dBydz_S = derivs_SW[fs::dPERBydz] + derivs_SW[fs::dBGBydz];
    creal dBzdx_W = derivs_SW[fs::dPERBzdx] + derivs_SW[fs::dBGBzdx];
@@ -500,7 +503,7 @@ void calculateEdgeElectricFieldX(
    
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ex_SW += cp_SW[CellParams::EXHALL_000_100];
+      Ex_SW += cp_SW[CellParams::EXHALL_000_100] / (rho_S*physicalconstants::MU_0*physicalconstants::CHARGE);
    }
    
    // Electron pressure gradient term
@@ -554,7 +557,7 @@ void calculateEdgeElectricFieldX(
 
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ex_SE += cp_SE[CellParams::EXHALL_010_110];
+      Ex_SE += cp_SE[CellParams::EXHALL_010_110] / (rho_S*physicalconstants::MU_0*physicalconstants::CHARGE);
    }
    
    // Electron pressure gradient term
@@ -608,7 +611,7 @@ void calculateEdgeElectricFieldX(
    
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ex_NW += cp_NW[CellParams::EXHALL_001_101];
+      Ex_NW += cp_NW[CellParams::EXHALL_001_101]  / (rho_S*physicalconstants::MU_0*physicalconstants::CHARGE);
    }
    
    // Electron pressure gradient term
@@ -662,7 +665,7 @@ void calculateEdgeElectricFieldX(
 
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ex_NE += cp_NE[CellParams::EXHALL_011_111];
+      Ex_NE += cp_NE[CellParams::EXHALL_011_111] / (rho_S*physicalconstants::MU_0*physicalconstants::CHARGE);
    }
    
    // Electron pressure gradient term
@@ -776,7 +779,7 @@ void calculateEdgeElectricFieldY(
    creal* const derivs_NE = cache.cells[fs_cache::calculateNbrID(1-1,1  ,1-1)]->derivatives;
 
    // Fetch required plasma parameters:
-   Real Bz_S, Bx_W, Bx_E, Bz_N, perBz_S, perBx_W, perBx_E, perBz_N;
+   Real Bz_S, Bx_W, Bx_E, Bz_N, perBz_S, perBx_W, perBx_E, perBz_N, rho_S;
    Real minRho = std::numeric_limits<Real>::max();
    Real maxRho = std::numeric_limits<Real>::min();
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
@@ -790,6 +793,7 @@ void calculateEdgeElectricFieldY(
       perBz_N = cp_NW[CellParams::PERBZ];
       Vx0  = divideIfNonZero(cp_SW[CellParams::RHOVX], cp_SW[CellParams::RHO]);
       Vz0  = divideIfNonZero(cp_SW[CellParams::RHOVZ], cp_SW[CellParams::RHO]);
+      rho_S = FOURTH*(cp_SW[CellParams::RHO] + cp_SE[CellParams::RHO] + cp_NW[CellParams::RHO] + cp_NE[CellParams::RHO]);
       minRho = min(minRho,
                   min(cp_SW[CellParams::RHO],
                      min(cp_SE[CellParams::RHO],
@@ -817,6 +821,7 @@ void calculateEdgeElectricFieldY(
       perBz_N = cp_NW[CellParams::PERBZ_DT2];
       Vx0  = divideIfNonZero(cp_SW[CellParams::RHOVX_DT2], cp_SW[CellParams::RHO_DT2]);
       Vz0  = divideIfNonZero(cp_SW[CellParams::RHOVZ_DT2], cp_SW[CellParams::RHO_DT2]);
+      rho_S = FOURTH*(cp_SW[CellParams::RHO_DT2] + cp_SE[CellParams::RHO_DT2] + cp_NW[CellParams::RHO_DT2] + cp_NE[CellParams::RHO_DT2]);
       minRho = min(minRho,
                   min(cp_SW[CellParams::RHO_DT2],
                      min(cp_SE[CellParams::RHO_DT2],
@@ -834,6 +839,7 @@ void calculateEdgeElectricFieldY(
                      )
                   );
    }
+   rho_S = (rho_S <= Parameters::hallMinimumRho) ? Parameters::hallMinimumRho : rho_S ;
    
    creal dBxdy_W = derivs_SW[fs::dPERBxdy] + derivs_SW[fs::dBGBxdy];
    creal dBxdz_W = derivs_SW[fs::dPERBxdz] + derivs_SW[fs::dBGBxdz];
@@ -868,7 +874,7 @@ void calculateEdgeElectricFieldY(
    
    // Hall term
    if (Parameters::ohmHallTerm > 0) {
-      Ey_SW += cp_SW[CellParams::EYHALL_000_010];
+      Ey_SW += cp_SW[CellParams::EYHALL_000_010] / (rho_S*physicalconstants::MU_0*physicalconstants::CHARGE);
    }
    
    // Electron pressure gradient term
@@ -922,7 +928,7 @@ void calculateEdgeElectricFieldY(
 
    // Hall term
    if (Parameters::ohmHallTerm > 0) {
-      Ey_SE += cp_SE[CellParams::EYHALL_001_011];
+      Ey_SE += cp_SE[CellParams::EYHALL_001_011] / (rho_S*physicalconstants::MU_0*physicalconstants::CHARGE);
    }
    
    // Electron pressure gradient term
@@ -976,7 +982,7 @@ void calculateEdgeElectricFieldY(
 
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ey_NW += cp_NW[CellParams::EYHALL_100_110];
+      Ey_NW += cp_NW[CellParams::EYHALL_100_110] / (rho_S*physicalconstants::MU_0*physicalconstants::CHARGE);
    }
    
    // Electron pressure gradient term
@@ -1030,7 +1036,7 @@ void calculateEdgeElectricFieldY(
 
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ey_NE += cp_NE[CellParams::EYHALL_101_111];
+      Ey_NE += cp_NE[CellParams::EYHALL_101_111] / (rho_S*physicalconstants::MU_0*physicalconstants::CHARGE);
    }
    
    // Electron pressure gradient term
@@ -1142,7 +1148,7 @@ void calculateEdgeElectricFieldZ(
    creal* const derivs_NW = cache.cells[fs_cache::calculateNbrID(1  ,1-1,1  )]->derivatives;
 
    // Fetch needed plasma parameters/derivatives from the four cells:
-   Real Bx_S, By_W, By_E, Bx_N, perBx_S, perBy_W, perBy_E, perBx_N;
+   Real Bx_S, By_W, By_E, Bx_N, perBx_S, perBy_W, perBy_E, perBx_N, rho_S;
    Real minRho = std::numeric_limits<Real>::max();
    Real maxRho = std::numeric_limits<Real>::min();
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
@@ -1156,6 +1162,7 @@ void calculateEdgeElectricFieldZ(
       perBx_N    = cp_NW[CellParams::PERBX];
       Vx0  = divideIfNonZero(cp_SW[CellParams::RHOVX], cp_SW[CellParams::RHO]);
       Vy0  = divideIfNonZero(cp_SW[CellParams::RHOVY], cp_SW[CellParams::RHO]);
+      rho_S = FOURTH*(cp_SW[CellParams::RHO] + cp_SE[CellParams::RHO] + cp_NW[CellParams::RHO] + cp_NE[CellParams::RHO]);
       minRho = min(minRho,
                   min(cp_SW[CellParams::RHO],
                      min(cp_SE[CellParams::RHO],
@@ -1183,6 +1190,7 @@ void calculateEdgeElectricFieldZ(
       perBx_N    = cp_NW[CellParams::PERBX_DT2];
       Vx0  = divideIfNonZero(cp_SW[CellParams::RHOVX_DT2], cp_SW[CellParams::RHO_DT2]);
       Vy0  = divideIfNonZero(cp_SW[CellParams::RHOVY_DT2], cp_SW[CellParams::RHO_DT2]);
+      rho_S = FOURTH*(cp_SW[CellParams::RHO_DT2] + cp_SE[CellParams::RHO_DT2] + cp_NW[CellParams::RHO_DT2] + cp_NE[CellParams::RHO_DT2]);
       minRho = min(minRho,
                   min(cp_SW[CellParams::RHO_DT2],
                      min(cp_SE[CellParams::RHO_DT2],
@@ -1200,6 +1208,7 @@ void calculateEdgeElectricFieldZ(
                      )
                   );
    }
+   rho_S = (rho_S <= Parameters::hallMinimumRho) ? Parameters::hallMinimumRho : rho_S ;
    
    creal dBxdy_S = derivs_SW[fs::dPERBxdy] + derivs_SW[fs::dBGBxdy];
    creal dBxdz_S = derivs_SW[fs::dPERBxdz] + derivs_SW[fs::dBGBxdz];
@@ -1234,7 +1243,7 @@ void calculateEdgeElectricFieldZ(
    
    // Hall term
    if (Parameters::ohmHallTerm > 0) {
-      Ez_SW += cp_SW[CellParams::EZHALL_000_001];
+      Ez_SW += cp_SW[CellParams::EZHALL_000_001] / (rho_S*physicalconstants::MU_0*physicalconstants::CHARGE);
    }
    
    // Electron pressure gradient term
@@ -1287,9 +1296,10 @@ void calculateEdgeElectricFieldZ(
      (cp_SE[CellParams::RHO]*physicalconstants::CHARGE) /
      physicalconstants::MU_0 *
      (derivs_SE[fs::dPERBydx]/cp_SE[CellParams::DX] - derivs_SE[fs::dPERBxdy]/cp_SE[CellParams::DY]);
+   
    // Hall term
    if (Parameters::ohmHallTerm > 0) {
-      Ez_SE += cp_SE[CellParams::EZHALL_100_101];
+      Ez_SE += cp_SE[CellParams::EZHALL_100_101] / (rho_S*physicalconstants::MU_0*physicalconstants::CHARGE);
    }
    
    // Electron pressure gradient term
@@ -1343,7 +1353,7 @@ void calculateEdgeElectricFieldZ(
 
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ez_NW += cp_NW[CellParams::EZHALL_010_011];
+      Ez_NW += cp_NW[CellParams::EZHALL_010_011] / (rho_S*physicalconstants::MU_0*physicalconstants::CHARGE);
    }
    
    // Electron pressure gradient term
@@ -1397,7 +1407,7 @@ void calculateEdgeElectricFieldZ(
    
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ez_NE += cp_NE[CellParams::EZHALL_110_111];
+      Ez_NE += cp_NE[CellParams::EZHALL_110_111] / (rho_S*physicalconstants::MU_0*physicalconstants::CHARGE);
    }
    
    // Electron pressure gradient term

--- a/fieldsolver/ldz_gradpe.cpp
+++ b/fieldsolver/ldz_gradpe.cpp
@@ -183,7 +183,7 @@ void calculateEdgeGradPeTermXComponents(
    cint& RKCase
 ) {
    #warning Particles (charge) assumed to be protons here
-   Real hallRho;
+   Real hallRho = 0.0;
    switch (Parameters::ohmGradPeTerm) {
       case 0:
          cerr << __FILE__ << __LINE__ << "You shouldn't be in a electron pressure gradient term function if Parameters::ohmGradPeTerm == 0." << endl;
@@ -211,7 +211,7 @@ void calculateEdgeGradPeTermYComponents(
    cint& RKCase
 ) {
    #warning Particles (charge) assumed to be protons here
-   Real hallRho;
+   Real hallRho = 0.0;
    switch (Parameters::ohmGradPeTerm) {
       case 0:
          cerr << __FILE__ << __LINE__ << "You shouldn't be in a electron pressure gradient term function if Parameters::ohmGradPeTerm == 0." << endl;
@@ -239,7 +239,7 @@ void calculateEdgeGradPeTermZComponents(
    cint& RKCase
 ) {
   #warning Particles (charge) assumed to be protons here
-   Real hallRho;
+   Real hallRho = 0.0;
    switch (Parameters::ohmGradPeTerm) {
       case 0:
          cerr << __FILE__ << __LINE__ << "You shouldn't be in a electron pressure gradient term function if Parameters::ohmGradPeTerm == 0." << endl;

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -437,7 +437,11 @@ void calculateEdgeHallTermXComponents(
 ) {
    #warning Particles (charge) assumed to be protons here
    
-   Real By, Bz, hallRho = 0.0;
+   Real By = 0.0;
+   Real Bz = 0.0;
+   Real hallRho = 0.0;
+   creal drhody = 0.5*derivs[fieldsolver::drhody];
+   creal drhodz = 0.5*derivs[fieldsolver::drhodz];
    
    switch (Parameters::ohmHallTerm) {
     case 0:
@@ -467,31 +471,45 @@ void calculateEdgeHallTermXComponents(
       break;
     case 2:
       if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-         hallRho =  (cp[CellParams::RHO] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO] ;
+         hallRho = cp[CellParams::RHO] - drhody - drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EXHALL_000_100] = JXBX_000_100(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
                                         / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO] + drhody - drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EXHALL_010_110] = JXBX_010_110(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
                                         / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO] - drhody + drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EXHALL_001_101] = JXBX_001_101(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
                                         / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO] + drhody + drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EXHALL_011_111] = JXBX_011_111(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
                                         / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
       }
       if (RKCase == RK_ORDER2_STEP1) {
-         hallRho =  (cp[CellParams::RHO_DT2] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO_DT2] ;
+         hallRho = cp[CellParams::RHO_DT2] - drhody - drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EXHALL_000_100] = JXBX_000_100(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
                                         / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO_DT2] + drhody - drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EXHALL_010_110] = JXBX_010_110(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
                                         / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO_DT2] - drhody + drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EXHALL_001_101] = JXBX_001_101(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
                                         / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO_DT2] + drhody + drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EXHALL_011_111] = JXBX_011_111(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
                                         / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
@@ -524,7 +542,11 @@ void calculateEdgeHallTermYComponents(
 ) {
    #warning Particles (charge) assumed to be protons here
    
-   Real Bx, Bz, hallRho = 0.0;
+   Real Bx = 0.0;
+   Real Bz = 0.0;
+   Real hallRho = 0.0;
+   creal drhodx = 0.5*derivs[fieldsolver::drhodx];
+   creal drhodz = 0.5*derivs[fieldsolver::drhodz];
    
    switch (Parameters::ohmHallTerm) {
     case 0:
@@ -555,34 +577,48 @@ void calculateEdgeHallTermYComponents(
       
     case 2:
       if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-         hallRho =  (cp[CellParams::RHO] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO] ;
+         hallRho = cp[CellParams::RHO] - drhodx - drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EYHALL_000_010] = JXBY_000_010(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                         cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                   / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO] + drhodx - drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EYHALL_100_110] = JXBY_100_110(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                         cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                   / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO] - drhodx + drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EYHALL_001_011] = JXBY_001_011(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                         cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-      / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO] + drhodx + drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EYHALL_101_111] = JXBY_101_111(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                         cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-      / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
       }
       if (RKCase == RK_ORDER2_STEP1) {
-         hallRho =  (cp[CellParams::RHO_DT2] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO_DT2] ;
+         hallRho = cp[CellParams::RHO_DT2] - drhodx - drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EYHALL_000_010] = JXBY_000_010(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                         cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-      / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO_DT2] + drhodx - drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EYHALL_100_110] = JXBY_100_110(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                         cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-      / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO_DT2] - drhodx + drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EYHALL_001_011] = JXBY_001_011(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                         cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-      / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO_DT2] + drhodx + drhodz;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EYHALL_101_111] = JXBY_101_111(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                         cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-      / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
       }
       break;
 
@@ -612,8 +648,12 @@ void calculateEdgeHallTermZComponents(
 ) {
   #warning Particles (charge) assumed to be protons here
    
-   Real Bx, By, hallRho = 0.0;
-
+   Real Bx = 0.0;
+   Real By = 0.0;
+   Real hallRho = 0.0;
+   creal drhodx = 0.5*derivs[fieldsolver::drhodx];
+   creal drhody = 0.5*derivs[fieldsolver::drhody];
+   
    switch (Parameters::ohmHallTerm) {
    case 0:
      cerr << __FILE__ << __LINE__ << "You shouldn't be in a Hall term function if Parameters::ohmHallTerm == 0." << endl;
@@ -643,34 +683,48 @@ void calculateEdgeHallTermZComponents(
 
    case 2:
       if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-         hallRho =  (cp[CellParams::RHO] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO] ;
+         hallRho = cp[CellParams::RHO] - drhodx - drhody;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EZHALL_000_001] = JXBZ_000_001(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-           / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO] + drhodx - drhody;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EZHALL_100_101] = JXBZ_100_101(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-           / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO] - drhodx + drhody;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EZHALL_010_011] = JXBZ_010_011(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-           / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO] + drhodx + drhody;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EZHALL_110_111] = JXBZ_110_111(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-           / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
       }
       if (RKCase == RK_ORDER2_STEP1) {
-         hallRho =  (cp[CellParams::RHO_DT2] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO_DT2] ;
+         hallRho = cp[CellParams::RHO_DT2] - drhodx - drhody;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EZHALL_000_001] = JXBZ_000_001(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-           / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO_DT2] + drhodx - drhody;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EZHALL_100_101] = JXBZ_100_101(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-           / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO_DT2] - drhodx + drhody;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EZHALL_010_011] = JXBZ_010_011(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-           / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+         hallRho = cp[CellParams::RHO_DT2] + drhodx + drhody;
+         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EZHALL_110_111] = JXBZ_110_111(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
                                                        cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-           / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
       }
       break;
       

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -436,9 +436,8 @@ void calculateEdgeHallTermXComponents(
    cint& RKCase
 ) {
    #warning Particles (charge) assumed to be protons here
-
-   Real hallRho;
-   Real By, Bz, EXHall = 0.0;
+   
+   Real By, Bz, hallRho = 0.0;
    
    switch (Parameters::ohmHallTerm) {
     case 0:
@@ -450,27 +449,21 @@ void calculateEdgeHallTermXComponents(
          By = cp[CellParams::PERBY]+cp[CellParams::BGBY];
          Bz = cp[CellParams::PERBZ]+cp[CellParams::BGBZ];
          hallRho =  (cp[CellParams::RHO] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO] ;
-         EXHall = (Bz*((derivs[fieldsolver::dBGBxdz]+derivs[fieldsolver::dPERBxdz])/cp[CellParams::DZ] -
-                       (derivs[fieldsolver::dBGBzdx]+derivs[fieldsolver::dPERBzdx])/cp[CellParams::DX]) -
-                   By*((derivs[fieldsolver::dBGBydx]+derivs[fieldsolver::dPERBydx])/cp[CellParams::DX]-
-                       ((derivs[fieldsolver::dBGBxdy]+derivs[fieldsolver::dPERBxdy])/cp[CellParams::DY])))
-                / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
       }
       if (RKCase == RK_ORDER2_STEP1) {
          By = cp[CellParams::PERBY_DT2]+cp[CellParams::BGBY];
          Bz = cp[CellParams::PERBZ_DT2]+cp[CellParams::BGBZ];
          hallRho =  (cp[CellParams::RHO_DT2] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO_DT2] ;
-         EXHall = (Bz*((derivs[fieldsolver::dBGBxdz]+derivs[fieldsolver::dPERBxdz])/cp[CellParams::DZ] -
-                       (derivs[fieldsolver::dBGBzdx]+derivs[fieldsolver::dPERBzdx])/cp[CellParams::DX]) -
-                   By*((derivs[fieldsolver::dBGBydx]+derivs[fieldsolver::dPERBydx])/cp[CellParams::DX]-
-                       ((derivs[fieldsolver::dBGBxdy]+derivs[fieldsolver::dPERBxdy])/cp[CellParams::DY])))
-                / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
       }
 
       cp[CellParams::EXHALL_000_100] =
       cp[CellParams::EXHALL_010_110] =
       cp[CellParams::EXHALL_001_101] =
-      cp[CellParams::EXHALL_011_111] = EXHall;
+      cp[CellParams::EXHALL_011_111] = (Bz*((derivs[fieldsolver::dBGBxdz]+derivs[fieldsolver::dPERBxdz])/cp[CellParams::DZ] -
+                                            (derivs[fieldsolver::dBGBzdx]+derivs[fieldsolver::dPERBzdx])/cp[CellParams::DX]) -
+                                        By*((derivs[fieldsolver::dBGBydx]+derivs[fieldsolver::dPERBydx])/cp[CellParams::DX]-
+                                            (derivs[fieldsolver::dBGBxdy]+derivs[fieldsolver::dPERBxdy])/cp[CellParams::DY]))
+                                     / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
       break;
     case 2:
       if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
@@ -530,9 +523,8 @@ void calculateEdgeHallTermYComponents(
    cint& RKCase
 ) {
    #warning Particles (charge) assumed to be protons here
-
-   Real hallRho;
-   Real Bx, Bz, EYHall = 0.0;
+   
+   Real Bx, Bz, hallRho = 0.0;
    
    switch (Parameters::ohmHallTerm) {
     case 0:
@@ -544,27 +536,21 @@ void calculateEdgeHallTermYComponents(
          Bx = cp[CellParams::PERBX]+cp[CellParams::BGBX];
          Bz = cp[CellParams::PERBZ]+cp[CellParams::BGBZ];
          hallRho =  (cp[CellParams::RHO] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO] ;
-         EYHall = (Bx*((derivs[fieldsolver::dBGBydx]+derivs[fieldsolver::dPERBydx])/cp[CellParams::DX] -
-                       (derivs[fieldsolver::dBGBxdy]+derivs[fieldsolver::dPERBxdy])/cp[CellParams::DY]) -
-                   Bz*((derivs[fieldsolver::dBGBzdy]+derivs[fieldsolver::dPERBzdy])/cp[CellParams::DY] -
-                       ((derivs[fieldsolver::dBGBydz]+derivs[fieldsolver::dPERBydz])/cp[CellParams::DZ] )))
-                / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
       }
       if (RKCase == RK_ORDER2_STEP1) {
          Bx = cp[CellParams::PERBX_DT2]+cp[CellParams::BGBX];
          Bz = cp[CellParams::PERBZ_DT2]+cp[CellParams::BGBZ];
          hallRho =  (cp[CellParams::RHO_DT2] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO_DT2] ;
-         EYHall = (Bx*((derivs[fieldsolver::dBGBydx]+derivs[fieldsolver::dPERBydx])/cp[CellParams::DX] -
-                       (derivs[fieldsolver::dBGBxdy]+derivs[fieldsolver::dPERBxdy])/cp[CellParams::DY]) -
-                   Bz*((derivs[fieldsolver::dBGBzdy]+derivs[fieldsolver::dPERBzdy])/cp[CellParams::DY] -
-                       ((derivs[fieldsolver::dBGBydz]+derivs[fieldsolver::dPERBydz])/cp[CellParams::DZ] )))
-                / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
       }
 
       cp[CellParams::EYHALL_000_010] =
       cp[CellParams::EYHALL_100_110] =
       cp[CellParams::EYHALL_101_111] =
-      cp[CellParams::EYHALL_001_011] = EYHall;
+      cp[CellParams::EYHALL_001_011] = (Bx*((derivs[fieldsolver::dBGBydx]+derivs[fieldsolver::dPERBydx])/cp[CellParams::DX] -
+                                            (derivs[fieldsolver::dBGBxdy]+derivs[fieldsolver::dPERBxdy])/cp[CellParams::DY]) -
+                                        Bz*((derivs[fieldsolver::dBGBzdy]+derivs[fieldsolver::dPERBzdy])/cp[CellParams::DY] -
+                                            (derivs[fieldsolver::dBGBydz]+derivs[fieldsolver::dPERBydz])/cp[CellParams::DZ]))
+                                     / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
       break;
       
     case 2:
@@ -625,9 +611,8 @@ void calculateEdgeHallTermZComponents(
    cint& RKCase
 ) {
   #warning Particles (charge) assumed to be protons here
-
-   Real hallRho;
-   Real Bx, By, EZHall=0.0;
+   
+   Real Bx, By, hallRho = 0.0;
 
    switch (Parameters::ohmHallTerm) {
    case 0:
@@ -639,27 +624,21 @@ void calculateEdgeHallTermZComponents(
         Bx = cp[CellParams::PERBX]+cp[CellParams::BGBX];
         By = cp[CellParams::PERBY]+cp[CellParams::BGBY];
         hallRho =  (cp[CellParams::RHO] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO] ;
-        EZHall = (By*((derivs[fieldsolver::dBGBzdy]+derivs[fieldsolver::dPERBzdy])/cp[CellParams::DY] -
-                      (derivs[fieldsolver::dBGBydz]+derivs[fieldsolver::dPERBydz])/cp[CellParams::DZ]) -
-                  Bx*((derivs[fieldsolver::dBGBxdz]+derivs[fieldsolver::dPERBxdz])/cp[CellParams::DZ] -
-                      ((derivs[fieldsolver::dBGBzdx]+derivs[fieldsolver::dPERBzdx])/cp[CellParams::DX])))
-          / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
      }
      if (RKCase == RK_ORDER2_STEP1) {
         Bx = cp[CellParams::PERBX_DT2]+cp[CellParams::BGBX];
         By = cp[CellParams::PERBY_DT2]+cp[CellParams::BGBY];
         hallRho =  (cp[CellParams::RHO_DT2] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO_DT2] ;
-        EZHall = (By*((derivs[fieldsolver::dBGBzdy]+derivs[fieldsolver::dPERBzdy])/cp[CellParams::DY] -
-                      (derivs[fieldsolver::dBGBydz]+derivs[fieldsolver::dPERBydz])/cp[CellParams::DZ]) -
-                  Bx*((derivs[fieldsolver::dBGBxdz]+derivs[fieldsolver::dPERBxdz])/cp[CellParams::DZ] -
-                      ((derivs[fieldsolver::dBGBzdx]+derivs[fieldsolver::dPERBzdx])/cp[CellParams::DX])))
-          / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
      }
 
       cp[CellParams::EZHALL_000_001] =
       cp[CellParams::EZHALL_100_101] =
       cp[CellParams::EZHALL_110_111] =
-      cp[CellParams::EZHALL_010_011] = EZHall;
+      cp[CellParams::EZHALL_010_011] = (By*((derivs[fieldsolver::dBGBzdy]+derivs[fieldsolver::dPERBzdy])/cp[CellParams::DY] -
+                                            (derivs[fieldsolver::dBGBydz]+derivs[fieldsolver::dPERBydz])/cp[CellParams::DZ]) -
+                                        Bx*((derivs[fieldsolver::dBGBxdz]+derivs[fieldsolver::dPERBxdz])/cp[CellParams::DZ] -
+                                            (derivs[fieldsolver::dBGBzdx]+derivs[fieldsolver::dPERBzdx])/cp[CellParams::DX]))
+                                     / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
      break;
 
    case 2:

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -417,7 +417,7 @@ REAL JXBZ_110_111(
      (pC[a_xz]*pC[c_xyz])/(48*dx)+(pC[a_y]*pC[c_xy])/(4*dx)+(pC[a_xy]*pC[c_xy])/(8*dx)+(pC[a_xx]*pC[c_xy])/(12*dx)+(pC[a_x]*pC[c_xy])/(4*dx)+(pC[a_0]*pC[c_xy])/(2*dx)+(pC[a_z]*pC[c_xxz])/(12*dx)+(pC[a_xz]*pC[c_xxz])/(24*dx)+(pC[a_y]*pC[c_xx])/(2*dx)+(pC[a_xy]*pC[c_xx])/(4*dx)+(pC[a_xx]*pC[c_xx])/(6*dx)+(pC[a_x]*pC[c_xx])/(2*dx)+(pC[a_0]*pC[c_xx])/dx+(pC[a_y]*pC[c_x])/(2*dx)+(pC[a_xy]*pC[c_x])/(4*dx)+(pC[a_xx]*pC[c_x])/(6*dx)+(pC[a_x]*pC[c_x])/(2*dx)+(pC[a_0]*pC[c_x])/dx;
 }
 
-/*! \brief Low-level function computing the Hall term x components.
+/*! \brief Low-level function computing the Hall term numerator x components.
  * 
  * Calls the lower-level inline templates and scales the components properly.
  * 
@@ -439,9 +439,6 @@ void calculateEdgeHallTermXComponents(
    
    Real By = 0.0;
    Real Bz = 0.0;
-   Real hallRho = 0.0;
-   creal drhody = 0.5*derivs[fieldsolver::drhody];
-   creal drhodz = 0.5*derivs[fieldsolver::drhodz];
    
    switch (Parameters::ohmHallTerm) {
     case 0:
@@ -452,67 +449,40 @@ void calculateEdgeHallTermXComponents(
       if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
          By = cp[CellParams::PERBY]+cp[CellParams::BGBY];
          Bz = cp[CellParams::PERBZ]+cp[CellParams::BGBZ];
-         hallRho =  (cp[CellParams::RHO] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO] ;
       }
       if (RKCase == RK_ORDER2_STEP1) {
          By = cp[CellParams::PERBY_DT2]+cp[CellParams::BGBY];
          Bz = cp[CellParams::PERBZ_DT2]+cp[CellParams::BGBZ];
-         hallRho =  (cp[CellParams::RHO_DT2] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO_DT2] ;
       }
 
       cp[CellParams::EXHALL_000_100] =
       cp[CellParams::EXHALL_010_110] =
       cp[CellParams::EXHALL_001_101] =
-      cp[CellParams::EXHALL_011_111] = (Bz*((derivs[fieldsolver::dBGBxdz]+derivs[fieldsolver::dPERBxdz])/cp[CellParams::DZ] -
-                                            (derivs[fieldsolver::dBGBzdx]+derivs[fieldsolver::dPERBzdx])/cp[CellParams::DX]) -
-                                        By*((derivs[fieldsolver::dBGBydx]+derivs[fieldsolver::dPERBydx])/cp[CellParams::DX]-
-                                            (derivs[fieldsolver::dBGBxdy]+derivs[fieldsolver::dPERBxdy])/cp[CellParams::DY]))
-                                     / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+      cp[CellParams::EXHALL_011_111] = Bz*((derivs[fieldsolver::dBGBxdz]+derivs[fieldsolver::dPERBxdz])/cp[CellParams::DZ] -
+                                           (derivs[fieldsolver::dBGBzdx]+derivs[fieldsolver::dPERBzdx])/cp[CellParams::DX]) -
+                                       By*((derivs[fieldsolver::dBGBydx]+derivs[fieldsolver::dPERBydx])/cp[CellParams::DX]-
+                                           (derivs[fieldsolver::dBGBxdy]+derivs[fieldsolver::dPERBxdy])/cp[CellParams::DY]);
       break;
     case 2:
       if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-         hallRho = cp[CellParams::RHO] - drhody - drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EXHALL_000_100] = JXBX_000_100(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO] + drhody - drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EXHALL_010_110] = JXBX_010_110(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO] - drhody + drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EXHALL_001_101] = JXBX_001_101(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO] + drhody + drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EXHALL_011_111] = JXBX_011_111(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
       }
       if (RKCase == RK_ORDER2_STEP1) {
-         hallRho = cp[CellParams::RHO_DT2] - drhody - drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EXHALL_000_100] = JXBX_000_100(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO_DT2] + drhody - drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EXHALL_010_110] = JXBX_010_110(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO_DT2] - drhody + drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EXHALL_001_101] = JXBX_001_101(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO_DT2] + drhody + drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EXHALL_011_111] = JXBX_011_111(perturbedCoefficients, cp[CellParams::BGBY], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
       }
       break;
 
@@ -522,7 +492,7 @@ void calculateEdgeHallTermXComponents(
    }
 }
 
-/*! \brief Low-level function computing the Hall term y components.
+/*! \brief Low-level function computing the Hall term numerator y components.
  * 
  * Calls the lower-level inline templates and scales the components properly.
  * 
@@ -544,9 +514,6 @@ void calculateEdgeHallTermYComponents(
    
    Real Bx = 0.0;
    Real Bz = 0.0;
-   Real hallRho = 0.0;
-   creal drhodx = 0.5*derivs[fieldsolver::drhodx];
-   creal drhodz = 0.5*derivs[fieldsolver::drhodz];
    
    switch (Parameters::ohmHallTerm) {
     case 0:
@@ -557,68 +524,41 @@ void calculateEdgeHallTermYComponents(
       if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
          Bx = cp[CellParams::PERBX]+cp[CellParams::BGBX];
          Bz = cp[CellParams::PERBZ]+cp[CellParams::BGBZ];
-         hallRho =  (cp[CellParams::RHO] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO] ;
       }
       if (RKCase == RK_ORDER2_STEP1) {
          Bx = cp[CellParams::PERBX_DT2]+cp[CellParams::BGBX];
          Bz = cp[CellParams::PERBZ_DT2]+cp[CellParams::BGBZ];
-         hallRho =  (cp[CellParams::RHO_DT2] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO_DT2] ;
       }
 
       cp[CellParams::EYHALL_000_010] =
       cp[CellParams::EYHALL_100_110] =
       cp[CellParams::EYHALL_101_111] =
-      cp[CellParams::EYHALL_001_011] = (Bx*((derivs[fieldsolver::dBGBydx]+derivs[fieldsolver::dPERBydx])/cp[CellParams::DX] -
-                                            (derivs[fieldsolver::dBGBxdy]+derivs[fieldsolver::dPERBxdy])/cp[CellParams::DY]) -
-                                        Bz*((derivs[fieldsolver::dBGBzdy]+derivs[fieldsolver::dPERBzdy])/cp[CellParams::DY] -
-                                            (derivs[fieldsolver::dBGBydz]+derivs[fieldsolver::dPERBydz])/cp[CellParams::DZ]))
-                                     / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+      cp[CellParams::EYHALL_001_011] = Bx*((derivs[fieldsolver::dBGBydx]+derivs[fieldsolver::dPERBydx])/cp[CellParams::DX] -
+                                           (derivs[fieldsolver::dBGBxdy]+derivs[fieldsolver::dPERBxdy])/cp[CellParams::DY]) -
+                                       Bz*((derivs[fieldsolver::dBGBzdy]+derivs[fieldsolver::dPERBzdy])/cp[CellParams::DY] -
+                                           (derivs[fieldsolver::dBGBydz]+derivs[fieldsolver::dPERBydz])/cp[CellParams::DZ]);
       break;
       
     case 2:
       if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-         hallRho = cp[CellParams::RHO] - drhodx - drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EYHALL_000_010] = JXBY_000_010(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO] + drhodx - drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EYHALL_100_110] = JXBY_100_110(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO] - drhodx + drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EYHALL_001_011] = JXBY_001_011(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO] + drhodx + drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EYHALL_101_111] = JXBY_101_111(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
       }
       if (RKCase == RK_ORDER2_STEP1) {
-         hallRho = cp[CellParams::RHO_DT2] - drhodx - drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EYHALL_000_010] = JXBY_000_010(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO_DT2] + drhodx - drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EYHALL_100_110] = JXBY_100_110(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO_DT2] - drhodx + drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EYHALL_001_011] = JXBY_001_011(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO_DT2] + drhodx + drhodz;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EYHALL_101_111] = JXBY_101_111(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBZ], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
       }
       break;
 
@@ -628,7 +568,7 @@ void calculateEdgeHallTermYComponents(
    }
 }
 
-/*! \brief Low-level function computing the Hall term z components.
+/*! \brief Low-level function computing the Hall term numerator z components.
  * 
  * Calls the lower-level inline templates and scales the components properly.
  * 
@@ -650,9 +590,6 @@ void calculateEdgeHallTermZComponents(
    
    Real Bx = 0.0;
    Real By = 0.0;
-   Real hallRho = 0.0;
-   creal drhodx = 0.5*derivs[fieldsolver::drhodx];
-   creal drhody = 0.5*derivs[fieldsolver::drhody];
    
    switch (Parameters::ohmHallTerm) {
    case 0:
@@ -663,68 +600,41 @@ void calculateEdgeHallTermZComponents(
      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
         Bx = cp[CellParams::PERBX]+cp[CellParams::BGBX];
         By = cp[CellParams::PERBY]+cp[CellParams::BGBY];
-        hallRho =  (cp[CellParams::RHO] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO] ;
      }
      if (RKCase == RK_ORDER2_STEP1) {
         Bx = cp[CellParams::PERBX_DT2]+cp[CellParams::BGBX];
         By = cp[CellParams::PERBY_DT2]+cp[CellParams::BGBY];
-        hallRho =  (cp[CellParams::RHO_DT2] <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : cp[CellParams::RHO_DT2] ;
      }
 
       cp[CellParams::EZHALL_000_001] =
       cp[CellParams::EZHALL_100_101] =
       cp[CellParams::EZHALL_110_111] =
-      cp[CellParams::EZHALL_010_011] = (By*((derivs[fieldsolver::dBGBzdy]+derivs[fieldsolver::dPERBzdy])/cp[CellParams::DY] -
-                                            (derivs[fieldsolver::dBGBydz]+derivs[fieldsolver::dPERBydz])/cp[CellParams::DZ]) -
-                                        Bx*((derivs[fieldsolver::dBGBxdz]+derivs[fieldsolver::dPERBxdz])/cp[CellParams::DZ] -
-                                            (derivs[fieldsolver::dBGBzdx]+derivs[fieldsolver::dPERBzdx])/cp[CellParams::DX]))
-                                     / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+      cp[CellParams::EZHALL_010_011] = By*((derivs[fieldsolver::dBGBzdy]+derivs[fieldsolver::dPERBzdy])/cp[CellParams::DY] -
+                                           (derivs[fieldsolver::dBGBydz]+derivs[fieldsolver::dPERBydz])/cp[CellParams::DZ]) -
+                                       Bx*((derivs[fieldsolver::dBGBxdz]+derivs[fieldsolver::dPERBxdz])/cp[CellParams::DZ] -
+                                           (derivs[fieldsolver::dBGBzdx]+derivs[fieldsolver::dPERBzdx])/cp[CellParams::DX]);
      break;
 
    case 2:
       if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-         hallRho = cp[CellParams::RHO] - drhodx - drhody;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EZHALL_000_001] = JXBZ_000_001(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO] + drhodx - drhody;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EZHALL_100_101] = JXBZ_100_101(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO] - drhodx + drhody;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EZHALL_010_011] = JXBZ_010_011(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO] + drhodx + drhody;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EZHALL_110_111] = JXBZ_110_111(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
       }
       if (RKCase == RK_ORDER2_STEP1) {
-         hallRho = cp[CellParams::RHO_DT2] - drhodx - drhody;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
          cp[CellParams::EZHALL_000_001] = JXBZ_000_001(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO_DT2] + drhodx - drhody;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EZHALL_100_101] = JXBZ_100_101(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO_DT2] - drhodx + drhody;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EZHALL_010_011] = JXBZ_010_011(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
-         hallRho = cp[CellParams::RHO_DT2] + drhodx + drhody;
-         hallRho = (hallRho <= Parameters::hallMinimumRho ) ? Parameters::hallMinimumRho : hallRho ;
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
          cp[CellParams::EZHALL_110_111] = JXBZ_110_111(perturbedCoefficients, cp[CellParams::BGBX], cp[CellParams::BGBY], 
-                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]) 
-                                        / (physicalconstants::MU_0*hallRho*physicalconstants::CHARGE);
+                                                       cp[CellParams::DX], cp[CellParams::DY], cp[CellParams::DZ]);
       }
       break;
       
@@ -734,7 +644,7 @@ void calculateEdgeHallTermZComponents(
    }
 }
 
-/** \brief Calculate the Hall term on all given cells.
+/** \brief Calculate the numerator of the Hall term on all given cells.
  * \param sysBoundaries System boundary condition functions.
  * \param cache Cache for local cells.
  * \param cells Local IDs of calculated cells, one of the vectors in fs_cache::CacheContainer.
@@ -819,7 +729,7 @@ void calculateHallTerm(
 
 /*! \brief High-level function computing the Hall term.
  * 
- * Performs the communication before and after the computation as well as the computation of all Hall term components.
+ * Performs the communication before and after the computation as well as the computation of all Hall term numerator components.
  * 
  * \param mpiGrid Grid
  * \param sysBoundaries System boundary condition functions.


### PR DESCRIPTION
This implements the Option 2 of #306, namely interpolation of rho to the cell edges for the Hall term components.