### PR TITLE
Warn users in project.cpp if spatial cell would be empty

### DIFF
--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -545,6 +545,9 @@ namespace projects {
          const Real maxValue = setVelocityBlock(cell,blockLID,popID);
          if (maxValue < getObjectWrapper().particleSpecies[popID].sparseMinValue) removeList.push_back(blockGID);
       }
+      if (removeList.size() >= blocksToInitialize.size()) {
+         cerr << "WARNING: removing all blocks in spatial cell" << endl;
+      }
 
       // Get AMR refinement criterion and use it to test which blocks should be refined
       amr_ref_criteria::Base* refCriterion = getObjectWrapper().amrVelRefCriteria.create(Parameters::amrVelRefCriterion);


### PR DESCRIPTION
With too high minimum dist func threshold I got 0 densities and looks like that was a feature not a bug. A warning would've been nice so this adds it.