### PR TITLE
Update fsgrid coupling calls to share coupling information.

### DIFF
--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -377,19 +377,20 @@ int main(int argn,char* args[]) {
    std::array<bool,3> periodicity{mpiGrid.topology.is_periodic(0),
                                  mpiGrid.topology.is_periodic(1),
                                  mpiGrid.topology.is_periodic(2)};
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> perBGrid(dimensions, comm, periodicity);
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> perBDt2Grid(dimensions, comm, periodicity);
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> EGrid(dimensions, comm, periodicity);
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> EDt2Grid(dimensions, comm, periodicity);
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2> EHallGrid(dimensions, comm, periodicity);
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2> EGradPeGrid(dimensions, comm, periodicity);
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> momentsGrid(dimensions, comm, periodicity);
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> momentsDt2Grid(dimensions, comm, periodicity);
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2> dPerBGrid(dimensions, comm, periodicity);
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2> dMomentsGrid(dimensions, comm, periodicity);
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2> BgBGrid(dimensions, comm, periodicity);
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2> volGrid(dimensions, comm, periodicity);
-   FsGrid< fsgrids::technical, 2> technicalGrid(dimensions, comm, periodicity);
+   FsGridCouplingInformation gridCoupling;
+   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> perBGrid(dimensions, comm, periodicity,gridCoupling);
+   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> perBDt2Grid(dimensions, comm, periodicity,gridCoupling);
+   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> EGrid(dimensions, comm, periodicity,gridCoupling);
+   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> EDt2Grid(dimensions, comm, periodicity,gridCoupling);
+   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2> EHallGrid(dimensions, comm, periodicity,gridCoupling);
+   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2> EGradPeGrid(dimensions, comm, periodicity,gridCoupling);
+   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> momentsGrid(dimensions, comm, periodicity,gridCoupling);
+   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> momentsDt2Grid(dimensions, comm, periodicity,gridCoupling);
+   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2> dPerBGrid(dimensions, comm, periodicity,gridCoupling);
+   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2> dMomentsGrid(dimensions, comm, periodicity,gridCoupling);
+   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2> BgBGrid(dimensions, comm, periodicity,gridCoupling);
+   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2> volGrid(dimensions, comm, periodicity,gridCoupling);
+   FsGrid< fsgrids::technical, 2> technicalGrid(dimensions, comm, periodicity,gridCoupling);
    // Set DX,DY and DZ
    // TODO: This is currently just taking the values from cell 1, and assuming them to be
    // constant throughout the simulation.
@@ -406,50 +407,14 @@ int main(int argn,char* args[]) {
    phiprof::start("Initial fsgrid coupling");
    const std::vector<CellID>& cells = getLocalCells();
 
-   // Couple FSGrids to mpiGrid
-   // TODO: Do we really need to couple *all* of these fields?
-   perBGrid.setupForGridCoupling(cells.size());
-   perBDt2Grid.setupForGridCoupling(cells.size());
-   EGrid.setupForGridCoupling(cells.size());
-   EDt2Grid.setupForGridCoupling(cells.size());
-   EHallGrid.setupForGridCoupling(cells.size());
-   EGradPeGrid.setupForGridCoupling(cells.size());
-   momentsGrid.setupForGridCoupling(cells.size());
-   momentsDt2Grid.setupForGridCoupling(cells.size());
-   dPerBGrid.setupForGridCoupling(cells.size());
-   dMomentsGrid.setupForGridCoupling(cells.size());
-   BgBGrid.setupForGridCoupling(cells.size());
-   volGrid.setupForGridCoupling(cells.size());
+   // Couple FSGrids to mpiGrid. Note that the coupling information is shared
+   // between them.
    technicalGrid.setupForGridCoupling(cells.size());
 
    // FSGrid cellIds are 0-based, whereas DCCRG cellIds are 1-based, beware
    for(auto& i : cells) {
-      perBGrid.setGridCoupling(i-1, myRank);
-      perBDt2Grid.setGridCoupling(i-1, myRank);
-      EGrid.setGridCoupling(i-1, myRank);
-      EDt2Grid.setGridCoupling(i-1, myRank);
-      EHallGrid.setGridCoupling(i-1, myRank);
-      EGradPeGrid.setGridCoupling(i-1, myRank);
-      momentsGrid.setGridCoupling(i-1, myRank);
-      momentsDt2Grid.setGridCoupling(i-1, myRank);
-      dPerBGrid.setGridCoupling(i-1, myRank);
-      dMomentsGrid.setGridCoupling(i-1, myRank);
-      BgBGrid.setGridCoupling(i-1, myRank);
-      volGrid.setGridCoupling(i-1, myRank);
       technicalGrid.setGridCoupling(i-1, myRank);
    }
-   perBGrid.finishGridCoupling();
-   perBDt2Grid.finishGridCoupling();
-   EGrid.finishGridCoupling();
-   EDt2Grid.finishGridCoupling();
-   EHallGrid.finishGridCoupling();
-   EGradPeGrid.finishGridCoupling();
-   momentsGrid.finishGridCoupling();
-   momentsDt2Grid.finishGridCoupling();
-   dPerBGrid.finishGridCoupling();
-   dMomentsGrid.finishGridCoupling();
-   BgBGrid.finishGridCoupling();
-   volGrid.finishGridCoupling();
    technicalGrid.finishGridCoupling();
    phiprof::stop("Initial fsgrid coupling");
 
@@ -852,48 +817,12 @@ int main(int argn,char* args[]) {
          // Re-couple fsgrids to updated grid situation
          phiprof::start("fsgrid-recouple-after-lb");
          const vector<CellID>& cells = getLocalCells();
-         perBGrid.setupForGridCoupling(cells.size());
-         perBDt2Grid.setupForGridCoupling(cells.size());
-         EGrid.setupForGridCoupling(cells.size());
-         EDt2Grid.setupForGridCoupling(cells.size());
-         EHallGrid.setupForGridCoupling(cells.size());
-         EGradPeGrid.setupForGridCoupling(cells.size());
-         momentsGrid.setupForGridCoupling(cells.size());
-         momentsDt2Grid.setupForGridCoupling(cells.size());
-         dPerBGrid.setupForGridCoupling(cells.size());
-         dMomentsGrid.setupForGridCoupling(cells.size());
-         BgBGrid.setupForGridCoupling(cells.size());
-         volGrid.setupForGridCoupling(cells.size());
          technicalGrid.setupForGridCoupling(cells.size());
          
          // FSGrid cellIds are 0-based, whereas DCCRG cellIds are 1-based, beware
          for(auto& i : cells) {
-            perBGrid.setGridCoupling(i-1, myRank);
-            perBDt2Grid.setGridCoupling(i-1, myRank);
-            EGrid.setGridCoupling(i-1, myRank);
-            EDt2Grid.setGridCoupling(i-1, myRank);
-            EHallGrid.setGridCoupling(i-1, myRank);
-            EGradPeGrid.setGridCoupling(i-1, myRank);
-            momentsGrid.setGridCoupling(i-1, myRank);
-            momentsDt2Grid.setGridCoupling(i-1, myRank);
-            dPerBGrid.setGridCoupling(i-1, myRank);
-            dMomentsGrid.setGridCoupling(i-1, myRank);
-            BgBGrid.setGridCoupling(i-1, myRank);
-            volGrid.setGridCoupling(i-1, myRank);
             technicalGrid.setGridCoupling(i-1, myRank);
          }
-         perBGrid.finishGridCoupling();
-         perBDt2Grid.finishGridCoupling();
-         EGrid.finishGridCoupling();
-         EDt2Grid.finishGridCoupling();
-         EHallGrid.finishGridCoupling();
-         EGradPeGrid.finishGridCoupling();
-         momentsGrid.finishGridCoupling();
-         momentsDt2Grid.finishGridCoupling();
-         dPerBGrid.finishGridCoupling();
-         dMomentsGrid.finishGridCoupling();
-         BgBGrid.finishGridCoupling();
-         volGrid.finishGridCoupling();
          technicalGrid.finishGridCoupling();
          phiprof::stop("fsgrid-recouple-after-lb");
 


### PR DESCRIPTION
This works in connection with the fsgrid pull request https://github.com/fmihpc/fsgrid/pull/6

Instead of coupling each fsgrid independently, their coupling informaiton is shared and only communicated once, drastically cutting down on small message storms at load balance time.