### PR TITLE
Added a loss cone population DRO for precipitation

### DIFF
--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -251,6 +251,13 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          continue;
       }
+      if(*it == "populations_PrecipitationDiffFlux") {
+         // Per-population precipitation directional differential number flux
+         for(unsigned int i =0; i < getObjectWrapper().particleSpecies.size(); i++) {
+            outputReducer->addOperator(new DRO::VariablePrecipitationDiffFlux(i));
+         }
+         continue;
+      }
       if(*it == "derivs") {
          // Derivatives of all quantities that might be of interest
          outputReducer->addOperator(new DRO::DataReductionOperatorDerivatives("drhomdx",fieldsolver::drhomdx,1));

--- a/datareduction/datareductionoperator.h
+++ b/datareduction/datareductionoperator.h
@@ -507,6 +507,25 @@ namespace DRO {
       std::string popName;
    };
    
+   // Precipitation directional differential number flux
+   class VariablePrecipitationDiffFlux: public DataReductionOperator {
+   public:
+      VariablePrecipitationDiffFlux(cuint popID);
+      virtual ~VariablePrecipitationDiffFlux();
+      
+      virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
+      virtual std::string getName() const;
+      virtual bool reduceData(const SpatialCell* cell,char* buffer);
+      virtual bool setSpatialCell(const SpatialCell* cell);
+      
+   protected:
+      uint popID;
+      std::string popName;
+      int nChannels;
+      Real emin, emax;
+      Real cosAngle;
+      std::vector<Real> channels, dataDiffFlux;
+   };
 } // namespace DRO
 
 #endif

--- a/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
+++ b/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
@@ -12,12 +12,12 @@ charge = 1
 diagnostic_write_interval = 10
 write_initial_state = 0
 
-system_write_t_interval = 20
+system_write_t_interval = 10
 system_write_file_name = bulk
 system_write_distribution_stride = 0
 system_write_distribution_xline_stride = 10
-system_write_distribution_yline_stride = 10
-system_write_distribution_zline_stride = 1
+system_write_distribution_yline_stride = 0
+system_write_distribution_zline_stride = 10
 
 #[bailout]
 #write_restart = 0
@@ -32,7 +32,7 @@ y_min = -5.0e6
 y_max = 5.0e6
 z_min = -250.0e6
 z_max = 250.0e6
-t_max = 20.05
+t_max = 1000.05
 
 
 [proton_vspace]
@@ -76,6 +76,7 @@ output = BoundaryType
 output = MPIrank
 output = populations_Blocks
 output = fSaved
+output = populations_PrecipitationDiffFlux
 diagnostic = populations_Blocks
 
 

--- a/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
+++ b/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
@@ -12,12 +12,12 @@ charge = 1
 diagnostic_write_interval = 10
 write_initial_state = 0
 
-system_write_t_interval = 10
+system_write_t_interval = 20
 system_write_file_name = bulk
 system_write_distribution_stride = 0
 system_write_distribution_xline_stride = 10
-system_write_distribution_yline_stride = 0
-system_write_distribution_zline_stride = 10
+system_write_distribution_yline_stride = 10
+system_write_distribution_zline_stride = 1
 
 #[bailout]
 #write_restart = 0
@@ -32,7 +32,7 @@ y_min = -5.0e6
 y_max = 5.0e6
 z_min = -250.0e6
 z_max = 250.0e6
-t_max = 1000.05
+t_max = 20.05
 
 
 [proton_vspace]
@@ -76,7 +76,7 @@ output = BoundaryType
 output = MPIrank
 output = populations_Blocks
 output = fSaved
-output = populations_PrecipitationDiffFlux
+#output = populations_PrecipitationDiffFlux
 diagnostic = populations_Blocks
 
 


### PR DESCRIPTION
Added a data reduction operator to save the loss-cone population of ion species in each cell.
- At the moment, the number of energy bins (16) as well as the minimum and maximum bin values (100 eV and 100 keV) are hardcoded. Energy bins are logarithmically spaced. Particles with energies under 100 eV (above 100 keV) are counted with the lowest (highest) energy bin.
- The loss-cone opening angle has a fixed value which is the same in the whole simulation domain. The value was set to 10 deg, which should be ok as a first approximation, since the phase-space density is averaged inside the loss cone (not integrated).
- At the moment, the loss-cone population is saved everywhere, including in regions where it is not relevant for particle precipitation.
- Differential ion number flux values are saved in units used by observers [ion/(cm2 s sr eV)], which is a deviation from the convention of manipulating SI units only.
