### PR TITLE
Fix stupid single-character Makefile bug building without jemalloc an…

### DIFF
--- a/MAKE/Makefile.sisu_gcc
+++ b/MAKE/Makefile.sisu_gcc
@@ -40,7 +40,7 @@ CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 #                         errors that come up when using 
 #                         mpi.h in c++ on Cray
 
-CXXFLAGS = -DMPICH_IGNORE_CXX_SEEK
+CXXFLAGS += -DMPICH_IGNORE_CXX_SEEK
 
 FLAGS = 
 


### PR DESCRIPTION
…d papi.

This caused runs on sisu to run without those, and then crashing with unpredictable error messages once they inevitably run out of memory.