### PR TITLE
Fix acceleration

### DIFF
--- a/common.h
+++ b/common.h
@@ -352,18 +352,18 @@ RK_ORDER2_STEP1,   /*!< Two-step second order method, first step */
 RK_ORDER2_STEP2    /*!< Two-step second order method, second step */
 };
 
-const uint WID = 4;         /*!< Number of cells per coordinate in a velocity block. Only a value of 4 supported by vectorized Leveque solver */
-const uint WID2 = WID*WID;  /*!< Number of cells per 2D slab in a velocity block. */
-const uint WID3 = WID2*WID; /*!< Number of cells in a velocity block. */
+const int WID = 4;         /*!< Number of cells per coordinate in a velocity block. Only a value of 4 supported by vectorized Leveque solver */
+const int WID2 = WID*WID;  /*!< Number of cells per 2D slab in a velocity block. */
+const int WID3 = WID2*WID; /*!< Number of cells in a velocity block. */
 
 /*!
 Get the cellindex in the velocity space block
 */
-template<typename UINT> inline UINT cellIndex(const UINT& i,const UINT& j,const UINT& k) {
+template<typename INT> inline INT cellIndex(const INT& i,const INT& j,const INT& k) {
    return k*WID2 + j*WID + i;
 }
 
-const uint SIZE_VELBLOCK    = WID3; /*!< Number of cells in a velocity block. */
+const int SIZE_VELBLOCK    = WID3; /*!< Number of cells in a velocity block. */
 
 /*!
  * Name space for flags needed globally, such as the bailout flag.

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -126,7 +126,7 @@ void calculateDerivatives(
          
          array[fs::dPERBydx]  = limiter(left[cp::PERBY],cent[cp::PERBY],rght[cp::PERBY]);
          array[fs::dPERBzdx]  = limiter(left[cp::PERBZ],cent[cp::PERBZ],rght[cp::PERBZ]);
-         if(Parameters::ohmHallTerm < 2) {
+         if (Parameters::ohmHallTerm < 2 || sysBoundaryLayer == 1) {
             array[fs::dPERBydxx] = 0.0;
             array[fs::dPERBzdxx] = 0.0;
          } else {
@@ -151,7 +151,7 @@ void calculateDerivatives(
          
          array[fs::dPERBydx]  = limiter(left[cp::PERBY_DT2],cent[cp::PERBY_DT2],rght[cp::PERBY_DT2]);
          array[fs::dPERBzdx]  = limiter(left[cp::PERBZ_DT2],cent[cp::PERBZ_DT2],rght[cp::PERBZ_DT2]);
-         if(Parameters::ohmHallTerm < 2) {
+         if (Parameters::ohmHallTerm < 2 || sysBoundaryLayer == 1) {
             array[fs::dPERBydxx] = 0.0;
             array[fs::dPERBzdxx] = 0.0;
          } else {
@@ -192,7 +192,7 @@ void calculateDerivatives(
          array[fs::dPERBxdy]  = limiter(left[cp::PERBX],cent[cp::PERBX],rght[cp::PERBX]);
          array[fs::dPERBzdy]  = limiter(left[cp::PERBZ],cent[cp::PERBZ],rght[cp::PERBZ]);
 
-         if(Parameters::ohmHallTerm < 2) {
+         if (Parameters::ohmHallTerm < 2 || sysBoundaryLayer == 1) {
             array[fs::dPERBxdyy] = 0.0;
             array[fs::dPERBzdyy] = 0.0;
          } else {
@@ -217,7 +217,7 @@ void calculateDerivatives(
          
          array[fs::dPERBxdy]  = limiter(left[cp::PERBX_DT2],cent[cp::PERBX_DT2],rght[cp::PERBX_DT2]);
          array[fs::dPERBzdy]  = limiter(left[cp::PERBZ_DT2],cent[cp::PERBZ_DT2],rght[cp::PERBZ_DT2]);
-         if(Parameters::ohmHallTerm < 2) {
+         if (Parameters::ohmHallTerm < 2 || sysBoundaryLayer == 1) {
             array[fs::dPERBxdyy] = 0.0;
             array[fs::dPERBzdyy] = 0.0;
          } else {
@@ -257,7 +257,7 @@ void calculateDerivatives(
          
          array[fs::dPERBxdz]  = limiter(left[cp::PERBX],cent[cp::PERBX],rght[cp::PERBX]);
          array[fs::dPERBydz]  = limiter(left[cp::PERBY],cent[cp::PERBY],rght[cp::PERBY]);
-         if(Parameters::ohmHallTerm < 2) {
+         if (Parameters::ohmHallTerm < 2 || sysBoundaryLayer == 1) {
             array[fs::dPERBxdzz] = 0.0;
             array[fs::dPERBydzz] = 0.0;
          } else {
@@ -282,7 +282,7 @@ void calculateDerivatives(
          
          array[fs::dPERBxdz]  = limiter(left[cp::PERBX_DT2],cent[cp::PERBX_DT2],rght[cp::PERBX_DT2]);
          array[fs::dPERBydz]  = limiter(left[cp::PERBY_DT2],cent[cp::PERBY_DT2],rght[cp::PERBY_DT2]);
-         if(Parameters::ohmHallTerm < 2) {
+         if (Parameters::ohmHallTerm < 2 || sysBoundaryLayer == 1) {
             array[fs::dPERBxdzz] = 0.0;
             array[fs::dPERBydzz] = 0.0;
          } else {
@@ -298,7 +298,7 @@ void calculateDerivatives(
       }
    }
    
-   if (Parameters::ohmHallTerm < 2) {
+   if (Parameters::ohmHallTerm < 2 || sysBoundaryLayer == 1) {
       array[fs::dPERBxdyz] = 0.0;
       array[fs::dPERBydxz] = 0.0;
       array[fs::dPERBzdxy] = 0.0;


### PR DESCRIPTION
Fix for #340 

At https://github.com/fmihpc/vlasiator/blob/master/vlasovsolver/cpu_acc_map.cpp#L309,  we divide an int with WID. The int can (legally) be negative, and in that case the result will be a very large integer since WID is uint. See https://stackoverflow.com/questions/32175191/output-of-dividing-int64-t-by-uint64-t for further discussion.

Seems safer to just make WID int, since we may have other similar uses in the code. Other similar parameters could potentially also be converted to int to be safe.
