### PR TITLE
Fix single-byte bug that crashes if a velocity space is completely full.

### DIFF
--- a/velocity_mesh_old.h
+++ b/velocity_mesh_old.h
@@ -604,7 +604,7 @@ namespace vmesh {
 
    template<typename GID,typename LID> inline
    bool VelocityMesh<GID,LID>::push_back(const std::vector<GID>& blocks) {
-      if (size()+blocks.size() >= meshParameters[meshID].max_velocity_blocks) {
+      if (size()+blocks.size() > meshParameters[meshID].max_velocity_blocks) {
          std::cerr << "vmesh: too many blocks, current size is " << size();
          std::cerr << ", adding " << blocks.size() << " blocks";
          std::cerr << ", max is " << meshParameters[meshID].max_velocity_blocks << std::endl;


### PR DESCRIPTION
Thanks to Arto for immediately finding it.
Thiago tested this, it fixes the crash.