### PR TITLE
Fix Backstreaming V and Pressure Tensor computation

### DIFF
--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -911,6 +911,7 @@ namespace DRO {
       V[0] = 0;
       V[1] = 0;
       V[2] = 0;
+      Real n = 0;
       # pragma omp parallel
       {
          Real thread_nvx_sum = 0.0;
@@ -956,16 +957,22 @@ namespace DRO {
             }
          } // for-loop over velocity blocks
 
-         // Accumulate contributions coming from this velocity block
+         // Accumulate contributions coming from this velocity block.
          // If multithreading / OpenMP is used, 
          // these updates need to be atomic:
          # pragma omp critical
          {
-            V[0] += thread_nvx_sum / thread_n_sum;
-            V[1] += thread_nvy_sum / thread_n_sum;
-            V[2] += thread_nvz_sum / thread_n_sum;
+            V[0] += thread_nvx_sum;
+            V[1] += thread_nvy_sum;
+            V[2] += thread_nvz_sum;
+            n += thread_n_sum;
          }
       }
+
+      // Finally, divide n*V by V.
+      V[0]/=n;
+      V[1]/=n;
+      V[2]/=n;
       return;
    }
 

--- a/testpackage/small_test_definitions.sh
+++ b/testpackage/small_test_definitions.sh
@@ -82,7 +82,7 @@ variable_components[8]="0 0 1 2 0 1 2 0 1 2"
 test_name[9]="Magnetosphere_polar_small"
 comparison_vlsv[9]="bulk.0000001.vlsv"
 comparison_phiprof[9]="phiprof_0.txt"
-variable_names[9]="proton/rho proton/V proton/V proton/V B B B E E E protons"
+variable_names[9]="proton/rho proton/V proton/V proton/V B B B E E E protons proton/VNonBackstream proton/PTensorNonBackstreamDiagonal"
 variable_components[9]="0 0 1 2 0 1 2 0 1 2"
 
 # Field solver test

--- a/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
+++ b/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
@@ -70,6 +70,8 @@ output = E
 output = Pressure
 output = populations_V
 output = populations_Rho
+output = populations_moments_Backstream
+output = populations_moments_NonBackstream
 output = BoundaryType
 output = MPIrank
 output = populations_Blocks
@@ -122,13 +124,20 @@ noDipoleInSW = 1.0
 dipoleType = 2
 dipoleMirrorLocationX = 625.0e6
 
+[proton_backstream]
+# Pretty much bogus values, just so that the reducer has something
+# to play with. (This cuts the solar wind roughly in half)
+radius = 5e5
+vx = -2.5e5
+vy = 0
+vz = 0
+
 [proton_Magnetosphere]
 T = 0.5e6
 rho = 1.0e6
 VX0 = -7.5e5
 VY0 = 0.0
 VZ0 = 0.0
-
 
 nSpaceSamples = 1
 nVelocitySamples = 1


### PR DESCRIPTION
The critical section summing up individual velocity blocks' velocity contributions was taking the average at the wrong spot, thus inadvertantly causing a division by zero in some cases.

Compiles and runs fine with the testpackage, which is not unexpected, since the testpackage doesn't even look at the backstreaming pressure tensor. Duh.

So it add's a little bit of testing for it to the Magnetosphere_Polar_small test.