### PR TITLE
Fix outflow and ionosphere boundaries to get symmetric B evaluation.

### DIFF
--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -576,6 +576,7 @@ namespace SBC {
                   propagateMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, i, j, k, dt, RKCase, false, false, true);
                   break;
                default:
+                  cerr << "ERROR: ionosphere boundary tried to propagate nonsensical magnetic field component " << component << endl;
                   break;
             }
             return bGrid->get(i,j,k)->at(fsgrids::bfield::PERBX + component);

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -33,6 +33,7 @@
 #include "../vlasovmover.h"
 #include "../fieldsolver/fs_common.h"
 #include "../fieldsolver/fs_limiters.h"
+#include "../fieldsolver/ldz_magnetic_field.hpp"
 #include "../common.h"
 #include "../object_wrapper.h"
 
@@ -554,6 +555,34 @@ namespace SBC {
          bGrid = &perBDt2Grid;
       }
       
+      // Easy case: in case we are neighboured by a non-sysboundary cell, we still solve the
+      // fields normally here.
+      cuint sysBoundaryLayer = technicalGrid.get(i,j,k)->sysBoundaryLayer;
+      if(sysBoundaryLayer == 1) {
+         cint neigh_i=i + ((component==0)?-1:0);
+         cint neigh_j=j + ((component==1)?-1:0);
+         cint neigh_k=k + ((component==2)?-1:0);
+         cuint neighborSysBoundaryFlag = technicalGrid.get(neigh_i, neigh_j, neigh_k)->sysBoundaryFlag;
+
+         if (neighborSysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) {
+            switch(component) {
+               case 0:
+                  propagateMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, i, j, k, dt, RKCase, true, false, false);
+                  break;
+               case 1:
+                  propagateMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, i, j, k, dt, RKCase, false, true, false);
+                  break;
+               case 2:
+                  propagateMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, i, j, k, dt, RKCase, false, false, true);
+                  break;
+               default:
+                  break;
+            }
+            return bGrid->get(i,j,k)->at(fsgrids::bfield::PERBX + component);
+         }
+      }
+
+      // Otherwise:
       // Sum perturbed B component over all nearest NOT_SYSBOUNDARY neighbours
       std::array<Real, 3> averageB = {{ 0.0 }};
       for (uint it = 0; it < closestCells.size(); it++) {

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -359,54 +359,40 @@ namespace SBC {
       determineFace(&isThisCellOnAFace[0], x, y, z, dx, dy, dz, true);
       
       cuint sysBoundaryLayer = technicalGrid.get(i,j,k)->sysBoundaryLayer;
+      if(sysBoundaryLayer == 1) {
+         cint neigh_i=i + ((component==0)?-1:0);
+         cint neigh_j=j + ((component==1)?-1:0);
+         cint neigh_k=k + ((component==2)?-1:0);
+         cuint neighborSysBoundaryFlag = technicalGrid.get(neigh_i, neigh_j, neigh_k)->sysBoundaryFlag;
       
-      if (sysBoundaryLayer == 1
-         && isThisCellOnAFace[0]                            // we are on the face
-         && this->facesToProcess[0]                         // we are supposed to do this face
-         && !this->facesToSkipFields[0]                     // we are not supposed to skip fields on this face
-         && component == 0                                  // we do the component normal to this face
-         && !(isThisCellOnAFace[2] || isThisCellOnAFace[3] || isThisCellOnAFace[4] || isThisCellOnAFace[5]) // we are not in a corner
-      ) {
-         propagateMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, i, j, k, dt, RKCase, true, false, false);
-         if(RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-            fieldValue = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBX + component);
-         } else {
-            fieldValue = perBDt2Grid.get(i,j,k)->at(fsgrids::bfield::PERBX + component);
-         }
-      } else if (sysBoundaryLayer == 1
-         && isThisCellOnAFace[2]                            // we are on the face
-         && this->facesToProcess[2]                         // we are supposed to do this face
-         && !this->facesToSkipFields[2]                     // we are not supposed to skip fields on this face
-         && component == 1                                  // we do the component normal to this face
-         && !(isThisCellOnAFace[0] || isThisCellOnAFace[1] || isThisCellOnAFace[4] || isThisCellOnAFace[5]) // we are not in a corner
-      ) {
-         propagateMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, i, j, k, dt, RKCase, false, true, false);
-         if(RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-            fieldValue = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBX + component);
-         } else {
-            fieldValue = perBDt2Grid.get(i,j,k)->at(fsgrids::bfield::PERBX + component);
-         }
-      } else if (sysBoundaryLayer == 1
-         && isThisCellOnAFace[4]                            // we are on the face
-         && this->facesToProcess[4]                         // we are supposed to do this face
-         && !this->facesToSkipFields[4]                     // we are not supposed to skip fields on this face
-         && component == 2                                  // we do the component normal to this face
-         && !(isThisCellOnAFace[0] || isThisCellOnAFace[1] || isThisCellOnAFace[2] || isThisCellOnAFace[3]) // we are not in a corner
-      ) {
-         propagateMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, i, j, k, dt, RKCase, false, false, true);
-         if(RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-            fieldValue = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBX + component);
-         } else {
-            fieldValue = perBDt2Grid.get(i,j,k)->at(fsgrids::bfield::PERBX + component);
-         }
-      } else {
-         if(RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-            fieldValue = fieldBoundaryCopyFromExistingFaceNbrMagneticField(perBGrid, technicalGrid, i, j, k, component);
-         } else {
-            fieldValue = fieldBoundaryCopyFromExistingFaceNbrMagneticField(perBDt2Grid, technicalGrid, i, j, k, component);
+         if (neighborSysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) {
+            switch(component) {
+               case 0:
+                  propagateMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, i, j, k, dt, RKCase, true, false, false);
+                  break;
+               case 1:
+                  propagateMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, i, j, k, dt, RKCase, false, true, false);
+                  break;
+               case 2:
+                  propagateMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, i, j, k, dt, RKCase, false, false, true);
+                  break;
+               default:
+                  break;
+            }
+            if(RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+               fieldValue = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBX + component);
+            } else {
+               fieldValue = perBDt2Grid.get(i,j,k)->at(fsgrids::bfield::PERBX + component);
+            }
+            return fieldValue;
          }
       }
-      
+
+      if(RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         fieldValue = fieldBoundaryCopyFromExistingFaceNbrMagneticField(perBGrid, technicalGrid, i, j, k, component);
+      } else {
+         fieldValue = fieldBoundaryCopyFromExistingFaceNbrMagneticField(perBDt2Grid, technicalGrid, i, j, k, component);
+      }
       return fieldValue;
    }
 

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -377,6 +377,7 @@ namespace SBC {
                   propagateMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, i, j, k, dt, RKCase, false, false, true);
                   break;
                default:
+                  cerr << "ERROR: outflow boundary tried to propagate nonsensical magnetic field component " << component << endl;
                   break;
             }
             if(RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {


### PR DESCRIPTION
Before, B vectors were always copied in the sysboundary cells, which
caused the Yee-Lattice locations of these components to be asymmetric
wrt. the boundary. Now, it is checking whether the neighbour on the
corresponding components' side is a non-sysboundary and solving the
field normally if it is.

This should increase inner boundary accuracy. Hopefully. Testing in
progress.