### PR TITLE
Fix gradPE calculation components.

### DIFF
--- a/fieldsolver/ldz_gradpe.cpp
+++ b/fieldsolver/ldz_gradpe.cpp
@@ -142,8 +142,8 @@ void calculateGradPeTerm(
       sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondGradPeElectricField(EGradPeGrid,i,j,k,2);
    } else {
       calculateEdgeGradPeTermXComponents(EGradPeGrid,momentsGrid,dMomentsGrid,i,j,k);
-      calculateEdgeGradPeTermXComponents(EGradPeGrid,momentsGrid,dMomentsGrid,i,j,k);
       calculateEdgeGradPeTermYComponents(EGradPeGrid,momentsGrid,dMomentsGrid,i,j,k);
+      calculateEdgeGradPeTermZComponents(EGradPeGrid,momentsGrid,dMomentsGrid,i,j,k);
    }
 }
 


### PR DESCRIPTION
It was run twice for X, once for Y, and never for Z.
Must have been a typo in the fsgrid effort.