### PR TITLE
Added some source code comments to slightly confusing data definitions.

### DIFF
--- a/common.h
+++ b/common.h
@@ -116,7 +116,11 @@ namespace BlockParams {
 /*! A namespace for storing indices into an array which contains the 
  * physical parameters of each spatial cell. Do not change the order 
  * of variables unless you know what you are doing - MPI transfers in 
- * field solver are optimised for this particular ordering.
+ * field solver are relying on this particular ordering, even though the actual
+ * fsgrid data layouts might be slightly different (see below).
+ *
+ * Note: RHOM and RHOQ are somewhat out-of-order for backwards compatibility
+ * with pre-multipop tools.
  */
 namespace CellParams {
    enum {
@@ -179,12 +183,12 @@ namespace CellParams {
       VX_R,   /*!< VX after propagation in ordinary space*/
       VY_R,   /*!< VY after propagation in ordinary space*/
       VZ_R,   /*!< VZ after propagation in ordinary space*/
-      RHOQ_R,     /*!< RHO after propagation in ordinary space*/
-      RHOM_V,     /*!< RHO after propagation in velocity space*/
+      RHOQ_R,     /*!< RHOQ after propagation in ordinary space*/
+      RHOM_V,     /*!< RHOM after propagation in velocity space*/
       VX_V,   /*!< VX after propagation in velocity space*/
       VY_V,   /*!< VY after propagation in velocity space*/
       VZ_V,   /*!< VZ after propagation in velocity space*/
-      RHOQ_V,     /*!< RHO after propagation in velocity space*/
+      RHOQ_V,     /*!< RHOQ after propagation in velocity space*/
       P_11,     /*!< Pressure P_xx component, computed by Vlasov propagator. */
       P_22,     /*!< Pressure P_yy component, computed by Vlasov propagator. */
       P_33,     /*!< Pressure P_zz component, computed by Vlasov propagator. */
@@ -326,6 +330,9 @@ namespace bvolderivatives {
 
 /*! Namespace containing enums and structs for the various field solver grid instances
  * 
+ * Note that in some of these, the order of members differs from the cell
+ * parameter fields (see above). So double-check before blindly copying data
+ * back and forth.
  */
 namespace fsgrids {
    enum bfield {
@@ -366,8 +373,8 @@ namespace fsgrids {
    };
    
    enum moments {
-      RHOM, /*!< Mass density. Calculated by Vlasov propagator, used to propagate fields.*/
-      RHOQ, /*!< Mass density. Calculated by Vlasov propagator, used to propagate fields.*/
+      RHOM, /*!< Overall mass density. Calculated by Vlasov propagator, used to propagate fields.*/
+      RHOQ, /*!< Overall charge density. Calculated by Vlasov propagator, used to propagate fields.*/
       VX,   /*!< Vx. Calculated by Vlasov propagator, used to propagate fields.*/
       VY,   /*!< Vy. Calculated by Vlasov propagator, used to propagate fields.*/
       VZ,   /*!< Vz. Calculated by Vlasov propagator, used to propagate fields.*/

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -227,6 +227,7 @@ bool readNBlocks(vlsv::ParallelReader& file,const std::string& meshName,
 
    // Read mesh bounding box to all processes, the info in bbox contains 
    // the number of spatial cells in the mesh.
+   // (This is *not* the physical coordinate bounding box.)
    uint64_t bbox[6];
    uint64_t* bbox_ptr = bbox;
    list<pair<string,string> > attribs;

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -164,6 +164,9 @@ bool writeVelocityDistributionData(const uint popID,Writer& vlsvWriter,
    if (success == false) logFile << "(MAIN) writeGrid: ERROR failed to write CELLSWITHBLOCKS to file!" << endl << writeVerbose;
 
    // Write (partial) velocity mesh data
+   // The mesh bounding box gives the outer extent of the available velocity space
+   // in blocks and cells. Note that this is not the physical extent of that
+   // space, but a purely numerical bounding box.
    uint64_t bbox[6];
    const size_t meshID = getObjectWrapper().particleSpecies[popID].velocityMesh;
    bbox[0] = getObjectWrapper().velocityMeshes[meshID].gridLength[0];
@@ -736,6 +739,7 @@ bool writeBoundingBoxNodeCoordinates ( Writer & vlsvWriter,
 
 
 /*! Function for writing the bounding box. This writes only if the process running it is the master rank. This array contains info on the boundaries of the grid so for example the number of cells in x, y, z direction.
+ * Note that this is *not* the physical coordinate bounding box, but the computational domain bounding box, measured in blocks and cells.
  \param vlsvWriter Some vlsv writer with a file open
  \param meshName Name of the mesh to write ("SpatialGrid" is used in writeGrid and it should be the default)
  \param masterRank The master process' id. Vlasiator uses 0 as the master process id, so by default should be 0


### PR DESCRIPTION
Specifically, clarified that MESH_BBOXes are numerical bounding boxes
measured in cells, not physical dimensions, and added some clarifying
comments to the different orderings of cell parameters vs. fsgrid field
members.