### PR TITLE
Fix amr source cells

### DIFF
--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -117,7 +117,7 @@ void computeSpatialSourceCellsForPencil(const dccrg::Dccrg<SpatialCell,dccrg::Ca
    // Iterate through distances for VLASOV_STENCIL_WIDTH elements starting from the smallest distance.
    // Distances are negative here so largest distance has smallest value
    auto irend = distances.rbegin();
-   std::advance(irend, VLASOV_STENCIL_WIDTH);
+   std::advance(irend, std::min((int)distances.size(), VLASOV_STENCIL_WIDTH));
    for (auto it = distances.rbegin(); it != irend; ++it) {
       // Collect all neighbors at distance *it to a vector
       std::vector< CellID > neighbors;
@@ -147,7 +147,7 @@ void computeSpatialSourceCellsForPencil(const dccrg::Dccrg<SpatialCell,dccrg::Ca
    // Iterate through distances for VLASOV_STENCIL_WIDTH elements starting from the smallest distance.
    // Distances are positive here so smallest distance has smallest value.
    auto iend = distances.begin();
-   std::advance(iend,VLASOV_STENCIL_WIDTH);
+   std::advance(iend,std::min((int)distances.size(), VLASOV_STENCIL_WIDTH));
    for (auto it = distances.begin(); it != iend; ++it) {
       
       // Collect all neighbors at distance *it to a vector
@@ -166,7 +166,7 @@ void computeSpatialSourceCellsForPencil(const dccrg::Dccrg<SpatialCell,dccrg::Ca
       }
    }
 
-   /*loop to neative side and replace all invalid cells with the closest good cell*/
+   /*loop to negative side and replace all invalid cells with the closest good cell*/
    SpatialCell* lastGoodCell = mpiGrid[ids.front()];
    for(int i = VLASOV_STENCIL_WIDTH - 1; i >= 0 ;i--){
       if(sourceCells[i] == NULL) 

--- a/vlasovsolver/cpu_trans_map_amr.hpp
+++ b/vlasovsolver/cpu_trans_map_amr.hpp
@@ -178,7 +178,7 @@ CellID selectNeighbor(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry> 
 void propagatePencil(Vec* dz, Vec* values, const uint dimension, const uint blockGID,
                      const Realv dt,
                      const vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID> &vmesh,
-                     const uint lengthOfPencil, bool debugflag);
+                     const uint lengthOfPencil);
 
 void copy_trans_block_data_amr(
     SpatialCell** source_neighbors,


### PR DESCRIPTION
Fixes for the source cell computation in the AMR translation solver
1. Changed the order that ghost cells on the negative side of the pencil are iterated through.
2. Added a check that prevents iterators from advancing past the end of their respective containers.