### PR TITLE
Spatial cell update

### DIFF
--- a/MAKE/Makefile.appa
+++ b/MAKE/Makefile.appa
@@ -89,8 +89,8 @@ LIB_PAPI = -L$(LIBRARY_PREFIX)/papi/lib -lpapi
 
 INC_EIGEN = -I$(LIBRARY_PREFIX)/eigen/
 INC_DCCRG = -I$(LIBRARY_PREFIX)/dccrg/
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass
-
+INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass/
+INC_FSGRID = -I$(LIBRARY_PREFIX)/fsgrid/
 
 
 

--- a/MAKE/Makefile.appa
+++ b/MAKE/Makefile.appa
@@ -1,0 +1,96 @@
+# -*- mode: makefile -*-
+CMP = mpic++
+LNK = mpic++
+
+#======== Vectorization ==========
+#Set vector backend type for vlasov solvers, sets precision and length. 
+#NOTE this has to have the same precision as the distribution function define (DISTRIBUTION_FP_PRECISION)
+#Options: 
+# AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
+# AVX512:   VEC8D_AGNER, VEC16F_AGNER
+# Fallback: VEC4D_FALLBACK, VEC4F_FALLBACK, VEC8F_FALLBACK
+
+ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
+#Single-precision        
+	VECTORCLASS = VEC8F_AGNER
+else
+#Double-precision
+	VECTORCLASS = VEC4D_AGNER
+endif
+
+#======== PAPI ==========
+#Add PAPI_MEM define to use papi to report memory consumption?
+CXXFLAGS +=  -DPAPI_MEM
+
+
+#======== Allocator =========
+#Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
+#Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
+CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+
+
+#======= Compiler and compilation flags =========
+# NOTES on compiler flags:
+# CXXFLAGS is for compiler flags, they are always used
+# MATHFLAGS are for special math etc. flags, these are only applied on solver functions
+# LDFLAGS flags for linker
+
+#-DNO_WRITE_AT_ALL:  Define to disable write at all to 
+#                    avoid memleak (much slower IO)
+#-DMPICH_IGNORE_CXX_SEEK: Ignores some multiple definition 
+#                         errors that come up when using 
+#                         mpi.h in c++ on Cray
+
+CXXFLAGS += -DMPICH_IGNORE_CXX_SEEK
+
+FLAGS = 
+
+#GNU flags:
+CC_BRAND = gcc
+CC_BRAND_VERSION = 5.4.0
+CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++11 -W -Wall -Wno-unused -fabi-version=0 -mavx2 
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++0x -fabi-version=0  -mavx
+
+MATHFLAGS = -ffast-math
+LDFLAGS =
+LIB_MPI = -lgomp
+
+# BOOST_VERSION = current trilinos version
+# ZOLTAN_VERSION = current trilinos verson
+
+#======== Libraries ===========
+
+MPT_VERSION = 7.2.6
+JEMALLOC_VERSION = 5.0.1
+LIBRARY_PREFIX = /home/tkoskela/lib
+
+
+#compiled libraries
+INC_BOOST = -I$/usr/include/boost
+LIB_BOOST = -L$/usr/lib/x86_64-linux-gnu -lboost_program_options
+
+INC_ZOLTAN = -I$(LIBRARY_PREFIX)/zoltan/Zoltan_v3.83/build/include
+#LIB_ZOLTAN = -I$(LIBRARY_PREFIX)/zoltan/Zoltan_v3.83/build/lib -lzoltan
+LIB_ZOLTAN = /home/tkoskela/lib/zoltan/Zoltan_v3.83/build/lib/libzoltan.a
+
+INC_JEMALLOC = -I$(LIBRARY_PREFIX)/jemalloc/include
+LIB_JEMALLOC = -L$(LIBRARY_PREFIX)/jemalloc/lib -ljemalloc
+
+INC_VLSV = -I$(LIBRARY_PREFIX)/vlsv
+LIB_VLSV = -L$(LIBRARY_PREFIX)/vlsv -lvlsv
+
+INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/phiprof-2.0-beta/include
+LIB_PROFILE = -L$(LIBRARY_PREFIX)/phiprof/phiprof-2.0-beta/lib -lphiprof
+
+INC_PAPI = -I$(LIBRARY_PREFIX)/papi/include
+LIB_PAPI = -L$(LIBRARY_PREFIX)/papi/lib -lpapi
+
+#header libraries
+
+INC_EIGEN = -I$(LIBRARY_PREFIX)/eigen/
+INC_DCCRG = -I$(LIBRARY_PREFIX)/dccrg/
+INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass
+
+
+
+

--- a/grid.cpp
+++ b/grid.cpp
@@ -125,14 +125,14 @@ void initializeGrid(
    // );
 
    mpiGrid.set_initial_length(grid_length)
-      .initialize(comm)
       .set_load_balancing_method(&P::loadBalanceAlgorithm[0])
       .set_neighborhood_length(neighborhood_size)
       .set_maximum_refinement_level(0)
-      .set_geometry(geom_params)
       .set_periodic(sysBoundaries.isBoundaryPeriodic(0),
                     sysBoundaries.isBoundaryPeriodic(1),
-                    sysBoundaries.isBoundaryPeriodic(2));
+                    sysBoundaries.isBoundaryPeriodic(2))
+      .initialize(comm)
+      .set_geometry(geom_params);
    
    // Init velocity mesh on all cells
    initVelocityGridGeometry(mpiGrid);   

--- a/grid.cpp
+++ b/grid.cpp
@@ -113,18 +113,26 @@ void initializeGrid(
    geom_params.level_0_cell_length[1] = P::dy_ini;
    geom_params.level_0_cell_length[2] = P::dz_ini;
    
-   mpiGrid.initialize(
-      grid_length,
-      comm,
-      &P::loadBalanceAlgorithm[0],
-      neighborhood_size, // neighborhood size
-      0, // maximum refinement level
-      sysBoundaries.isBoundaryPeriodic(0),
-      sysBoundaries.isBoundaryPeriodic(1),
-      sysBoundaries.isBoundaryPeriodic(2)
-   );
-   
-   mpiGrid.set_geometry(geom_params);
+   // mpiGrid.initialize(
+   //    grid_length,
+   //    comm,
+   //    &P::loadBalanceAlgorithm[0],
+   //    neighborhood_size, // neighborhood size
+   //    0, // maximum refinement level
+   //    sysBoundaries.isBoundaryPeriodic(0),
+   //    sysBoundaries.isBoundaryPeriodic(1),
+   //    sysBoundaries.isBoundaryPeriodic(2)
+   // );
+
+   mpiGrid.set_initial_length(grid_length)
+      .initialize(comm)
+      .set_load_balancing_method(&P::loadBalanceAlgorithm[0])
+      .set_neighborhood_length(neighborhood_size)
+      .set_maximum_refinement_level(0)
+      .set_geometry(geom_params)
+      .set_periodic(sysBoundaries.isBoundaryPeriodic(0),
+                    sysBoundaries.isBoundaryPeriodic(1),
+                    sysBoundaries.isBoundaryPeriodic(2));
    
    // Init velocity mesh on all cells
    initVelocityGridGeometry(mpiGrid);   
@@ -496,14 +504,15 @@ bool adjustVelocityBlocks(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& m
       SpatialCell* cell = mpiGrid[cell_id];
       
       // gather spatial neighbor list and create vector with pointers to neighbor spatial cells
-      const vector<CellID>* neighbors = mpiGrid.get_neighbors_of(cell_id, NEAREST_NEIGHBORHOOD_ID);
+      const auto* neighbors = mpiGrid.get_neighbors_of(cell_id, NEAREST_NEIGHBORHOOD_ID);
       vector<SpatialCell*> neighbor_ptrs;
       neighbor_ptrs.reserve(neighbors->size());
-      for (vector<CellID>::const_iterator neighbor_id = neighbors->begin(); neighbor_id != neighbors->end(); ++neighbor_id) {
-         if (*neighbor_id == 0 || *neighbor_id == cell_id) {
+      for ( pair<CellID, array<int,4>> nbrPair : *neighbors) {
+         CellID neighbor_id = nbrPair.first;
+         if (neighbor_id == 0 || neighbor_id == cell_id) {
             continue;
          }
-         neighbor_ptrs.push_back(mpiGrid[*neighbor_id]);
+         neighbor_ptrs.push_back(mpiGrid[neighbor_id]);
       }
       if (getObjectWrapper().particleSpecies[popID].sparse_conserve_mass) {
          for (size_t i=0; i<cell->get_number_of_velocity_blocks(popID)*WID3; ++i) {
@@ -931,11 +940,14 @@ bool validateMesh(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,c
          SpatialCell* cell = mpiGrid[cells[c]];
             
          // Get all spatial neighbors
-         const vector<CellID>* neighbors = mpiGrid.get_neighbors_of(cells[c],NEAREST_NEIGHBORHOOD_ID);
+         //const vector<CellID>* neighbors = mpiGrid.get_neighbors_of(cells[c],NEAREST_NEIGHBORHOOD_ID);
+         const auto* neighbors = mpiGrid.get_neighbors_of(cells[c], NEAREST_NEIGHBORHOOD_ID);
                
          // Iterate over all spatial neighbors
-         for (size_t n=0; n<neighbors->size(); ++n) {
-            CellID nbrCellID = (*neighbors)[n];
+         // for (size_t n=0; n<neighbors->size(); ++n) {
+         for (pair<CellID,array<int,4> > nbrPair : *neighbors) {
+            // CellID nbrCellID = (*neighbors)[n];
+            CellID nbrCellID = nbrPair.first;
             const SpatialCell* nbr = mpiGrid[nbrCellID];
                   
             // Iterate over all blocks in the spatial neighbor, 

--- a/poisson_solver/poisson_solver.cpp
+++ b/poisson_solver/poisson_solver.cpp
@@ -78,7 +78,7 @@ namespace poisson {
 
       // Fetch pointers
       for (size_t c=0; c<cells.size(); ++c) {
-	 Poisson::localCellParams[c] = mpiGrid[cells[c]]->parameters;
+	 Poisson::localCellParams[c] = mpiGrid[cells[c]]->parameters.data();
       }
    }
 

--- a/poisson_solver/poisson_solver_cg.cpp
+++ b/poisson_solver/poisson_solver_cg.cpp
@@ -186,7 +186,7 @@ namespace poisson {
          CellCache3D<cgvar::SIZE> cache;
          cache.cellID = cells[c];
          cache.cell = mpiGrid[cells[c]];
-         cache[0]   = mpiGrid[cells[c]]->parameters;
+         cache[0]   = mpiGrid[cells[c]]->parameters.data();
 
          #ifdef DEBUG_POISSON_CG
          if (cache.cell == NULL) {
@@ -205,8 +205,8 @@ namespace poisson {
             case sysboundarytype::NOT_SYSBOUNDARY:
                // Fetch pointers to this cell's (cell) parameters array, 
                // and pointers to +/- xyz face neighbors' arrays               
-               indices[0] -= 1; cache[1] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-               indices[0] += 2; cache[2] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+               indices[0] -= 1; cache[1] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+               indices[0] += 2; cache[2] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
                indices[0] -= 1;
             
                if (indices[1] == 2) {
@@ -218,10 +218,10 @@ namespace poisson {
                      cache[3] = dummy->get_cell_parameters();
                   }
                } else {
-                  indices[1] -= 1; cache[3] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+                  indices[1] -= 1; cache[3] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
                }
 
-               indices[1] += 2; cache[4] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+               indices[1] += 2; cache[4] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
                indices[1] -= 1;
                break;
 
@@ -232,11 +232,11 @@ namespace poisson {
                indices[0] -= 1;
                dummy = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ];
                if (dummy == NULL) cache[1] = bndryCellParams;
-               else               cache[1] = dummy->parameters;
+               else               cache[1] = dummy->parameters.data();
                indices[0] += 2;
                dummy = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ];
                if (dummy == NULL) cache[2] = bndryCellParams;
-               else               cache[2] = dummy->parameters;
+               else               cache[2] = dummy->parameters.data();
                indices[0] -= 1;
 
                // Set +/- y-neighbors both point to +y neighbor 
@@ -249,7 +249,7 @@ namespace poisson {
                   if (dummy == NULL) {
                      cache[4] = bndryCellParams;
                   } else {
-                     cache[4] = dummy->parameters;
+                     cache[4] = dummy->parameters.data();
                   }
                   indices[1] -= 1;
                } else {
@@ -259,7 +259,7 @@ namespace poisson {
                   if (dummy == NULL) {
                      cache[3] = bndryCellParams;
                   } else {
-                     cache[3] = dummy->parameters;
+                     cache[3] = dummy->parameters.data();
                   }
                   indices[1] += 1;
                }
@@ -270,24 +270,24 @@ namespace poisson {
                dummy = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ];
                //if (dummy == NULL) cache[1] = bndryCellParams;
                if (dummy == NULL) continue;
-               else               cache[1] = dummy->parameters;
+               else               cache[1] = dummy->parameters.data();
                indices[0] += 2;
                dummy = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ];
                //if (dummy == NULL) cache[2] = bndryCellParams;
                if (dummy == NULL) continue;
-               else               cache[2] = dummy->parameters;
+               else               cache[2] = dummy->parameters.data();
                indices[0] -= 1;
 
                indices[1] -= 1; 
                dummy = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ];
                //if (dummy == NULL) cache[3] = bndryCellParams;
                if (dummy == NULL) continue;
-               else               cache[3] = dummy->parameters;
+               else               cache[3] = dummy->parameters.data();
                indices[1] += 2;
                dummy = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ];
                //if (dummy == NULL) cache[4] = bndryCellParams;
                if (dummy == NULL) continue;
-               else               cache[4] = dummy->parameters;
+               else               cache[4] = dummy->parameters.data();
                indices[1] -= 1;
                break;
          }
@@ -316,18 +316,18 @@ namespace poisson {
             // Fetch pointers to this cell's (cell) parameters array, 
             // and pointers to +/- xyz face neighbors' arrays
             cache.cell = mpiGrid[cells[c]];
-            cache[0] = mpiGrid[cells[c]]->parameters;
+            cache[0] = mpiGrid[cells[c]]->parameters.data();
             
-            indices[0] -= 1; cache[1] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-            indices[0] += 2; cache[2] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+            indices[0] -= 1; cache[1] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+            indices[0] += 2; cache[2] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
             indices[0] -= 1;
             
-            indices[1] -= 1; cache[3] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-            indices[1] += 2; cache[4] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+            indices[1] -= 1; cache[3] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+            indices[1] += 2; cache[4] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
             indices[1] -= 1;
             
-            indices[2] -= 1; cache[5] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-            indices[2] += 2; cache[6] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+            indices[2] -= 1; cache[5] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+            indices[2] += 2; cache[6] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
             indices[2] -= 1;
             
             redCache.push_back(cache);
@@ -340,18 +340,18 @@ namespace poisson {
             // Fetch pointers to this cell's (cell) parameters array,
             // and pointers to +/- xyz face neighbors' arrays
             cache.cell = mpiGrid[cells[c]];
-            cache[0] = mpiGrid[cells[c]]->parameters;
+            cache[0] = mpiGrid[cells[c]]->parameters.data();
             
-            indices[0] -= 1; cache[1] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-            indices[0] += 2; cache[2] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+            indices[0] -= 1; cache[1] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+            indices[0] += 2; cache[2] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
             indices[0] -= 1;
             
-            indices[1] -= 1; cache[3] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-            indices[1] += 2; cache[4] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+            indices[1] -= 1; cache[3] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+            indices[1] += 2; cache[4] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
             indices[1] -= 1;
             
-            indices[2] -= 1; cache[5] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-            indices[2] += 2; cache[6] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+            indices[2] -= 1; cache[5] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+            indices[2] += 2; cache[6] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
             indices[2] -= 1;
             
             blackCache.push_back(cache);

--- a/poisson_solver/poisson_solver_sor.cpp
+++ b/poisson_solver/poisson_solver_sor.cpp
@@ -313,7 +313,7 @@ namespace poisson {
          CellCache3D<SOR_VARS> cache;
          cache.cellID = cells[c];
          cache.cell = mpiGrid[cells[c]];
-         cache[0]   = mpiGrid[cells[c]]->parameters;
+         cache[0]   = mpiGrid[cells[c]]->parameters.data();
 
          #ifdef DEBUG_POISSON_SOR
          if (cache.cell == NULL) {
@@ -332,12 +332,12 @@ namespace poisson {
             case sysboundarytype::NOT_SYSBOUNDARY:
                // Fetch pointers to this cell's (cell) parameters array, 
                // and pointers to +/- xyz face neighbors' arrays
-               indices[0] -= 1; cache[1] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-               indices[0] += 2; cache[2] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+               indices[0] -= 1; cache[1] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+               indices[0] += 2; cache[2] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
                indices[0] -= 1;
             
-               indices[1] -= 1; cache[3] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-               indices[1] += 2; cache[4] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+               indices[1] -= 1; cache[3] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+               indices[1] += 2; cache[4] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
                indices[1] -= 1;
                break;
                
@@ -346,11 +346,11 @@ namespace poisson {
                indices[0] -= 1;
                dummy = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ];
                if (dummy == NULL) cache[1] = bndryCellParams;
-               else               cache[1] = dummy->parameters;
+               else               cache[1] = dummy->parameters.data();
                indices[0] += 2;
                dummy = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ];
                if (dummy == NULL) cache[2] = bndryCellParams;
-               else               cache[2] = dummy->parameters;
+               else               cache[2] = dummy->parameters.data();
                indices[0] -= 1;
 
                // Set +/- y-neighbors both point to +y neighbor 
@@ -363,7 +363,7 @@ namespace poisson {
                   if (dummy == NULL) {
                      cache[4] = bndryCellParams;
                   } else {
-                     cache[4] = dummy->parameters;
+                     cache[4] = dummy->parameters.data();
                   }
                   indices[1] -= 1;
                } else {
@@ -373,7 +373,7 @@ namespace poisson {
                   if (dummy == NULL) {
                      cache[3] = bndryCellParams;
                   } else {
-                     cache[3] = dummy->parameters;
+                     cache[3] = dummy->parameters.data();
                   }
                   indices[1] += 1;
                }
@@ -383,21 +383,21 @@ namespace poisson {
                indices[0] -= 1;
                dummy = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ];
                if (dummy == NULL) cache[1] = bndryCellParams;
-               else               cache[1] = dummy->parameters;
+               else               cache[1] = dummy->parameters.data();
                indices[0] += 2;
                dummy = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ];
                if (dummy == NULL) cache[2] = bndryCellParams;
-               else               cache[2] = dummy->parameters;
+               else               cache[2] = dummy->parameters.data();
                indices[0] -= 1;
 
                indices[1] -= 1; 
                dummy = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ];
                if (dummy == NULL) cache[3] = bndryCellParams;
-               else               cache[3] = dummy->parameters;
+               else               cache[3] = dummy->parameters.data();
                indices[1] += 2;
                dummy = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ];
                if (dummy == NULL) cache[4] = bndryCellParams;
-               else               cache[4] = dummy->parameters;
+               else               cache[4] = dummy->parameters.data();
                indices[1] -= 1;
                break;
          }
@@ -429,18 +429,18 @@ namespace poisson {
             // Fetch pointers to this cell's (cell) parameters array, 
             // and pointers to +/- xyz face neighbors' arrays
             cache.cell = mpiGrid[cells[c]];
-            cache[0] = mpiGrid[cells[c]]->parameters;
+            cache[0] = mpiGrid[cells[c]]->parameters.data();
             
-            indices[0] -= 1; cache[1] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-            indices[0] += 2; cache[2] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+            indices[0] -= 1; cache[1] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+            indices[0] += 2; cache[2] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
             indices[0] -= 1;
             
-            indices[1] -= 1; cache[3] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-            indices[1] += 2; cache[4] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+            indices[1] -= 1; cache[3] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+            indices[1] += 2; cache[4] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
             indices[1] -= 1;
             
-            indices[2] -= 1; cache[5] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-            indices[2] += 2; cache[6] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+            indices[2] -= 1; cache[5] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+            indices[2] += 2; cache[6] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
             indices[2] -= 1;
             
             redCache.push_back(cache);
@@ -451,18 +451,18 @@ namespace poisson {
             // Fetch pointers to this cell's (cell) parameters array,
             // and pointers to +/- xyz face neighbors' arrays
             cache.cell = mpiGrid[cells[c]];
-            cache[0] = mpiGrid[cells[c]]->parameters;
+            cache[0] = mpiGrid[cells[c]]->parameters.data();
             
-            indices[0] -= 1; cache[1] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-            indices[0] += 2; cache[2] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+            indices[0] -= 1; cache[1] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+            indices[0] += 2; cache[2] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
             indices[0] -= 1;
             
-            indices[1] -= 1; cache[3] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-            indices[1] += 2; cache[4] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+            indices[1] -= 1; cache[3] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+            indices[1] += 2; cache[4] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
             indices[1] -= 1;
             
-            indices[2] -= 1; cache[5] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
-            indices[2] += 2; cache[6] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters;
+            indices[2] -= 1; cache[5] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
+            indices[2] += 2; cache[6] = mpiGrid[ mpiGrid.mapping.get_cell_from_indices(indices,0) ]->parameters.data();
             indices[2] -= 1;
             
             blackCache.push_back(cache);

--- a/projects/Diffusion/Diffusion.cpp
+++ b/projects/Diffusion/Diffusion.cpp
@@ -136,6 +136,6 @@ namespace projects {
    void Diffusion::setCellBackgroundField(SpatialCell* cell) {
       ConstantField bgField;
       bgField.initialize(0,0,this->B0); //bg bx, by,bz
-      setBackgroundField(bgField,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+      setBackgroundField(bgField,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
 } // namespace projects

--- a/projects/Dispersion/Dispersion.cpp
+++ b/projects/Dispersion/Dispersion.cpp
@@ -260,6 +260,6 @@ namespace projects {
                          this->B0 * sin(this->angleXY) * cos(this->angleXZ),
                          this->B0 * sin(this->angleXZ));
                          
-      setBackgroundField(bgField,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+      setBackgroundField(bgField,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
 } // namespace projects

--- a/projects/Distributions/Distributions.cpp
+++ b/projects/Distributions/Distributions.cpp
@@ -173,7 +173,7 @@ namespace projects {
                          this->By,
                          this->Bz);
       
-      setBackgroundField(bgField,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+      setBackgroundField(bgField,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
    
    vector<std::array<Real, 3>> Distributions::getV0(

--- a/projects/Flowthrough/Flowthrough.cpp
+++ b/projects/Flowthrough/Flowthrough.cpp
@@ -211,8 +211,8 @@ namespace projects {
 
    void Flowthrough::setCellBackgroundField(spatial_cell::SpatialCell* cell) const {
       ConstantField bgField;
-      bgField.initialize(Bx,By,Bz); //bg bx, by,bz
-      setBackgroundField(bgField,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+      bgField.initialize(Bx,By,Bz); //bg bx, by,bz      
+      setBackgroundField(bgField,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
    
    std::vector<std::array<Real, 3> > Flowthrough::getV0(

--- a/projects/Fluctuations/Fluctuations.cpp
+++ b/projects/Fluctuations/Fluctuations.cpp
@@ -183,8 +183,8 @@ namespace projects {
       bgField.initialize(this->BX0,
                          this->BY0,
                          this->BZ0);
-      
-      setBackgroundField(bgField,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+
+      setBackgroundField(bgField,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
    
    std::vector<std::array<Real, 3> > Fluctuations::getV0(

--- a/projects/Harris/Harris.cpp
+++ b/projects/Harris/Harris.cpp
@@ -167,7 +167,7 @@ namespace projects {
    }
 
    void Harris::setCellBackgroundField(SpatialCell *cell) const {
-      setBackgroundFieldToZero(cell->parameters, cell->derivatives,cell->derivativesBVOL);
+      setBackgroundFieldToZero(cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
 
 } // namespace projects

--- a/projects/IPShock/IPShock.cpp
+++ b/projects/IPShock/IPShock.cpp
@@ -492,7 +492,7 @@ namespace projects {
   }
 
   void IPShock::setCellBackgroundField(spatial_cell::SpatialCell* cell) const {
-    setBackgroundFieldToZero(cell->parameters, cell->derivatives,cell->derivativesBVOL);
+     setBackgroundFieldToZero(cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
   }
 
 }//namespace projects

--- a/projects/Larmor/Larmor.cpp
+++ b/projects/Larmor/Larmor.cpp
@@ -161,7 +161,7 @@ namespace projects {
                          this->BY0,
                          this->BZ0);
       
-      setBackgroundField(bgField,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+      setBackgroundField(bgField,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
 } //namespace projects 
   

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -235,7 +235,7 @@ namespace projects {
    /* set 0-centered dipole */
    void Magnetosphere::setCellBackgroundField(SpatialCell *cell) const {
       if(cell->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN && this->noDipoleInSW) {
-         setBackgroundFieldToZero(cell->parameters, cell->derivatives,cell->derivativesBVOL);
+         setBackgroundFieldToZero(cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
       }
       else {
          Dipole bgFieldDipole;
@@ -248,29 +248,29 @@ namespace projects {
          switch(this->dipoleType) {
              case 0:
                 bgFieldDipole.initialize(8e15 *this->dipoleScalingFactor, 0.0, 0.0, 0.0, 0.0 );//set dipole moment
-                setBackgroundField(bgFieldDipole,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+                setBackgroundField(bgFieldDipole,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
                 break;
              case 1:
                 bgFieldLineDipole.initialize(126.2e6 *this->dipoleScalingFactor, 0.0, 0.0, 0.0 );//set dipole moment     
-                setBackgroundField(bgFieldLineDipole,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+                setBackgroundField(bgFieldLineDipole,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
                 break;
              case 2:
                 bgFieldLineDipole.initialize(126.2e6 *this->dipoleScalingFactor, 0.0, 0.0, 0.0 );//set dipole moment     
-                setBackgroundField(bgFieldLineDipole,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+                setBackgroundField(bgFieldLineDipole,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
                 //Append mirror dipole
                 bgFieldLineDipole.initialize(126.2e6 *this->dipoleScalingFactor, this->dipoleMirrorLocationX, 0.0, 0.0 );
-                setBackgroundField(bgFieldLineDipole,cell->parameters, cell->derivatives,cell->derivativesBVOL, true);
+                setBackgroundField(bgFieldLineDipole,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data(), true);
                 break;
              case 3:
                 bgFieldDipole.initialize(8e15 *this->dipoleScalingFactor, 0.0, 0.0, 0.0, 0.0 );//set dipole moment
-                setBackgroundField(bgFieldDipole,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+                setBackgroundField(bgFieldDipole,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
                 //Append mirror dipole                
                 bgFieldDipole.initialize(8e15 *this->dipoleScalingFactor, this->dipoleMirrorLocationX, 0.0, 0.0, 0.0 );//mirror
-                setBackgroundField(bgFieldDipole,cell->parameters, cell->derivatives,cell->derivativesBVOL, true);
+                setBackgroundField(bgFieldDipole,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data(), true);
                 break;
                 
              default:
-                setBackgroundFieldToZero(cell->parameters, cell->derivatives,cell->derivativesBVOL);
+                setBackgroundFieldToZero(cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
                 
          }
       }

--- a/projects/MultiPeak/MultiPeak.cpp
+++ b/projects/MultiPeak/MultiPeak.cpp
@@ -235,7 +235,7 @@ namespace projects {
                          this->By,
                          this->Bz);
       
-      setBackgroundField(bgField,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+      setBackgroundField(bgField,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
    
    std::vector<std::array<Real, 3> > MultiPeak::getV0(

--- a/projects/Shocktest/Shocktest.cpp
+++ b/projects/Shocktest/Shocktest.cpp
@@ -226,7 +226,7 @@ namespace projects {
    void Shocktest::setCellBackgroundField(SpatialCell* cell) {
       ConstantField bgField;
       bgField.initialize(0,0,0); //bg bx, by,bz
-      setBackgroundField(bgField,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+      setBackgroundField(bgField,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
 
 } // Namespace projects

--- a/projects/Template/Template.cpp
+++ b/projects/Template/Template.cpp
@@ -75,9 +75,9 @@ namespace projects {
       Dipole bgField;
       bgField.initialize(8e15, 0.0, 0.0, 0.0, 0.0); //set dipole moment and location
       if(cell->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) {
-         setBackgroundFieldToZero(cell->parameters, cell->derivatives,cell->derivativesBVOL);
+         setBackgroundFieldToZero(cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
       } else {
-         setBackgroundField(bgField,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+         setBackgroundField(bgField,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
       }
    }
    

--- a/projects/VelocityBox/VelocityBox.cpp
+++ b/projects/VelocityBox/VelocityBox.cpp
@@ -115,7 +115,7 @@ namespace projects {
                          this->By,
                          this->Bz);
       
-      setBackgroundField(bgField,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+      setBackgroundField(bgField,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
    
 }// namespace projects

--- a/projects/projects_common.h
+++ b/projects/projects_common.h
@@ -80,11 +80,11 @@ template<typename CELLID> CELLID getNeighbour(const dccrg::Dccrg<SpatialCell,dcc
 // ********************************
 
 template<typename CELLID> CELLID getNeighbour(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,const CELLID& cellID,const int& i,const int& j,const int& k){
-    std::vector<uint64_t> neighbors = mpiGrid.get_neighbors_of_at_offset(cellID, i, j, k);
+    auto neighbors = mpiGrid.get_neighbors_of_at_offset(cellID, i, j, k);
 
     //FIXME: support refined grids
     if(neighbors.size() > 0) {
-        return neighbors[0];
+        return neighbors[0].first;
     } else {
         return INVALID_CELLID;
     }

--- a/projects/test_fp/test_fp.cpp
+++ b/projects/test_fp/test_fp.cpp
@@ -106,7 +106,7 @@ namespace projects {
    }
    
    void test_fp::setCellBackgroundField(spatial_cell::SpatialCell *cell) const {
-      setBackgroundFieldToZero(cell->parameters, cell->derivatives,cell->derivativesBVOL);
+      setBackgroundFieldToZero(cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
    
    void test_fp::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {

--- a/projects/test_trans/test_trans.cpp
+++ b/projects/test_trans/test_trans.cpp
@@ -139,7 +139,7 @@ namespace projects {
    void test_trans::setCellBackgroundField(SpatialCell* cell) const {
       ConstantField bgField;
       bgField.initialize(0.0,0.0,1e-9);
-      setBackgroundField(bgField,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+      setBackgroundField(bgField,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
 
 }// namespace projects

--- a/projects/verificationLarmor/verificationLarmor.cpp
+++ b/projects/verificationLarmor/verificationLarmor.cpp
@@ -133,7 +133,7 @@ namespace projects {
                          this->BY0,
                          this->BZ0);
       
-      setBackgroundField(bgField,cell->parameters, cell->derivatives,cell->derivativesBVOL);
+      setBackgroundField(bgField,cell->parameters.data(), cell->derivatives.data(),cell->derivativesBVOL.data());
    }
 
 } //namespace projects

--- a/spatial_cell.cpp
+++ b/spatial_cell.cpp
@@ -79,23 +79,26 @@ namespace spatial_cell {
      velocity_block_with_no_content_list(other.velocity_block_with_no_content_list),
      initialized(other.initialized),
      mpiTransferEnabled(other.mpiTransferEnabled),
-     populations(other.populations) {
+     populations(other.populations),
+     parameters(other.parameters),
+     derivatives(other.derivatives),
+     derivativesBVOL(other.derivativesBVOL),
+     null_block_data(std::array<Realf,WID3> {}) {
 
-        //copy parameters
-        for(unsigned int i=0;i< CellParams::N_SPATIAL_CELL_PARAMS;i++){
-           parameters[i]=other.parameters[i];
-        }
-        //copy derivatives
-        for(unsigned int i=0;i< fieldsolver::N_SPATIAL_CELL_DERIVATIVES;i++){
-           derivatives[i]=other.derivatives[i];
-        }
-        //copy BVOL derivatives
-        for(unsigned int i=0;i< bvolderivatives::N_BVOL_DERIVATIVES;i++){
-           derivativesBVOL[i]=other.derivativesBVOL[i];
-        }
-        
-        //set null block data
-        for (unsigned int i=0; i<WID3; ++i) null_block_data[i] = 0.0;
+        // //copy parameters
+        // for(unsigned int i=0;i< CellParams::N_SPATIAL_CELL_PARAMS;i++){
+        //    parameters[i]=other.parameters[i];
+        // }
+        // //copy derivatives
+        // for(unsigned int i=0;i< fieldsolver::N_SPATIAL_CELL_DERIVATIVES;i++){
+        //    derivatives[i]=other.derivatives[i];
+        // }
+        // //copy BVOL derivatives
+        // for(unsigned int i=0;i< bvolderivatives::N_BVOL_DERIVATIVES;i++){
+        //    derivativesBVOL[i]=other.derivativesBVOL[i];
+        // }        
+        // //set null block data
+        // for (unsigned int i=0; i<WID3; ++i) null_block_data[i] = 0.0;
    }
 
 

--- a/spatial_cell.cpp
+++ b/spatial_cell.cpp
@@ -71,35 +71,35 @@ namespace spatial_cell {
       }
    }
 
-   SpatialCell::SpatialCell(const SpatialCell& other):
-     sysBoundaryFlag(other.sysBoundaryFlag),
-     sysBoundaryLayer(other.sysBoundaryLayer),
-     sysBoundaryLayerNew(other.sysBoundaryLayerNew),
-     velocity_block_with_content_list(other.velocity_block_with_content_list),
-     velocity_block_with_no_content_list(other.velocity_block_with_no_content_list),
-     initialized(other.initialized),
-     mpiTransferEnabled(other.mpiTransferEnabled),
-     populations(other.populations),
-     parameters(other.parameters),
-     derivatives(other.derivatives),
-     derivativesBVOL(other.derivativesBVOL),
-     null_block_data(std::array<Realf,WID3> {}) {
+   // SpatialCell::SpatialCell(const SpatialCell& other):
+   //   sysBoundaryFlag(other.sysBoundaryFlag),
+   //   sysBoundaryLayer(other.sysBoundaryLayer),
+   //   sysBoundaryLayerNew(other.sysBoundaryLayerNew),
+   //   velocity_block_with_content_list(other.velocity_block_with_content_list),
+   //   velocity_block_with_no_content_list(other.velocity_block_with_no_content_list),
+   //   initialized(other.initialized),
+   //   mpiTransferEnabled(other.mpiTransferEnabled),
+   //   populations(other.populations),
+   //   parameters(other.parameters),
+   //   derivatives(other.derivatives),
+   //   derivativesBVOL(other.derivativesBVOL),
+   //   null_block_data(std::array<Realf,WID3> {}) {
 
-        // //copy parameters
-        // for(unsigned int i=0;i< CellParams::N_SPATIAL_CELL_PARAMS;i++){
-        //    parameters[i]=other.parameters[i];
-        // }
-        // //copy derivatives
-        // for(unsigned int i=0;i< fieldsolver::N_SPATIAL_CELL_DERIVATIVES;i++){
-        //    derivatives[i]=other.derivatives[i];
-        // }
-        // //copy BVOL derivatives
-        // for(unsigned int i=0;i< bvolderivatives::N_BVOL_DERIVATIVES;i++){
-        //    derivativesBVOL[i]=other.derivativesBVOL[i];
-        // }        
-        // //set null block data
-        // for (unsigned int i=0; i<WID3; ++i) null_block_data[i] = 0.0;
-   }
+   //      // //copy parameters
+   //      // for(unsigned int i=0;i< CellParams::N_SPATIAL_CELL_PARAMS;i++){
+   //      //    parameters[i]=other.parameters[i];
+   //      // }
+   //      // //copy derivatives
+   //      // for(unsigned int i=0;i< fieldsolver::N_SPATIAL_CELL_DERIVATIVES;i++){
+   //      //    derivatives[i]=other.derivatives[i];
+   //      // }
+   //      // //copy BVOL derivatives
+   //      // for(unsigned int i=0;i< bvolderivatives::N_BVOL_DERIVATIVES;i++){
+   //      //    derivativesBVOL[i]=other.derivativesBVOL[i];
+   //      // }        
+   //      // //set null block data
+   //      // for (unsigned int i=0; i<WID3; ++i) null_block_data[i] = 0.0;
+   // }
 
 
    /** Adds "important" and removes "unimportant" velocity blocks

--- a/spatial_cell.hpp
+++ b/spatial_cell.hpp
@@ -348,7 +348,7 @@ namespace spatial_cell {
       static bool mpiTransferAtSysBoundaries;                                 /**< Do we only transfer data at boundaries (true), or in the whole system (false).*/
 
     private:
-      SpatialCell& operator=(const SpatialCell&);
+      //SpatialCell& operator=(const SpatialCell&);
       
       bool compute_block_has_content(const vmesh::GlobalID& block,const uint popID) const;
       void merge_values_recursive(const uint popID,vmesh::GlobalID parentGID,vmesh::GlobalID blockGID,uint8_t refLevel,bool recursive,const Realf* data,
@@ -1891,9 +1891,9 @@ namespace spatial_cell {
       return populations[popID].vmesh.hasGrandParent(blockGID);
    }
    
-   inline SpatialCell& SpatialCell::operator=(const SpatialCell&) { 
-      return *this;
-   }
+   // inline SpatialCell& SpatialCell::operator=(const SpatialCell&) { 
+   //    return *this;
+   // }
 
 } // namespaces
 

--- a/spatial_cell.hpp
+++ b/spatial_cell.hpp
@@ -316,11 +316,16 @@ namespace spatial_cell {
       //random_data* get_rng_data_buffer();
 
       // Member variables //
-      Real derivatives[fieldsolver::N_SPATIAL_CELL_DERIVATIVES];              /**< Derivatives of bulk variables in this spatial cell.*/
-      Real derivativesBVOL[bvolderivatives::N_BVOL_DERIVATIVES];              /**< Derivatives of BVOL needed by the acceleration. 
-                                                                               * Separate array because it does not need to be communicated.*/
-      Real parameters[CellParams::N_SPATIAL_CELL_PARAMS];                     /**< Bulk variables in this spatial cell.*/
-      Realf null_block_data[WID3];
+      //Real derivatives[fieldsolver::N_SPATIAL_CELL_DERIVATIVES];              /**< Derivatives of bulk variables in this spatial cell.*/
+      std::array<Real, fieldsolver::N_SPATIAL_CELL_DERIVATIVES> derivatives;    /**< Derivatives of bulk variables in this spatial cell.*/
+      //Real derivativesBVOL[bvolderivatives::N_BVOL_DERIVATIVES];                /**< Derivatives of BVOL needed by the acceleration. 
+      //                                                                           * Separate array because it does not need to be communicated.*/
+      std::array<Real, bvolderivatives::N_BVOL_DERIVATIVES> derivativesBVOL;    /**< Derivatives of BVOL needed by the acceleration.            
+                                                                                 * Separate array because it does not need to be communicated.*/
+      //Real parameters[CellParams::N_SPATIAL_CELL_PARAMS];                     /**< Bulk variables in this spatial cell.*/
+      std::array<Real, CellParams::N_SPATIAL_CELL_PARAMS> parameters;
+      //Realf null_block_data[WID3];
+      std::array<Realf, WID3> null_block_data;
 
       uint64_t ioLocalCellId;                                                 /**< Local cell ID used for IO, not needed elsewhere 
                                                                                * and thus not being kept up-to-date.*/
@@ -414,7 +419,7 @@ namespace spatial_cell {
             
             if (nbrIDs.size() > 0) {     // This block has at least one existing neighbor
                if (refLevelDiff == -1) { // Neighbor is one level coarser, interpolate
-                  if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data; // (this check might not be necessary here)
+                  if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data.data(); // (this check might not be necessary here)
                   else ptr = src + nbrIDs[0]*WID3;
                   for (uint32_t i=0; i<PAD; ++i) for (uint32_t k=0; k<WID; ++k) for (uint32_t j=0; j<WID; ++j) {
                      pos[0] = crd + i;
@@ -424,7 +429,7 @@ namespace spatial_cell {
                   }
                   cellSizeFractions[(i_nbr_off+1)/2] = 2.0;
                } else if (refLevelDiff == 0) { // Neighbor at same level, copy data
-                  if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data; // (this check might not be necessary here)
+                  if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data.data(); // (this check might not be necessary here)
                   else ptr = src + nbrIDs[0]*WID3;
                   uint32_t i_src = 0;
                   if (i_nbr_off < 0) i_src = WID-PAD;
@@ -436,7 +441,7 @@ namespace spatial_cell {
                   for (uint32_t i=0; i<PAD; ++i) for (uint32_t k=0; k<WID; ++k) for (uint32_t j=0; j<WID; ++j) {
                      
                      int index = (k/2)*2 + j/2;
-                     if (nbrIDs[index] == invalid_local_id()) ptr = null_block_data;
+                     if (nbrIDs[index] == invalid_local_id()) ptr = null_block_data.data();
                      else ptr = src + nbrIDs[index]*WID3;
                      
                      pos[0] = crd + i;
@@ -475,7 +480,7 @@ namespace spatial_cell {
             
             if (nbrIDs.size() > 0) {     // This block has at least one existing neighbor
                if (refLevelDiff == -1) { // Neighbor is one level coarser, interpolate
-                  if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data; // (this check might not be necessary here)
+                  if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data.data(); // (this check might not be necessary here)
                   else ptr = src + nbrIDs[0]*WID3;
                   for (uint32_t j=0; j<PAD; ++j) for (uint32_t k=0; k<WID; ++k) for (uint32_t i=0; i<WID; ++i) {
                      pos[0] = 2*(i_block%2) + i/2 + 0.5;
@@ -485,7 +490,7 @@ namespace spatial_cell {
                   }
                   cellSizeFractions[(j_nbr_off+1)/2] = 2.0;
                } else if (refLevelDiff == 0) { // Neighbor at same level, copy data
-                  if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data; // (this check might not be necessary here)
+                  if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data.data(); // (this check might not be necessary here)
                   else ptr = src + nbrIDs[0]*WID3;
                   uint32_t j_src = 0;
                   if (j_nbr_off < 0) j_src = WID-PAD;
@@ -498,7 +503,7 @@ namespace spatial_cell {
                      // Iterate over the four neighbors. If the neighbor does not exist, 
                      // interpolate values from the null block
                      int index = (k/2)*2 + i/2;
-                     if (nbrIDs[index] == invalid_local_id()) ptr = null_block_data;
+                     if (nbrIDs[index] == invalid_local_id()) ptr = null_block_data.data();
                      else ptr = src + nbrIDs[index]*WID3;
                      
                      pos[0] = 2*(i%2) + 1;
@@ -537,7 +542,7 @@ namespace spatial_cell {
             
             if (nbrIDs.size() > 0) {     // This block has at least one existing neighbor
                if (refLevelDiff == -1) { // Neighbor is one level coarser, interpolate
-                  if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data; // (this check might not be necessary here)
+                  if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data.data(); // (this check might not be necessary here)
                   else ptr = src + nbrIDs[0]*WID3;
                   for (uint32_t k=0; k<PAD; ++k) for (uint32_t j=0; j<WID; ++j) for (uint32_t i=0; i<WID; ++i) {
                      pos[0] = 2*(i_block%2) + i/2 + 0.5;
@@ -547,7 +552,7 @@ namespace spatial_cell {
                   }
                   cellSizeFractions[(k_nbr_off+1)/2] = 2.0;
                } else if (refLevelDiff == 0) { // Neighbor at same level, copy data
-                  if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data; // (this check might not be necessary here)
+                  if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data.data(); // (this check might not be necessary here)
                   else ptr = src + nbrIDs[0]*WID3;
                   uint32_t k_src = 0;
                   if (k_nbr_off < 0) k_src = WID-PAD;
@@ -560,7 +565,7 @@ namespace spatial_cell {
                      // Iterate over the four neighbors. If the neighbor does not exist, 
                      // interpolate values from the null block
                      int index = (j/2)*2 + i/2;
-                     if (nbrIDs[index] == invalid_local_id()) ptr = null_block_data;
+                     if (nbrIDs[index] == invalid_local_id()) ptr = null_block_data.data();
                      else ptr = src + nbrIDs[index]*WID3;
                      
                      pos[0] = 2*(i%2) + 1;
@@ -620,7 +625,7 @@ namespace spatial_cell {
 
          if (nbrIDs.size() > 0) {
             if (refLevelDiff == -1) { // nbr one level coarser, interpolate
-               if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data;
+               if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data.data();
                else ptr = src + nbrIDs[0]*WID3;
                for (uint32_t i=0; i<PAD; ++i) for (uint32_t k=0; k<WID; ++k) for (uint32_t j=0; j<WID; ++j) {
                   pos[0] = crd + i;
@@ -629,7 +634,7 @@ namespace spatial_cell {
                   array[vblock::padIndex<PAD>(i_trgt+i,j+PAD,k+PAD)] = vblock::interp_yz<vblock::interpmethod::NGP>(pos,ptr);
                }
             } else if (refLevelDiff == 0) { // nbr at same level, simple data copy
-               if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data;
+               if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data.data();
                else ptr = src + nbrIDs[0]*WID3;
                uint32_t i_src = 0;
                if (i_nbr_off < 0) i_src = WID-PAD;
@@ -639,7 +644,7 @@ namespace spatial_cell {
             } else if (refLevelDiff == +1) { // nbr one level more refined, interpolate from four neighbors
                for (uint32_t i=0; i<PAD; ++i) for (uint32_t k=0; k<WID; ++k) for (uint32_t j=0; j<WID; ++j) {
                   int index = (k/2)*2 + j/2;
-                  if (nbrIDs[index] == invalid_local_id()) ptr = null_block_data;
+                  if (nbrIDs[index] == invalid_local_id()) ptr = null_block_data.data();
                   else ptr = src + nbrIDs[index]*WID3;
 
                   pos[0] = crd + i;
@@ -667,7 +672,7 @@ namespace spatial_cell {
          
          if (nbrIDs.size() > 0) {
             if (refLevelDiff == -1) { // nbr one level coarser, interpolate
-               if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data;
+               if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data.data();
                else ptr = src + nbrIDs[0]*WID3;
                for (uint32_t j=0; j<PAD; ++j) for (uint32_t k=0; k<WID; ++k) for (uint32_t i=0; i<WID; ++i) {
                   pos[0] = 2*(i_block%2) + i/2 + 0.5;
@@ -676,7 +681,7 @@ namespace spatial_cell {
                   array[vblock::padIndex<PAD>(i+PAD,j_trgt+j,k+PAD)] = vblock::interp_xz<vblock::interpmethod::NGP>(pos,ptr);
                }
             } else if (refLevelDiff == 0) { // nbr at same level, simple data copy
-               if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data;
+               if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data.data();
                else ptr = src + nbrIDs[0]*WID3;
                uint32_t j_src = 0;
                if (j_nbr_off < 0) j_src = WID-PAD;
@@ -686,7 +691,7 @@ namespace spatial_cell {
             } else if (refLevelDiff == +1) { // nbr one level more refined, interpolate from four neighbors
                for (uint32_t j=0; j<PAD; ++j) for (uint32_t k=0; k<WID; ++k) for (uint32_t i=0; i<WID; ++i) {
                   int index = (k/2)*2 + i/2;
-                  if (nbrIDs[index] == invalid_local_id()) ptr = null_block_data;
+                  if (nbrIDs[index] == invalid_local_id()) ptr = null_block_data.data();
                   else ptr = src + nbrIDs[index]*WID3;
 
                   pos[0] = 2*(i%2) + 1;
@@ -714,7 +719,7 @@ namespace spatial_cell {
          
          if (nbrIDs.size() > 0) {
             if (refLevelDiff == -1) { // nbr one level coarser, interpolate
-               if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data;
+               if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data.data();
                else ptr = src + nbrIDs[0]*WID3;
                for (uint32_t k=0; k<PAD; ++k) for (uint32_t j=0; j<WID; ++j) for (uint32_t i=0; i<WID; ++i) {
                   pos[0] = 2*(i_block%2) + i/2 + 0.5;
@@ -723,7 +728,7 @@ namespace spatial_cell {
                   array[vblock::padIndex<PAD>(i+PAD,j+PAD,k_trgt+k)] = vblock::interp_xy<vblock::interpmethod::NGP>(pos,ptr);
                }
             } else if (refLevelDiff == 0) { // nbr at same level, simple data copy
-               if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data;
+               if (nbrIDs[0] == invalid_local_id()) ptr = null_block_data.data();
                else ptr = src + nbrIDs[0]*WID3;
                uint32_t k_src = 0;
                if (k_nbr_off < 0) k_src = WID-PAD;
@@ -733,7 +738,7 @@ namespace spatial_cell {
             } else if (refLevelDiff == +1) { // nbr one level more refined, interpolate from four neighbors
                for (uint32_t k=0; k<PAD; ++k) for (uint32_t j=0; j<WID; ++j) for (uint32_t i=0; i<WID; ++i) {
                   int index = (j/2)*2 + i/2;
-                  if (nbrIDs[index] == invalid_local_id()) ptr = null_block_data;
+                  if (nbrIDs[index] == invalid_local_id()) ptr = null_block_data.data();
                   else ptr = src + nbrIDs[index]*WID3;
                   
                   pos[0] = 2*(i%2) + 1;
@@ -796,7 +801,7 @@ namespace spatial_cell {
          exit(1);
       }
       #endif
-      if (blockLID == vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>::invalidLocalID()) return null_block_data;
+      if (blockLID == vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>::invalidLocalID()) return null_block_data.data();
       return populations[popID].blockContainer.getData(blockLID);
    }
    
@@ -813,7 +818,7 @@ namespace spatial_cell {
          exit(1);
       }
       #endif
-      if (blockLID == vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>::invalidLocalID()) return null_block_data;
+      if (blockLID == vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>::invalidLocalID()) return null_block_data.data();
       return populations[popID].blockContainer.getData(blockLID);
    }
 
@@ -872,11 +877,11 @@ namespace spatial_cell {
    }
    
    inline Real* SpatialCell::get_cell_parameters() {
-       return parameters;
+      return parameters.data();
    }
 
    inline const Real* SpatialCell::get_cell_parameters() const {
-      return parameters;
+      return parameters.data();
    }
 
    inline uint8_t SpatialCell::get_maximum_refinement_level(const uint popID) {

--- a/sysboundary/antisymmetric.cpp
+++ b/sysboundary/antisymmetric.cpp
@@ -97,7 +97,7 @@ namespace SBC {
       const vector<CellID>& cells = getLocalCells();
       for (size_t c=0; c<cells.size(); ++c) {
          if (mpiGrid[cells[c]]->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) continue;
-         creal* const cellParams = mpiGrid[cells[c]]->parameters;
+         creal* const cellParams = mpiGrid[cells[c]]->parameters.data();
          creal dx = cellParams[CellParams::DX];
          creal dy = cellParams[CellParams::DY];
          creal dz = cellParams[CellParams::DZ];

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -453,7 +453,7 @@ namespace SBC {
       
       const OutflowSpeciesParameters& sP = this->speciesParams[popID];
       SpatialCell* cell = mpiGrid[cellID];
-      creal* const cellParams = cell->parameters;
+      creal* const cellParams = cell->parameters.data();
       creal dx = cellParams[CellParams::DX];
       creal dy = cellParams[CellParams::DY];
       creal dz = cellParams[CellParams::DZ];

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -427,10 +427,10 @@ bool SysBoundary::classifyCells(dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Ca
    for(uint i=0; i<cells.size(); i++) {
       mpiGrid[cells[i]]->sysBoundaryLayer=0; /*Initial value*/
       if(mpiGrid[cells[i]]->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY ) {
-         const std::vector<CellID>* nbrs = mpiGrid.get_neighbors_of(cells[i],SYSBOUNDARIES_NEIGHBORHOOD_ID);
+         const auto* nbrs = mpiGrid.get_neighbors_of(cells[i],SYSBOUNDARIES_NEIGHBORHOOD_ID);
          for(uint j=0; j<(*nbrs).size(); j++) {
-            if((*nbrs)[j]!=0 ) {
-               if(mpiGrid[(*nbrs)[j]]->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ) {
+            if((*nbrs)[j].first!=0 ) {
+               if(mpiGrid[(*nbrs)[j].first]->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ) {
                   mpiGrid[cells[i]]->sysBoundaryLayer=1;
                }
             }
@@ -448,10 +448,10 @@ bool SysBoundary::classifyCells(dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Ca
    for(uint layer=1;layer<maxLayers;layer++){
       for(uint i=0; i<cells.size(); i++) {
          if(mpiGrid[cells[i]]->sysBoundaryLayer==0){
-            const std::vector<CellID>* nbrs = mpiGrid.get_neighbors_of(cells[i],SYSBOUNDARIES_NEIGHBORHOOD_ID);
+            const auto* nbrs = mpiGrid.get_neighbors_of(cells[i],SYSBOUNDARIES_NEIGHBORHOOD_ID);
             for(uint j=0; j<(*nbrs).size(); j++) {
-               if((*nbrs)[j]!=0 && (*nbrs)[j]!=cells[i] ) {
-                  if(mpiGrid[(*nbrs)[j]]->sysBoundaryLayer==layer) { 
+               if((*nbrs)[j].first!=0 && (*nbrs)[j].first!=cells[i] ) {
+                  if(mpiGrid[(*nbrs)[j].first]->sysBoundaryLayer==layer) { 
                      mpiGrid[cells[i]]->sysBoundaryLayer=layer+1;
                      break;
                   }


### PR DESCRIPTION
Two minor updates:

- Changed C-style arrays in spatial_cell member variables to c++11 std::arrays. This allows us to use the default copy constructor and operator= for spatial_cell objects.

- Updated dccrg calls to get_neighbors_of() and initialize() to be compatible with the current dccrg master repo (commit 63699d6).

Tested in testpackage and saw no differences to master.