### PR TITLE
Fix for incompatible broken DCCRG API. Again.

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -762,7 +762,7 @@ void updateRemoteVelocityBlockLists(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Ge
      uint64_t cell_id = incoming_cells[i];
      SpatialCell* cell = mpiGrid[cell_id];
      if (cell == NULL) {
-       for (const auto& cell: mpiGrid.local_cells) {
+       for (const auto& cell: mpiGrid.local_cells()) {
 	 if (cell.id == cell_id) {
 	   cerr << __FILE__ << ":" << __LINE__ << std::endl;
 	   abort();

--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -1309,7 +1309,7 @@ int get_sibling_index(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGr
       return ERROR;
    }
    
-   vector<CellID> siblings = mpiGrid.get_all_children(parent);
+   auto siblings = mpiGrid.mapping.get_all_children(parent);
    auto location = std::find(siblings.begin(),siblings.end(),cellid);
    auto index = std::distance(siblings.begin(), location);
 
@@ -1539,7 +1539,7 @@ void update_remote_mapping_contribution_amr(
 
                   recvIndex = mySiblingIndex;
                   
-                  auto mySiblings = mpiGrid.get_all_children(mpiGrid.get_parent(c));
+                  auto mySiblings = mpiGrid.mapping.get_all_children(mpiGrid.get_parent(c));
                   auto myIndices = mpiGrid.mapping.get_indices(c);
                   
                   // Allocate memory for each sibling to receive all the data sent by coarser ncell. 


### PR DESCRIPTION
Apparently, some variables became functinos, and others were moved to a subobject of the mesh.

Compiles, but not tested yet.