### PR TITLE
Proper gyration of negatively charged particles

### DIFF
--- a/MAKE/Makefile.marconi
+++ b/MAKE/Makefile.marconi
@@ -12,7 +12,6 @@
 
 #======== Vectorization ==========
 #Set vector backend type for vlasov solvers, sets precision and length. 
-#NOTE this has to have the same precision as the distribution function define (DISTRIBUTION_FP_PRECISION)
 #Options: 
 # AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
 # AVX512:   VEC8D_AGNER, VEC16F_AGNER

--- a/MAKE/Makefile.sisu_gcc
+++ b/MAKE/Makefile.sisu_gcc
@@ -3,7 +3,6 @@ LNK = CC
 
 #======== Vectorization ==========
 #Set vector backend type for vlasov solvers, sets precision and length. 
-#NOTE this has to have the same precision as the distribution function define (DISTRIBUTION_FP_PRECISION)
 #Options: 
 # AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
 # AVX512:   VEC8D_AGNER, VEC16F_AGNER

--- a/MAKE/Makefile.taito_gcc
+++ b/MAKE/Makefile.taito_gcc
@@ -3,7 +3,6 @@ LNK = mpiCC
 
 #======== Vectorization ==========
 #Set vector backend type for vlasov solvers, sets precision and length. 
-#NOTE this has to have the same precision as the distribution function define (DISTRIBUTION_FP_PRECISION)
 #Options: 
 # AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
 # AVX512:   VEC8D_AGNER, VEC16F_AGNER

--- a/projects/MultiPeak/MultiPeak.cpp
+++ b/projects/MultiPeak/MultiPeak.cpp
@@ -81,10 +81,6 @@ namespace projects {
    }
 
    void MultiPeak::getParameters(){
-      if(getObjectWrapper().particleSpecies.size() > 1) {
-         std::cerr << "The selected project does not support multiple particle populations! Aborting in " << __FILE__ << " line " << __LINE__ << std::endl;
-         abort();
-      }
 
       typedef Readparameters RP;
       Project::getParameters();
@@ -138,7 +134,7 @@ namespace projects {
       Real value = 0.0;
 
       for (uint i=0; i<sP.numberOfPeaks; ++i) {
-         value += (sP.rho[i] * sP.rhoPertAbsAmp[i] * rhoRnd)
+         value += (sP.rho[i] + sP.rhoPertAbsAmp[i] * rhoRnd)
                * pow(mass / (2.0 * M_PI * kb ), 1.5) * 1.0
                / sqrt(sP.Tx[i]*sP.Ty[i]*sP.Tz[i]) 
                * exp(- mass * (pow(vx - sP.Vx[i], 2.0) / (2.0 * kb * sP.Tx[i]) 

--- a/testpackage/small_test_definitions.sh
+++ b/testpackage/small_test_definitions.sh
@@ -36,55 +36,60 @@ comparison_vlsv[3]="fullf.0000001.vlsv"
 comparison_phiprof[3]="phiprof_0.txt"
 
 test_name[4]="acctest_4_helium"
-comparison_vlsv[3]="fullf.0000001.vlsv"
+comparison_vlsv[4]="fullf.0000001.vlsv"
 #only one process does anything -> in _1 phiprof here
-comparison_phiprof[3]="phiprof_1.txt"
+comparison_phiprof[4]="phiprof_1.txt"
+
+# Gyration test with protons and antiprotons
+test_name[5]="acctest_5_proton_antiproton"
+#only one process does anything -> in _1 phiprof here
+comparison_phiprof[5]="phiprof_1.txt"
 
 # Restart tests. Writing and reading
-test_name[5]="restart_write"
-comparison_vlsv[5]="restart.vlsv"
-comparison_phiprof[5]="phiprof_0.txt"
-test_name[6]="restart_read"
+test_name[6]="restart_write"
 comparison_vlsv[6]="restart.vlsv"
 comparison_phiprof[6]="phiprof_0.txt"
-
-#Very small ecliptic magnetosphere, no subcycling in ACC or FS
-test_name[7]="Magnetosphere_small"
-comparison_vlsv[7]="bulk.0000001.vlsv"
+test_name[7]="restart_read"
+comparison_vlsv[7]="restart.vlsv"
 comparison_phiprof[7]="phiprof_0.txt"
 
-#Very small polar magnetosphere, with subcycling in ACC or FS
-test_name[8]="Magnetosphere_polar_small"
+#Very small ecliptic magnetosphere, no subcycling in ACC or FS
+test_name[8]="Magnetosphere_small"
 comparison_vlsv[8]="bulk.0000001.vlsv"
 comparison_phiprof[8]="phiprof_0.txt"
 
-# Field solver test
-test_name[9]="test_fp_fsolver_only_3D"
-comparison_vlsv[9]="fullf.0000001.vlsv"
+#Very small polar magnetosphere, with subcycling in ACC or FS
+test_name[9]="Magnetosphere_polar_small"
+comparison_vlsv[9]="bulk.0000001.vlsv"
 comparison_phiprof[9]="phiprof_0.txt"
 
-# Field solver test w/ subcycles
-test_name[10]="test_fp_substeps"
+# Field solver test
+test_name[10]="test_fp_fsolver_only_3D"
 comparison_vlsv[10]="fullf.0000001.vlsv"
 comparison_phiprof[10]="phiprof_0.txt"
 
-# Flowthrough tests
-test_name[11]="Flowthrough_trans_periodic"
-comparison_vlsv[11]="bulk.0000001.vlsv"
+# Field solver test w/ subcycles
+test_name[11]="test_fp_substeps"
+comparison_vlsv[11]="fullf.0000001.vlsv"
 comparison_phiprof[11]="phiprof_0.txt"
 
-test_name[12]="Flowthrough_x_inflow_y_outflow"
+# Flowthrough tests
+test_name[12]="Flowthrough_trans_periodic"
 comparison_vlsv[12]="bulk.0000001.vlsv"
 comparison_phiprof[12]="phiprof_0.txt"
 
-test_name[13]="Flowthrough_x_inflow_y_outflow_acc"
+test_name[13]="Flowthrough_x_inflow_y_outflow"
 comparison_vlsv[13]="bulk.0000001.vlsv"
 comparison_phiprof[13]="phiprof_0.txt"
 
-# Self-consistent wave generation test
-test_name[14]="Selfgen_Waves_Periodic"
-comparison_vlsv[14]="fullf.0000001.vlsv"
+test_name[14]="Flowthrough_x_inflow_y_outflow_acc"
+comparison_vlsv[14]="bulk.0000001.vlsv"
 comparison_phiprof[14]="phiprof_0.txt"
+
+# Self-consistent wave generation test
+test_name[15]="Selfgen_Waves_Periodic"
+comparison_vlsv[15]="fullf.0000001.vlsv"
+comparison_phiprof[15]="phiprof_0.txt"
 
 
 # define here the variables you want to be tested

--- a/testpackage/tests/acctest_1_maxw_500k_30kms_1deg/acctest_1_maxw_500k_30kms_1deg.cfg
+++ b/testpackage/tests/acctest_1_maxw_500k_30kms_1deg/acctest_1_maxw_500k_30kms_1deg.cfg
@@ -112,17 +112,6 @@ periodic_y = yes
 periodic_z = yes
 
 [MultiPeak]
-n = 1
-Vx = 0.0
-Vy = 5e5
-Vz = 0.0
-Tx = 500000.0
-Ty = 500000.0
-Tz = 500000.0
-rho  = 2000000.0
-rhoPertAbsAmp = 0
-
-
 #magnitude of 1.82206867e-10 gives a period of 360s, useful for testing...
 Bx = 1.2e-10
 By = 0.8e-10
@@ -132,3 +121,14 @@ magXPertAbsAmp = 0
 magYPertAbsAmp = 0
 magZPertAbsAmp = 0
 nVelocitySamples = 4
+
+[proton_MultiPeak]
+n = 1
+Vx = 0.0
+Vy = 5e5
+Vz = 0.0
+Tx = 500000.0
+Ty = 500000.0
+Tz = 500000.0
+rho  = 2000000.0
+rhoPertAbsAmp = 0

--- a/testpackage/tests/acctest_2_maxw_500k_100k_20kms_10deg/acctest_2_maxw_500k_100k_20kms_10deg.cfg
+++ b/testpackage/tests/acctest_2_maxw_500k_100k_20kms_10deg/acctest_2_maxw_500k_100k_20kms_10deg.cfg
@@ -70,6 +70,16 @@ periodic_y = yes
 periodic_z = yes
 
 [MultiPeak]
+#magnitude of 1.82206867e-10 gives a period of 360s, useful for testing...
+Bx = 1.2e-10
+By = 0.8e-10
+Bz = 1.1135233442526334e-10
+magXPertAbsAmp = 0
+magYPertAbsAmp = 0
+magZPertAbsAmp = 0
+nVelocitySamples = 3
+
+[proton_MultiPeak]
 n = 2
 Vx = 0.0
 Vy = 5e5
@@ -89,11 +99,3 @@ Tz = 100000.0
 rho = 2000000
 rhoPertAbsAmp = 0
 
-#magnitude of 1.82206867e-10 gives a period of 360s, useful for testing...
-Bx = 1.2e-10
-By = 0.8e-10
-Bz = 1.1135233442526334e-10
-magXPertAbsAmp = 0
-magYPertAbsAmp = 0
-magZPertAbsAmp = 0
-nVelocitySamples = 3

--- a/testpackage/tests/acctest_5_proton_antiproton/acctest_5_proton_antiproton.cfg
+++ b/testpackage/tests/acctest_5_proton_antiproton/acctest_5_proton_antiproton.cfg
@@ -1,3 +1,4 @@
+# Gyration and charge sign test: protons and antiprotons should gyrate 1/4 circle in opposite directions
 dynamic_timestep = 0
 project = MultiPeak
 propagate_field = 0
@@ -5,12 +6,13 @@ propagate_vlasov_acceleration = 1
 propagate_vlasov_translation = 0
 
 ParticlePopulations = proton
+ParticlePopulations = antiproton
 
 [io]
-diagnostic_write_interval = 1
+diagnostic_write_interval = 10
 write_initial_state = 0
 
-system_write_t_interval = 3600
+system_write_t_interval = 10
 system_write_file_name = fullf
 system_write_distribution_stride = 1
 system_write_distribution_xline_stride = 0
@@ -18,20 +20,21 @@ system_write_distribution_yline_stride = 0
 system_write_distribution_zline_stride = 0
 
 [variables]
-output = Rhom
 output = B
-output = Pressure
-output = populations_V
 output = E
-output = MPIrank
+output = Rhom
+output = Rhoq
+output = populations_Rho
+output = V
+output = populations_V
+output = MaxVdt
+output = MaxRdt
+output = populations_MaxVdt
+output = populations_MaxRdt
 output = populations_Blocks
-#output = VelocitySubSteps  
+output = populations_accSubcycles
 
 diagnostic = populations_Blocks
-#diagnostic = Pressure
-#diagnostic = populations_Rho
-#diagnostic = populations_RhoLossAdjust
-#diagnostic = populations_RhoLossVelBoundary
 
 [gridbuilder]
 x_length = 1
@@ -43,13 +46,17 @@ y_min = 0.0
 y_max = 1.0e6
 z_min = 0
 z_max = 1.0e6
-t_max = 3600
+t_max = 90
 dt = 10.0
 
 [proton_properties]
 mass = 1
 mass_units = PROTON
 charge = 1
+[antiproton_properties]
+mass = 1
+mass_units = PROTON
+charge = -1
 
 [proton_vspace]
 vx_min = -2.0e6
@@ -61,17 +68,26 @@ vz_max = +2.0e6
 vx_length = 50
 vy_length = 50
 vz_length = 50
+[antiproton_vspace]
+vx_min = -2.0e6
+vx_max = +2.0e6
+vy_min = -2.0e6
+vy_max = +2.0e6
+vz_min = -2.0e6
+vz_max = +2.0e6
+vx_length = 50
+vy_length = 50
+vz_length = 50
+
 [proton_sparse]
+minValue = 1.0e-16
+[antiproton_sparse]
 minValue = 1.0e-16
 
 [boundaries]
 periodic_x = yes
 periodic_y = yes
 periodic_z = yes
-
-[vlasovsolver]
-maxSlAccelerationRotation = 1
-maxSlAccelerationSubcycles = 20
 
 [MultiPeak]
 #magnitude of 1.82206867e-10 gives a period of 360s, useful for testing...
@@ -103,3 +119,22 @@ Tz = 100000.0
 rho = 2000000
 rhoPertAbsAmp = 0
 
+[antiproton_MultiPeak]
+n = 2
+Vx = 0.0
+Vy = 5e5
+Vz = 0.0
+Tx = 500000.0
+Ty = 500000.0
+Tz = 500000.0
+rho  = 2000000.0
+rhoPertAbsAmp = 0
+
+Vx = 0.0
+Vy = -5e5
+Vz = 0.0
+Tx = 100000.0
+Ty = 100000.0
+Tz = 100000.0
+rho = 2000000
+rhoPertAbsAmp = 0

--- a/testpackage/tests/transtest_2_maxw_500k_100k_20kms_20x20/transtest_2_maxw_500k_100k_20kms_20x20.cfg
+++ b/testpackage/tests/transtest_2_maxw_500k_100k_20kms_20x20/transtest_2_maxw_500k_100k_20kms_20x20.cfg
@@ -70,6 +70,17 @@ diagnostic = populations_Blocks
 #diagnostic = populations_RhoLossVelBoundary
 
 [MultiPeak]
+#magnitude of 1.82206867e-10 gives a period of 360s, useful for testing...
+Bx = 1.2e-10
+By = 0.8e-10
+Bz = 1.1135233442526334e-10
+magXPertAbsAmp = 0
+magYPertAbsAmp = 0
+magZPertAbsAmp = 0
+
+nVelocitySamples = 3
+
+[proton_MultiPeak]
 n = 1
 Vx = 5e5
 Vy = 5e5
@@ -80,12 +91,3 @@ Tz = 500000.0
 rho  = 1000000.0
 rhoPertAbsAmp = 10000
 
-#magnitude of 1.82206867e-10 gives a period of 360s, useful for testing...
-Bx = 1.2e-10
-By = 0.8e-10
-Bz = 1.1135233442526334e-10
-magXPertAbsAmp = 0
-magYPertAbsAmp = 0
-magZPertAbsAmp = 0
-
-nVelocitySamples = 3

--- a/vlasovsolver/cpu_acc_transform.cpp
+++ b/vlasovsolver/cpu_acc_transform.cpp
@@ -101,9 +101,9 @@ Eigen::Transform<Real,3,Eigen::Affine> compute_acceleration_transformation(
       unit_B(0,0) = 0; unit_B(1,0) = 0; unit_B(2,0) = 1;
    }
 
-   const Real gyro_period 
-     = 2 * M_PI * getObjectWrapper().particleSpecies[popID].mass
-     / (getObjectWrapper().particleSpecies[popID].charge * B_mag);
+   const Real gyro_period
+     = fabs(2 * M_PI * getObjectWrapper().particleSpecies[popID].mass
+     / (getObjectWrapper().particleSpecies[popID].charge * B_mag));
 
    // scale rho for hall term, if user requests
    const Real EPSILON = 1e10 * numeric_limits<Real>::min();
@@ -133,11 +133,11 @@ Eigen::Transform<Real,3,Eigen::Affine> compute_acceleration_transformation(
 
 
    unsigned int bulk_velocity_substeps; // in this many substeps we iterate forward bulk velocity when the complete transformation is computed (0.1 deg per substep).
-   bulk_velocity_substeps = fabs(dt) / (fabs(gyro_period)*(0.1/360.0)); 
+   bulk_velocity_substeps = fabs(dt) / (gyro_period*(0.1/360.0));
    if (bulk_velocity_substeps < 1) bulk_velocity_substeps=1;
 
-   // note, we assume q is positive (pretty good assumption though)
-   const Real substeps_radians = -(2.0*M_PI*dt/fabs(gyro_period))/bulk_velocity_substeps; // how many radians each substep is.
+   const Real substeps_radians = -(2.0*M_PI*dt/gyro_period)/bulk_velocity_substeps
+      * (getObjectWrapper().particleSpecies[popID].charge > 0)?(1.):(-1.); // how many radians each substep is.
    const Real substeps_dt=dt/bulk_velocity_substeps; /*!< how many s each substep is*/
    Eigen::Matrix<Real,3,1> EgradPe(
       spatial_cell->parameters[CellParams::EXGRADPE],
@@ -153,8 +153,6 @@ Eigen::Transform<Real,3,Eigen::Affine> compute_acceleration_transformation(
       rotation_pivot[0]-= hallPrefactor*(dBZdy - dBYdz);
       rotation_pivot[1]-= hallPrefactor*(dBXdz - dBZdx);
       rotation_pivot[2]-= hallPrefactor*(dBYdx - dBXdy);
-
-#warning Is particle charge sign taken correctly into account here?
       
       // add to transform matrix the small rotation around  pivot
       // when added like this, and not using *= operator, the transformations
@@ -165,8 +163,7 @@ Eigen::Transform<Real,3,Eigen::Affine> compute_acceleration_transformation(
 
       // Electron pressure gradient term
       if(Parameters::ohmGradPeTerm > 0) {
-         #warning Use actual population mass and charge for multipop here
-         total_transform=Translation<Real,3>( (fabs(physicalconstants::CHARGE)/physicalconstants::MASS_PROTON) * EgradPe * substeps_dt) * total_transform;
+         total_transform=Translation<Real,3>( (fabs(getObjectWrapper().particleSpecies[popID].charge)/getObjectWrapper().particleSpecies[popID].mass) * EgradPe * substeps_dt) * total_transform;
       }
    }
 

--- a/vlasovsolver/cpu_acc_transform.cpp
+++ b/vlasovsolver/cpu_acc_transform.cpp
@@ -102,8 +102,8 @@ Eigen::Transform<Real,3,Eigen::Affine> compute_acceleration_transformation(
    }
 
    const Real gyro_period
-     = fabs(2 * M_PI * getObjectWrapper().particleSpecies[popID].mass
-     / (getObjectWrapper().particleSpecies[popID].charge * B_mag));
+     = 2 * M_PI * getObjectWrapper().particleSpecies[popID].mass
+     / (getObjectWrapper().particleSpecies[popID].charge * B_mag);
 
    // scale rho for hall term, if user requests
    const Real EPSILON = 1e10 * numeric_limits<Real>::min();
@@ -133,11 +133,10 @@ Eigen::Transform<Real,3,Eigen::Affine> compute_acceleration_transformation(
 
 
    unsigned int bulk_velocity_substeps; // in this many substeps we iterate forward bulk velocity when the complete transformation is computed (0.1 deg per substep).
-   bulk_velocity_substeps = fabs(dt) / (gyro_period*(0.1/360.0));
+   bulk_velocity_substeps = fabs(dt) / fabs(gyro_period*(0.1/360.0));
    if (bulk_velocity_substeps < 1) bulk_velocity_substeps=1;
 
-   const Real substeps_radians = -(2.0*M_PI*dt/gyro_period)/bulk_velocity_substeps
-      * (getObjectWrapper().particleSpecies[popID].charge > 0)?(1.):(-1.); // how many radians each substep is.
+   const Real substeps_radians = -(2.0*M_PI*dt/gyro_period)/bulk_velocity_substeps; // how many radians each substep is.
    const Real substeps_dt=dt/bulk_velocity_substeps; /*!< how many s each substep is*/
    Eigen::Matrix<Real,3,1> EgradPe(
       spatial_cell->parameters[CellParams::EXGRADPE],


### PR DESCRIPTION
The velocity space update matrix calculation was effectively using abs(charge), so all particle populations had right-hand gyration, regardless of their actual charge sign.

This pull request also adds a multipop gyration test (proton/antiproton) to the testpackage and fixes the MultiPeak project so that it actually works properly.