### PR TITLE
Add basic function instrumentation support, for run-time tracing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ COMPFLAGS += -DNDEBUG
 # CXXFLAGS += -DDEBUG_SOLVERS
 # CXXFLAGS += -DDEBUG_IONOSPHERE
 
+#For really coarse run-time tracing, compile with function instrumentation in some (high-level) source files:
+#LDFLAGS += -rdynamic
+#INSTRUMENTATION = -finstrument-functions
+
 #Set order of semilag solver in velocity space acceleration
 #  ACC_SEMILAG_PLM 	2nd order	
 #  ACC_SEMILAG_PPM	3rd order 
@@ -192,7 +196,7 @@ OBJS = 	version.o memoryallocation.o backgroundfield.o quadr.o dipole.o linedipo
 	IPShock.o object_wrapper.o\
 	verificationLarmor.o Shocktest.o grid.o ioread.o iowrite.o vlasiator.o logger.o\
 	common.o parameters.o readparameters.o spatial_cell.o mesh_data_container.o\
-	vlasovmover.o $(FIELDSOLVER).o fs_common.o fs_limiters.o gridGlue.o
+	vlasovmover.o $(FIELDSOLVER).o fs_common.o fs_limiters.o gridGlue.o instrumented_functions.o
 
 # Add Vlasov solver objects (depend on mesh: AMR or non-AMR)
 ifeq ($(MESH),AMR)
@@ -461,7 +465,7 @@ gridGlue.o: ${DEPS_FSOLVER} fieldsolver/gridGlue.hpp fieldsolver/gridGlue.cpp
 	${CMP} ${CXXFLAGS} ${FLAGS} -c fieldsolver/gridGlue.cpp ${INC_BOOST} ${INC_FSGRID} ${INC_DCCRG} ${INC_PROFILE} ${INC_ZOLTAN}
 
 vlasiator.o: ${DEPS_COMMON} readparameters.h parameters.h ${DEPS_PROJECTS} grid.h vlasovmover.h ${DEPS_CELL} vlasiator.cpp iowrite.h fieldsolver/gridGlue.hpp
-	${CMP} ${CXXFLAGS} ${FLAG_OPENMP} ${FLAGS} -c vlasiator.cpp ${INC_MPI} ${INC_DCCRG} ${INC_FSGRID} ${INC_BOOST} ${INC_EIGEN} ${INC_ZOLTAN} ${INC_PROFILE} ${INC_VLSV}
+	${CMP} ${CXXFLAGS} ${FLAG_OPENMP} ${FLAGS} -c vlasiator.cpp ${INC_MPI} ${INC_DCCRG} ${INC_FSGRID} ${INC_BOOST} ${INC_EIGEN} ${INC_ZOLTAN} ${INC_PROFILE} ${INC_VLSV} ${INSTRUMENTATION}
 
 grid.o:  ${DEPS_COMMON} parameters.h ${DEPS_PROJECTS} ${DEPS_CELL} grid.cpp grid.h  sysboundary/sysboundary.h
 	${CMP} ${CXXFLAGS} ${FLAG_OPENMP} ${FLAGS} -c grid.cpp ${INC_MPI} ${INC_DCCRG} ${INC_FSGRID} ${INC_BOOST} ${INC_EIGEN} ${INC_ZOLTAN} ${INC_PROFILE} ${INC_VLSV} ${INC_PAPI}
@@ -492,6 +496,9 @@ vlscommon.o:  $(DEPS_COMMON)  vlscommon.h vlscommon.cpp
 
 object_wrapper.o:  $(DEPS_COMMON)  object_wrapper.h object_wrapper.cpp
 	${CMP} ${CXXFLAGS} ${FLAGS} -c object_wrapper.cpp ${INC_DCCRG} ${INC_ZOLTAN} ${INC_BOOST}
+
+instrumented_functions.o: instrumented_functions.cpp
+	${CMP} ${CXXFLAGS} ${FLAGS} -c instrumented_functions.cpp
 
 # Make executable
 vlasiator: $(OBJS) $(OBJS_POISSON) $(OBJS_FSOLVER)

--- a/instrumented_functions.cpp
+++ b/instrumented_functions.cpp
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Vlasiator.
+ * Copyright 2010-2016 Finnish Meteorological Institute
+ *
+ * For details of usage, see the COPYING file and read the "Rules of the Road"
+ * at http://www.physics.helsinki.fi/vlasiator/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/*-------------------------------------------------------------------------
+  Function call tracing hooks,
+  based on etrace by N. Devillard and V. Chudnovsky.
+
+  To activate this feature, compile with the -finstrument-functions flag.
+  --------------------------------------------------------------------------*/
+
+#if (__GNUC__>2) || ((__GNUC__ == 2) && (__GNUC_MINOR__ > 95))
+
+/*---------------------------------------------------------------------------
+                           Includes
+ ---------------------------------------------------------------------------*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <execinfo.h>
+
+/*---------------------------------------------------------------------------
+                           Defines
+ ---------------------------------------------------------------------------*/
+
+#define FUNCTION_ENTRY   "enter"
+#define FUNCTION_EXIT    "exit"
+
+/*---------------------------------------------------------------------------
+                     Function codes
+ ---------------------------------------------------------------------------*/
+
+static bool doOutput=false; 
+
+void instrumentation_init(bool doOutputOnThisRank) {
+   doOutput = doOutputOnThisRank;
+}
+
+extern "C" {
+   /** Function called by every function event */
+   void __attribute__((__no_instrument_function__)) gnu_ptrace(char * what, void * p) {
+      char** fun_name = backtrace_symbols(&p,1);
+      fprintf(stderr, "TRACE %ld> %s %s\n", (long)getpid(), what, fun_name[0]);
+      free(fun_name);
+      return ;
+   }
+
+   /** According to gcc documentation: called upon function entry */
+   void __attribute__((__no_instrument_function__)) __cyg_profile_func_enter(void *this_fn, void *call_site) {
+      if(doOutput) {
+         gnu_ptrace(FUNCTION_ENTRY, this_fn);
+         (void)call_site;
+      }
+   }
+
+   /** According to gcc documentation: called upon function exit */
+   void __attribute__((__no_instrument_function__)) __cyg_profile_func_exit(void *this_fn, void *call_site) {
+      if(doOutput) {
+         gnu_ptrace(FUNCTION_EXIT, this_fn);
+         (void)call_site;
+      }
+   }
+}
+
+#else
+#warning No instrumented function support!
+#endif

--- a/instrumented_functions.h
+++ b/instrumented_functions.h
@@ -1,0 +1,7 @@
+#pragma once
+
+/** Enable function instrumentation for run-time tracing
+ * @param doOutputOnThisRank Function names will only be printed if this parameter is set to true.
+ */
+void instrumentation_init(bool doOutputOnThisRank);
+

--- a/object_wrapper.h
+++ b/object_wrapper.h
@@ -53,6 +53,6 @@ struct ObjectWrapper {
 };
 
 // Currently defined in vlasiator.cpp
-ObjectWrapper& getObjectWrapper();
+ObjectWrapper& __attribute__((__no_instrument_function__)) getObjectWrapper();
 
 #endif

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -53,6 +53,7 @@
 
 #include "object_wrapper.h"
 #include "fieldsolver/gridGlue.hpp"
+#include "instrumented_functions.h"
 
 #ifdef CATCH_FPE
 #include <fenv.h>
@@ -224,7 +225,7 @@ bool computeNewTimeStep(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
    return true;
 }
 
-ObjectWrapper& getObjectWrapper() {
+ObjectWrapper& __attribute__((__no_instrument_function__)) getObjectWrapper() {
    return objectWrapper;
 }
 
@@ -269,6 +270,8 @@ int main(int argn,char* args[]) {
    
    MPI_Comm comm = MPI_COMM_WORLD;
    MPI_Comm_rank(comm,&myRank);
+
+   instrumentation_init(myRank == MASTER_RANK);
    SysBoundary sysBoundaries;
    bool isSysBoundaryCondDynamic;
    


### PR DESCRIPTION
This allows, for example, to observe the functions called from
vlasiator.cpp without the need to have a debugger attached, and limited
to the master rank. As such, it might be used as a poor man's "debugging at scale".

We're currently testing this for debugging BFA restart failures on marconi, and will then decide whether it is useful to merge or not.