### PR TITLE
Add a BeforeSetCell hook to Project, for complicated data juggling.

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -195,6 +195,9 @@ void initializeGrid(
       // Each initialization has to be independent to avoid threading problems 
       const vector<CellID>& cells = getLocalCells();
 
+      // Allow the project to set up data structures for it's setCell calls
+      project.setupBeforeSetCell(cells);
+
       #pragma omp parallel for schedule(dynamic)
       for (size_t i=0; i<cells.size(); ++i) {
          SpatialCell* cell = mpiGrid[cells[i]];

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -195,6 +195,11 @@ namespace projects {
       const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid
    ) const { }
 
+   void Project::setupBeforeSetCell(const std::vector<CellID>& cells) {
+      // Dummy implementation.
+      return;
+   }
+
    void Project::setCell(SpatialCell* cell) {
       // Set up cell parameters:
       calcCellParameters(cell,0.0);

--- a/projects/project.h
+++ b/projects/project.h
@@ -58,6 +58,13 @@ namespace projects {
        * @param cell Pointer to the spatial cell.*/
       virtual void setCellBackgroundField(spatial_cell::SpatialCell* cell) const;
       
+      /*! Setup data structures for subsequent setCell calls.
+       * This will most likely be empty for most projects, except for some advanced
+       * data juggling ones (like restart from a subset of a larger run)
+       * \param cells Local cellIDs of this task.
+       */
+      virtual void setupBeforeSetCell(const std::vector<CellID>& cells);
+
       /*!\brief Set the perturbed fields and distribution of a cell according to the default simulation settings.
        * This is used for the NOT_SYSBOUNDARY cells and some other system boundary conditions (e.g. Outflow).
        * NOTE: This function is called inside parallel region so it must be declared as const.


### PR DESCRIPTION
Specifically, this is needed for a mechanism to restart a small
simulation as a subset of a larger one, as Thiago is implementing now.