### PR TITLE
Allow a maximum memory per node bailout trigger to be set.

### DIFF
--- a/memoryallocation.cpp
+++ b/memoryallocation.cpp
@@ -27,6 +27,8 @@
 #include <limits>
 #include "logger.h"
 #include "memoryallocation.h"
+#include "common.h"
+#include "parameters.h"
 #ifdef PAPI_MEM
 #include "papi.h" 
 #endif 
@@ -156,6 +158,7 @@ void report_process_memory_consumption(){
          logFile << "(MEM) High water mark per node (GiB) avg: " << sum_mem_papi[0]/nNodes/GiB << " min: " << min_mem_papi[0]/GiB << " max: "  << max_mem_papi[0]/GiB <<
             " sum (TiB): " << sum_mem_papi[0]/TiB << " on "<< nNodes << " nodes" << endl;
          
+         bailout(sum_mem_papi[0]/nNodes/GiB > Parameters::bailout_max_memory, "Memory high water mark per node exceeds bailout threshold", __FILE__, __LINE__);
       }   
    }
    

--- a/memoryallocation.cpp
+++ b/memoryallocation.cpp
@@ -158,7 +158,7 @@ void report_process_memory_consumption(){
          logFile << "(MEM) High water mark per node (GiB) avg: " << sum_mem_papi[0]/nNodes/GiB << " min: " << min_mem_papi[0]/GiB << " max: "  << max_mem_papi[0]/GiB <<
             " sum (TiB): " << sum_mem_papi[0]/TiB << " on "<< nNodes << " nodes" << endl;
          
-         bailout(sum_mem_papi[0]/nNodes/GiB > Parameters::bailout_max_memory, "Memory high water mark per node exceeds bailout threshold", __FILE__, __LINE__);
+         bailout(max_mem_papi[0]/GiB > Parameters::bailout_max_memory, "Memory high water mark per node exceeds bailout threshold", __FILE__, __LINE__);
       }   
    }
    

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -145,6 +145,7 @@ Real P::hallMinimumRho=1.0;
 
 bool P::bailout_write_restart = false;
 Real P::bailout_min_dt = NAN;
+Real P::bailout_max_memory = std::numeric_limits<double>::max();
 
 uint P::amrMaxVelocityRefLevel = 0;
 Realf P::amrRefineLimit = 1.0;
@@ -244,6 +245,7 @@ bool Parameters::addParameters(){
    // bailout parameters
    Readparameters::add("bailout.write_restart", "If 1, write a restart file on bailout. Gets reset when sending a STOP (1) or a KILL (0).", true);
    Readparameters::add("bailout.min_dt", "Minimum time step below which bailout occurs (s).", 1e-6);
+   Readparameters::add("bailout.max_memory", "Maximum amount of memory used per node (in GB) over which bailout occurs.", std::numeric_limits<Real>::max());
 
    // Refinement parameters
    Readparameters::add("AMR.vel_refinement_criterion","Name of the velocity refinement criterion",string(""));
@@ -460,6 +462,7 @@ bool Parameters::getParameters(){
    // Get parameters related to bailout
    Readparameters::get("bailout.write_restart", P::bailout_write_restart);
    Readparameters::get("bailout.min_dt", P::bailout_min_dt);
+   Readparameters::get("bailout.max_memory", P::bailout_max_memory);
 
    for (size_t s=0; s<P::systemWriteName.size(); ++s) P::systemWrites.push_back(0);
    

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -145,7 +145,7 @@ Real P::hallMinimumRho=1.0;
 
 bool P::bailout_write_restart = false;
 Real P::bailout_min_dt = NAN;
-Real P::bailout_max_memory = 1e9;
+Real P::bailout_max_memory = 1073741824.;
 
 uint P::amrMaxVelocityRefLevel = 0;
 Realf P::amrRefineLimit = 1.0;
@@ -245,7 +245,7 @@ bool Parameters::addParameters(){
    // bailout parameters
    Readparameters::add("bailout.write_restart", "If 1, write a restart file on bailout. Gets reset when sending a STOP (1) or a KILL (0).", true);
    Readparameters::add("bailout.min_dt", "Minimum time step below which bailout occurs (s).", 1e-6);
-   Readparameters::add("bailout.max_memory", "Maximum amount of memory used per node (in GB) over which bailout occurs.", 1e9);
+   Readparameters::add("bailout.max_memory", "Maximum amount of memory used per node (in GiB) over which bailout occurs.", 1073741824.);
 
    // Refinement parameters
    Readparameters::add("AMR.vel_refinement_criterion","Name of the velocity refinement criterion",string(""));

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -145,7 +145,7 @@ Real P::hallMinimumRho=1.0;
 
 bool P::bailout_write_restart = false;
 Real P::bailout_min_dt = NAN;
-Real P::bailout_max_memory = std::numeric_limits<double>::max();
+Real P::bailout_max_memory = 1e9;
 
 uint P::amrMaxVelocityRefLevel = 0;
 Realf P::amrRefineLimit = 1.0;
@@ -245,7 +245,7 @@ bool Parameters::addParameters(){
    // bailout parameters
    Readparameters::add("bailout.write_restart", "If 1, write a restart file on bailout. Gets reset when sending a STOP (1) or a KILL (0).", true);
    Readparameters::add("bailout.min_dt", "Minimum time step below which bailout occurs (s).", 1e-6);
-   Readparameters::add("bailout.max_memory", "Maximum amount of memory used per node (in GB) over which bailout occurs.", std::numeric_limits<Real>::max());
+   Readparameters::add("bailout.max_memory", "Maximum amount of memory used per node (in GB) over which bailout occurs.", 1e9);
 
    // Refinement parameters
    Readparameters::add("AMR.vel_refinement_criterion","Name of the velocity refinement criterion",string(""));

--- a/parameters.h
+++ b/parameters.h
@@ -140,6 +140,7 @@ struct Parameters {
    
    static bool bailout_write_restart; /*!< If true, write a restart file on bailout. Gets reset when sending a STOP (true) or a KILL (false). */
    static Real bailout_min_dt; /*!< Minimum time step below which bailout occurs (s). */
+   static Real bailout_max_memory; /*!< Maximum amount of memory used per node (in GB) over which bailout occurs. */
 
    static uint amrMaxVelocityRefLevel;    /**< Maximum velocity mesh refinement level, defaults to 0.*/
    static Realf amrCoarsenLimit;          /**< If the value of refinement criterion is below this value, block can be coarsened.

--- a/parameters.h
+++ b/parameters.h
@@ -140,7 +140,7 @@ struct Parameters {
    
    static bool bailout_write_restart; /*!< If true, write a restart file on bailout. Gets reset when sending a STOP (true) or a KILL (false). */
    static Real bailout_min_dt; /*!< Minimum time step below which bailout occurs (s). */
-   static Real bailout_max_memory; /*!< Maximum amount of memory used per node (in GB) over which bailout occurs. */
+   static Real bailout_max_memory; /*!< Maximum amount of memory used per node (in GiB) over which bailout occurs. */
 
    static uint amrMaxVelocityRefLevel;    /**< Maximum velocity mesh refinement level, defaults to 0.*/
    static Realf amrCoarsenLimit;          /**< If the value of refinement criterion is below this value, block can be coarsened.


### PR DESCRIPTION
In order to prevent simulations from simply crashing when they run out of memory, this limit can be set to gracefully bailout once a certain memory level per node (given in GB) is exceeded.