### PR TITLE
Warnings reduction

### DIFF
--- a/amr_refinement_criteria.cpp
+++ b/amr_refinement_criteria.cpp
@@ -38,7 +38,7 @@ namespace amr_ref_criteria {
    
    Base* relDiffMaker() {return new RelativeDifference;}
    
-   void Base::evaluate(const Realf* velBlost,Realf* result,const uint popID) {
+   void Base::evaluate(const Realf* velBlost __attribute__((unused)),Realf* result,const uint popID __attribute__((unused))) {
       for (uint i=0; i<WID3; ++i) result[i] = 0.0;
    }
 
@@ -110,7 +110,7 @@ namespace amr_ref_criteria {
       return df;
    }
 
-   bool RelativeDifference::initialize(const std::string& configRegion) {
+   bool RelativeDifference::initialize(const std::string& configRegion __attribute__((unused))) {
       //df_max = 8.0;
       df_max = 1.0;
       return true;

--- a/backgroundfield/backgroundfield.cpp
+++ b/backgroundfield/backgroundfield.cpp
@@ -166,7 +166,6 @@ void setPerturbedField(
    //accurate results also for float simulations
    double accuracy = 1e-17;
    double start[3];
-   double end[3];
    double dx[3];
    unsigned int faceCoord1[3];
    unsigned int faceCoord2[3];
@@ -193,10 +192,6 @@ void setPerturbedField(
             dx[0] = perBGrid.DX;
             dx[1] = perBGrid.DY;
             dx[2] = perBGrid.DZ;
-            
-            end[0]=start[0]+dx[0];
-            end[1]=start[1]+dx[1];
-            end[2]=start[2]+dx[2];
             
             //Face averages
             for(uint fComponent=0; fComponent<3; fComponent++){

--- a/backgroundfield/vectordipole.cpp
+++ b/backgroundfield/vectordipole.cpp
@@ -259,12 +259,12 @@ double VectorDipole::call( double x, double y, double z) const
       //delAx[2] = (-3./(r2*r2*r1))*(q[1]*r[2]-q[2]*r[1])*r[2] +q[1]/(r2*r1);
 
       // Calculate del IMFAx, del IMFAy, del IMFAz
+      //double IMFdelAx[3];
       double IMFdelAy[3];
-      double IMFdelAx[3];
       double IMFdelAz[3];
-      IMFdelAx[0] = 0.;
-      IMFdelAx[1] = -0.5*IMF[2];
-      IMFdelAx[2] =  0.5*IMF[1];
+      //IMFdelAx[0] = 0.;
+      //IMFdelAx[1] = -0.5*IMF[2];
+      //IMFdelAx[2] =  0.5*IMF[1];
       IMFdelAy[0] =  0.5*IMF[2];
       IMFdelAy[1] = 0.0;
       IMFdelAy[2] = -0.5*IMF[0];

--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -49,14 +49,14 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "fg_b" || lowercase == "b") { // Bulk magnetic field at Yee-Lattice locations
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b",[](
                       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
                       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -83,15 +83,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(lowercase == "fg_backgroundb" || lowercase == "backgroundb" || lowercase == "fg_b_background") { // Static (typically dipole) magnetic field part
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_background",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
                       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -116,14 +116,14 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "fg_perturbedb" || lowercase == "perturbedb" || lowercase == "fg_b_perturbed") { // Fluctuating magnetic field part
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_perturbed",[](
                       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -147,15 +147,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(lowercase == "fg_e" || lowercase == "e") { // Bulk electric field at Yee-lattice locations
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_e",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
                       FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -184,15 +184,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(lowercase == "fg_rhom") { // Overall mass density (summed over all populations)
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rhom",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
                       FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -219,15 +219,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(lowercase == "fg_rhoq") { // Overall charge density (summed over all populations)
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rhoq",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
                       FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -264,15 +264,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(lowercase == "fg_v") { // Overall effective bulk density defining the center-of-mass frame from all populations
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_v",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
                       FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -418,15 +418,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "maxfieldsdt" || lowercase == "fg_maxfieldsdt" || lowercase == "fg_maxdt_fieldsolver") {
          // Maximum timestep constraint as calculated by the fieldsolver
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_maxdt_fieldsolver",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -455,15 +455,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "fsgridrank" || lowercase == "fg_rank") {
          // Map of spatial decomposition of the FsGrid into MPI ranks
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rank",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -483,15 +483,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "fsgridboundarytype" || lowercase == "fg_boundarytype") {
          // Type of boundarycells as stored in FSGrid
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_boundarytype",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -520,15 +520,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "fsgridboundarylayer" || lowercase == "fg_boundarylayer") {
          // Type of boundarycells as stored in FSGrid
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_boundarylayer",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -578,15 +578,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          for(int index=0; index<fsgrids::N_EHALL; index++) {
             std::string reducer_name = "fg_e_hall_" + std::to_string(index);
             outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(reducer_name,[index](
-                         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                         FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
+                         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                         FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
                          FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                         FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                         FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                         FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                         FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                         FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                         FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                         FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                         FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                         FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                         FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                          FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                   std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -621,13 +621,13 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(lowercase == "fg_volb" || lowercase == "fg_bvol" || lowercase == "fg_b_vol") { // Static (typically dipole) magnetic field part
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_vol",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
                       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
                       FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
@@ -673,15 +673,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "fg_pressure") {
          // Overall scalar pressure from all populations
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_pressure",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
                       FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -748,15 +748,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(lowercase == "fg_gridcoordinates") { 
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_x",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -775,15 +775,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
 	 outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$X_\\mathrm{fg}$","1.0");
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_y",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -802,15 +802,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
 	 outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$Y_\\mathrm{fg}$","1.0");
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_z",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -829,15 +829,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
 	 outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$Z_\\mathrm{fg}$","1.0");
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_dx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -847,15 +847,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
 	 outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$\\delta X_\\mathrm{fg}$","1.0");
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_dy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
@@ -865,15 +865,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
 	 outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$\\delta Y_\\mathrm{fg}$","1.0");
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_dz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
+                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2>& EHallGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2>& EGradPeGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2>& momentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2>& dPerBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid __attribute__((unused)),
                       FsGrid< fsgrids::technical, 2>& technicalGrid)->std::vector<double> {
 
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();

--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -49,7 +49,7 @@ namespace DRO {
     * @param buffer Buffer in which the reduced data is written.
     * @return If true, DataReductionOperator reduced data successfully.
     */
-   bool DataReductionOperator::reduceData(const SpatialCell* cell,char* buffer) {
+   bool DataReductionOperator::reduceData(const SpatialCell* cell __attribute__((unused)),char* buffer __attribute__((unused))) {
       cerr << "ERROR: DataReductionOperator::reduceData called instead of derived class function! (variable" <<
                getName() << ")" << endl;
       cerr << "       Did you use a diagnostic reducer for writing bulk data?" << endl;
@@ -63,7 +63,7 @@ namespace DRO {
     * @param buffer Buffer in which the reduced data is written.
     * @return If true, DataReductionOperator reduced data successfully.
     */
-   bool DataReductionOperator::reduceDiagnostic(const SpatialCell* cell,Real* result) {
+   bool DataReductionOperator::reduceDiagnostic(const SpatialCell* cell __attribute__((unused)),Real* result __attribute__((unused))) {
       cerr << "ERROR: DataReductionOperator::reduceData called instead of derived class function! (variable " <<
               getName() << ")" << endl;
       cerr << "       Did you use a bulk reducer for writing diagnostic data?" << endl;
@@ -87,7 +87,7 @@ namespace DRO {
 
    std::string DataReductionOperatorCellParams::getName() const {return variableName;}
    
-   bool DataReductionOperatorCellParams::reduceData(const SpatialCell* cell,char* buffer) {
+   bool DataReductionOperatorCellParams::reduceData(const SpatialCell* cell __attribute__((unused)),char* buffer) {
       const char* ptr = reinterpret_cast<const char*>(data);
       for (uint i = 0; i < vectorSize*sizeof(Real); ++i){
          buffer[i] = ptr[i];
@@ -95,7 +95,7 @@ namespace DRO {
       return true;
    }
    
-   bool DataReductionOperatorCellParams::reduceDiagnostic(const SpatialCell* cell,Real* buffer){
+   bool DataReductionOperatorCellParams::reduceDiagnostic(const SpatialCell* cell __attribute__((unused)),Real* buffer){
       //If vectorSize is >1 it still works, we just give the first value and no other ones..
       *buffer=data[0];
       return true;
@@ -118,14 +118,14 @@ namespace DRO {
       vectorSize = 1;
       return true;
    }
-   bool DataReductionOperatorFsGrid::reduceData(const SpatialCell* cell,char* buffer) {
+   bool DataReductionOperatorFsGrid::reduceData(const SpatialCell* cell __attribute__((unused)),char* buffer __attribute__((unused))) {
       // This returns false, since it will handle writing itself in writeFsGridData below.
       return false;
    }
-   bool DataReductionOperatorFsGrid::reduceDiagnostic(const SpatialCell* cell,Real * result) {
+   bool DataReductionOperatorFsGrid::reduceDiagnostic(const SpatialCell* cell __attribute__((unused)),Real * result __attribute__((unused))) {
       return false;
    }
-   bool DataReductionOperatorFsGrid::setSpatialCell(const SpatialCell* cell) {
+   bool DataReductionOperatorFsGrid::setSpatialCell(const SpatialCell* cell __attribute__((unused))) {
       return true;
    }
    
@@ -187,7 +187,7 @@ namespace DRO {
    
    std::string VariableBVol::getName() const {return "vg_b_vol";}
    
-   bool VariableBVol::reduceData(const SpatialCell* cell,char* buffer) {
+   bool VariableBVol::reduceData(const SpatialCell* cell __attribute__((unused)),char* buffer) {
       const char* ptr = reinterpret_cast<const char*>(B);
       for (uint i = 0; i < 3*sizeof(Real); ++i) buffer[i] = ptr[i];
       return true;
@@ -220,13 +220,13 @@ namespace DRO {
    
    std::string MPIrank::getName() const {return "vg_rank";}
    
-   bool MPIrank::reduceData(const SpatialCell* cell,char* buffer) {
+   bool MPIrank::reduceData(const SpatialCell* cell __attribute__((unused)),char* buffer) {
       const char* ptr = reinterpret_cast<const char*>(&mpiRank);
       for (uint i = 0; i < sizeof(int); ++i) buffer[i] = ptr[i];
       return true;
    }
    
-   bool MPIrank::setSpatialCell(const SpatialCell* cell) {
+   bool MPIrank::setSpatialCell(const SpatialCell* cell __attribute__((unused))) {
       int intRank;
       MPI_Comm_rank(MPI_COMM_WORLD,&intRank);
       rank = 1.0*intRank;
@@ -247,7 +247,7 @@ namespace DRO {
    
    std::string BoundaryType::getName() const {return "vg_boundarytype";}
    
-   bool BoundaryType::reduceData(const SpatialCell* cell,char* buffer) {
+   bool BoundaryType::reduceData(const SpatialCell* cell __attribute__((unused)),char* buffer) {
       const char* ptr = reinterpret_cast<const char*>(&boundaryType);
       for (uint i = 0; i < sizeof(int); ++i) buffer[i] = ptr[i];
       return true;
@@ -272,7 +272,7 @@ namespace DRO {
    
    std::string BoundaryLayer::getName() const {return "vg_boundarylayer";}
    
-   bool BoundaryLayer::reduceData(const SpatialCell* cell,char* buffer) {
+   bool BoundaryLayer::reduceData(const SpatialCell* cell __attribute__((unused)),char* buffer) {
       const char* ptr = reinterpret_cast<const char*>(&boundaryLayer);
       for (uint i = 0; i < sizeof(int); ++i) buffer[i] = ptr[i];
       return true;
@@ -298,13 +298,13 @@ namespace DRO {
    
    std::string Blocks::getName() const {return popName + "/vg_blocks";}
    
-   bool Blocks::reduceData(const SpatialCell* cell,char* buffer) {
+   bool Blocks::reduceData(const SpatialCell* cell __attribute__((unused)),char* buffer) {
       const char* ptr = reinterpret_cast<const char*>(&nBlocks);
       for (uint i = 0; i < sizeof(int); ++i) buffer[i] = ptr[i];
       return true;
    }
    
-   bool Blocks::reduceDiagnostic(const SpatialCell* cell,Real* buffer) {
+   bool Blocks::reduceDiagnostic(const SpatialCell* cell __attribute__((unused)),Real* buffer) {
       *buffer = 1.0 * nBlocks;
       return true;
    }
@@ -327,7 +327,7 @@ namespace DRO {
       return true;
    }
    
-   bool VariablePressureSolver::reduceData(const SpatialCell* cell,char* buffer) {
+   bool VariablePressureSolver::reduceData(const SpatialCell* cell __attribute__((unused)),char* buffer) {
       const char* ptr = reinterpret_cast<const char*>(&Pressure);
       for (uint i = 0; i < sizeof(Real); ++i) buffer[i] = ptr[i];
       return true;
@@ -541,7 +541,7 @@ namespace DRO {
       return true;
    }
    
-   bool MaxDistributionFunction::setSpatialCell(const SpatialCell* cell) {
+   bool MaxDistributionFunction::setSpatialCell(const SpatialCell* cell __attribute__((unused))) {
       return true;
    }
    
@@ -595,7 +595,7 @@ namespace DRO {
       return true;
    }
    
-   bool MinDistributionFunction::setSpatialCell(const SpatialCell* cell) {
+   bool MinDistributionFunction::setSpatialCell(const SpatialCell* cell __attribute__((unused))) {
       return true;
    }
 
@@ -717,7 +717,6 @@ namespace DRO {
 
    //Calculates rho thermal or rho non-thermal
    static void rhoNonthermalCalculation( const SpatialCell * cell, const bool calculateNonthermal, cuint popID, Real & rho ) {
-      const Real HALF = 0.5;
       # pragma omp parallel
       {
          Real thread_n_sum = 0.0;
@@ -956,14 +955,14 @@ namespace DRO {
    
    std::string VariableMeshData::getName() const {return "vg_meshdata";}
    
-   bool VariableMeshData::getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const {
+   bool VariableMeshData::getDataVectorInfo(std::string& dataType __attribute__((unused)),unsigned int& dataSize __attribute__((unused)),unsigned int& vectorSize __attribute__((unused))) const {
       return true;
    }
    
-   bool VariableMeshData::setSpatialCell(const SpatialCell* cell) {return true;}
+   bool VariableMeshData::setSpatialCell(const SpatialCell* cell __attribute__((unused))) {return true;}
    
-   bool VariableMeshData::writeData(const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-                                    const std::vector<CellID>& cells,const std::string& meshName,
+   bool VariableMeshData::writeData(const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid __attribute__((unused)),
+                                    const std::vector<CellID>& cells __attribute__((unused)),const std::string& meshName,
                                     vlsv::Writer& vlsvWriter) {
       bool success = true;
       for (size_t i = 0; i < getObjectWrapper().meshData.size(); ++i) {
@@ -1016,7 +1015,7 @@ namespace DRO {
       return true;
    }
    
-   bool VariableRhoNonthermal::setSpatialCell(const SpatialCell* cell) {
+   bool VariableRhoNonthermal::setSpatialCell(const SpatialCell* cell __attribute__((unused))) {
       RhoNonthermal = 0.0;
       return true;
    }
@@ -1045,7 +1044,7 @@ namespace DRO {
       return true;
    }
    
-   bool VariableRhoThermal::setSpatialCell(const SpatialCell* cell) {
+   bool VariableRhoThermal::setSpatialCell(const SpatialCell* cell __attribute__((unused))) {
       RhoThermal = 0.0;
       return true;
    }
@@ -1076,7 +1075,7 @@ namespace DRO {
       return true;
    }
    
-   bool VariableVNonthermal::setSpatialCell(const SpatialCell* cell) {
+   bool VariableVNonthermal::setSpatialCell(const SpatialCell* cell __attribute__((unused))) {
       // Initialize values
       for( uint i = 0; i < 3; ++i ) {
          VNonthermal[i] = 0.0;
@@ -1110,7 +1109,7 @@ namespace DRO {
       return true;
    }
    
-   bool VariableVThermal::setSpatialCell(const SpatialCell* cell) {
+   bool VariableVThermal::setSpatialCell(const SpatialCell* cell __attribute__((unused))) {
       // Initialize values
       for( uint i = 0; i < 3; ++i ) {
          VThermal[i] = 0.0;
@@ -1230,7 +1229,6 @@ namespace DRO {
       const bool calculateNonthermal = true;
       //Calculate and save:
       PTensorOffDiagonalNonthermalCalculations( cell, calculateNonthermal, averageVX, averageVY, averageVZ, popID, PTensor );
-      const uint vectorSize = 3;
       //Input data into buffer
       const char* ptr = reinterpret_cast<const char*>(&PTensor);
       for (uint i = 0; i < 3*sizeof(Real); ++i) buffer[i] = ptr[i];
@@ -1270,7 +1268,6 @@ namespace DRO {
       const bool calculateNonthermal = false;
       //Calculate and save:
       PTensorOffDiagonalNonthermalCalculations( cell, calculateNonthermal, averageVX, averageVY, averageVZ, popID, PTensor );
-      const uint vectorSize = 3;
       //Input data into buffer
       const char* ptr = reinterpret_cast<const char*>(&PTensor);
       for (uint i = 0; i < 3*sizeof(Real); ++i) buffer[i] = ptr[i];
@@ -1318,7 +1315,7 @@ namespace DRO {
       return true;
    }
 
-   bool VariableEffectiveSparsityThreshold::setSpatialCell(const spatial_cell::SpatialCell* cell) {
+   bool VariableEffectiveSparsityThreshold::setSpatialCell(const spatial_cell::SpatialCell* cell __attribute__((unused))) {
       return true;
    }
 
@@ -1367,7 +1364,6 @@ namespace DRO {
 
       // Unit B-field direction
       creal normB = sqrt(B[0]*B[0] + B[1]*B[1] + B[2]*B[2]);
-      std::array<Real,3> b_unit;
       for (uint i=0; i<3; i++){
          B[i] /= normB;
       }
@@ -1445,7 +1441,7 @@ namespace DRO {
       return true;
    }
    
-   bool VariablePrecipitationDiffFlux::setSpatialCell(const SpatialCell* cell) {
+   bool VariablePrecipitationDiffFlux::setSpatialCell(const SpatialCell* cell __attribute__((unused))) {
       return true;
    }
 
@@ -1551,7 +1547,7 @@ namespace DRO {
       return true;
    }
    
-   bool VariableEnergyDensity::setSpatialCell(const SpatialCell* cell) {
+   bool VariableEnergyDensity::setSpatialCell(const SpatialCell* cell __attribute__((unused))) {
       return true;
    }
    

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -73,7 +73,7 @@ template <typename T, int stencil> void computeCoupling(dccrg::Dccrg<SpatialCell
   }
 
   // Compute where to send data and what to send
-  for(int i=0; i< dccrgCells.size(); i++) {
+  for(uint i=0; i< dccrgCells.size(); i++) {
      //compute to which processes this cell maps
      std::vector<CellID> fsCells = mapDccrgIdToFsGridGlobalID(mpiGrid, dccrgCells[i]);
 

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -206,6 +206,7 @@ void getFieldsFromFsGrid(
       for(int i = 0; i < fieldsToCommunicate; i++){
          this->sums[i] += rhs.sums[i];
       }
+      return *this;
     }
   };
 

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -58,16 +58,16 @@ template <typename T, int stencil> void computeCoupling(dccrg::Dccrg<SpatialCell
   for (int k=0; k<gridDims[2]; k++) {
     for (int j=0; j<gridDims[1]; j++) {
       for (int i=0; i<gridDims[0]; i++) {
-	const std::array<int, 3> globalIndices = momentsGrid.getGlobalIndices(i,j,k);
-	const dccrg::Types<3>::indices_t  indices = {{(uint64_t)globalIndices[0],
-						      (uint64_t)globalIndices[1],
-						      (uint64_t)globalIndices[2]}}; //cast to avoid warnings
-	CellID dccrgCell = mpiGrid.get_existing_cell(indices, 0, mpiGrid.mapping.get_maximum_refinement_level());
-	int process = mpiGrid.get_process(dccrgCell);
-	int64_t  fsgridLid = momentsGrid.LocalIDForCoords(i,j,k);
-	int64_t  fsgridGid = momentsGrid.GlobalIDForCoords(i,j,k);
-	onFsgridMapRemoteProcess[process].insert(dccrgCell); //cells are ordered (sorted) in set
-	onFsgridMapCells[dccrgCell].push_back(fsgridLid);
+         const std::array<int, 3> globalIndices = momentsGrid.getGlobalIndices(i,j,k);
+         const dccrg::Types<3>::indices_t  indices = {{(uint64_t)globalIndices[0],
+            (uint64_t)globalIndices[1],
+            (uint64_t)globalIndices[2]}}; //cast to avoid warnings
+         CellID dccrgCell = mpiGrid.get_existing_cell(indices, 0, mpiGrid.mapping.get_maximum_refinement_level());
+         int process = mpiGrid.get_process(dccrgCell);
+         int64_t  fsgridLid = momentsGrid.LocalIDForCoords(i,j,k);
+         //int64_t  fsgridGid = momentsGrid.GlobalIDForCoords(i,j,k);
+         onFsgridMapRemoteProcess[process].insert(dccrgCell); //cells are ordered (sorted) in set
+         onFsgridMapCells[dccrgCell].push_back(fsgridLid);
       }
     }
   }
@@ -81,7 +81,7 @@ template <typename T, int stencil> void computeCoupling(dccrg::Dccrg<SpatialCell
      for (auto const &fsCellID : fsCells) {
        int process = momentsGrid.getTaskForGlobalID(fsCellID).first; //process on fsgrid
        onDccrgMapRemoteProcess[process].insert(dccrgCells[i]); //add to map
-     }    
+     }
   }
 }
 
@@ -120,7 +120,7 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
     int count = receives.second.size();
     receivedData[process].resize(count * fsgrids::moments::N_MOMENTS);
     MPI_Irecv(receivedData[process].data(), count * fsgrids::moments::N_MOMENTS * sizeof(Real),
-	      MPI_BYTE, process, 1, MPI_COMM_WORLD,&(receiveRequests[ii++]));
+          MPI_BYTE, process, 1, MPI_COMM_WORLD,&(receiveRequests[ii++]));
   }
   
   // Launch sends
@@ -133,28 +133,28 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
       //Collect data to send for this dccrg cell
       auto cellParams = mpiGrid[sendCell]->get_cell_parameters();
       if(!dt2) {
-        sendBuffer.push_back(cellParams[CellParams::RHOM]);
-	sendBuffer.push_back(cellParams[CellParams::RHOQ]);
-	sendBuffer.push_back(cellParams[CellParams::VX]);
-	sendBuffer.push_back(cellParams[CellParams::VY]);
-        sendBuffer.push_back(cellParams[CellParams::VZ]);
-	sendBuffer.push_back(cellParams[CellParams::P_11]);
-	sendBuffer.push_back(cellParams[CellParams::P_22]);
-        sendBuffer.push_back(cellParams[CellParams::P_33]);
+         sendBuffer.push_back(cellParams[CellParams::RHOM]);
+         sendBuffer.push_back(cellParams[CellParams::RHOQ]);
+         sendBuffer.push_back(cellParams[CellParams::VX]);
+         sendBuffer.push_back(cellParams[CellParams::VY]);
+         sendBuffer.push_back(cellParams[CellParams::VZ]);
+         sendBuffer.push_back(cellParams[CellParams::P_11]);
+         sendBuffer.push_back(cellParams[CellParams::P_22]);
+         sendBuffer.push_back(cellParams[CellParams::P_33]);
       } else {
-        sendBuffer.push_back(cellParams[CellParams::RHOM_DT2]);
-	sendBuffer.push_back(cellParams[CellParams::RHOQ_DT2]);
-	sendBuffer.push_back(cellParams[CellParams::VX_DT2]);
-	sendBuffer.push_back(cellParams[CellParams::VY_DT2]);
-        sendBuffer.push_back(cellParams[CellParams::VZ_DT2]);
-	sendBuffer.push_back(cellParams[CellParams::P_11_DT2]);
-	sendBuffer.push_back(cellParams[CellParams::P_22_DT2]);
-        sendBuffer.push_back(cellParams[CellParams::P_33_DT2]);
+         sendBuffer.push_back(cellParams[CellParams::RHOM_DT2]);
+         sendBuffer.push_back(cellParams[CellParams::RHOQ_DT2]);
+         sendBuffer.push_back(cellParams[CellParams::VX_DT2]);
+         sendBuffer.push_back(cellParams[CellParams::VY_DT2]);
+         sendBuffer.push_back(cellParams[CellParams::VZ_DT2]);
+         sendBuffer.push_back(cellParams[CellParams::P_11_DT2]);
+         sendBuffer.push_back(cellParams[CellParams::P_22_DT2]);
+         sendBuffer.push_back(cellParams[CellParams::P_33_DT2]);
       }
     }
     int count = sendBuffer.size(); //note, compared to receive this includes all elements to be sent
-    MPI_Isend(sendBuffer.data(), sendBuffer.size() * sizeof(Real),
-	      MPI_BYTE, targetProc, 1, MPI_COMM_WORLD,&(sendRequests[ii]));
+    MPI_Isend(sendBuffer.data(), count * sizeof(Real),
+          MPI_BYTE, targetProc, 1, MPI_COMM_WORLD,&(sendRequests[ii]));
     ii++;
   }
 
@@ -167,10 +167,10 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
     for(auto const &cell: receives.second){ //loop over cellids (dccrg) for receive
       // this part heavily relies on both sender and receiver having cellids sorted!
       for(auto lid: onFsgridMapCells[cell]){
-	std::array<Real, fsgrids::moments::N_MOMENTS> * fsgridData = momentsGrid.get(lid);
-	for(int l = 0; l < fsgrids::moments::N_MOMENTS; l++)   {
-	  fsgridData->at(l) = receiveBuffer[l];
-	}
+         std::array<Real, fsgrids::moments::N_MOMENTS> * fsgridData = momentsGrid.get(lid);
+         for(int l = 0; l < fsgrids::moments::N_MOMENTS; l++)   {
+            fsgridData->at(l) = receiveBuffer[l];
+         }
       }
       
       receiveBuffer+=fsgrids::moments::N_MOMENTS;
@@ -198,18 +198,18 @@ void getFieldsFromFsGrid(
     Average()  {
       cells = 0;
       for(int i = 0; i < fieldsToCommunicate; i++){
-	sums[i] = 0;
+         sums[i] = 0;
       }
     }
     Average operator+=(const Average& rhs) {
       this->cells += rhs.cells;
       for(int i = 0; i < fieldsToCommunicate; i++){
-	this->sums[i] += rhs.sums[i];
+         this->sums[i] += rhs.sums[i];
       }
     }
   };
 
-    
+
   int ii;
   //sorted list of dccrg cells. cells is typicall already sorted, but just to make sure....
   std::vector<CellID> dccrgCells = cells;

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -423,7 +423,6 @@ REAL JXBZ_110_111(
  * \param EHallGrid fsGrid holding the Hall contributions to the electric field
  * \param momentsGrid fsGrid holding the moment quantities
  * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derviatives of moments
  * \param BgBGrid fsGrid holding the background B quantities
  * \param technicalGrid fsGrid holding technical information (such as boundary types)
  * \param perturbedCoefficients Reconstruction coefficients
@@ -437,7 +436,6 @@ void calculateEdgeHallTermXComponents(
    FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2> & EHallGrid,
    FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> & momentsGrid,
    FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2> & dMomentsGrid,
    FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2> & BgBGrid,
    FsGrid< fsgrids::technical, 2> & technicalGrid,
    const Real* const perturbedCoefficients,
@@ -521,7 +519,6 @@ void calculateEdgeHallTermXComponents(
  * \param EHallGrid fsGrid holding the Hall contributions to the electric field
  * \param momentsGrid fsGrid holding the moment quantities
  * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derviatives of moments
  * \param BgBGrid fsGrid holding the background B quantities
  * \param technicalGrid fsGrid holding technical information (such as boundary types)
  * \param perturbedCoefficients Reconstruction coefficients
@@ -535,7 +532,6 @@ void calculateEdgeHallTermYComponents(
    FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2> & EHallGrid,
    FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> & momentsGrid,
    FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2> & dMomentsGrid,
    FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2> & BgBGrid,
    FsGrid< fsgrids::technical, 2> & technicalGrid,
    const Real* const perturbedCoefficients,
@@ -619,7 +615,6 @@ void calculateEdgeHallTermYComponents(
  * \param EHallGrid fsGrid holding the Hall contributions to the electric field
  * \param momentsGrid fsGrid holding the moment quantities
  * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derviatives of moments
  * \param BgBGrid fsGrid holding the background B quantities
  * \param technicalGrid fsGrid holding technical information (such as boundary types)
  * \param perturbedCoefficients Reconstruction coefficients
@@ -633,7 +628,6 @@ void calculateEdgeHallTermZComponents(
    FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2> & EHallGrid,
    FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> & momentsGrid,
    FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2> & dMomentsGrid,
    FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2> & BgBGrid,
    FsGrid< fsgrids::technical, 2> & technicalGrid,
    const Real* const perturbedCoefficients,
@@ -715,7 +709,6 @@ void calculateEdgeHallTermZComponents(
  * \param EHallGrid fsGrid holding the Hall contributions to the electric field
  * \param momentsGrid fsGrid holding the moment quantities
  * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derviatives of moments
  * \param BgBGrid fsGrid holding the background B quantities
  * \param technicalGrid fsGrid holding technical information (such as boundary types)
  * \param sysBoundaries System boundary condition functions.
@@ -728,7 +721,6 @@ void calculateHallTerm(
    FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2> & EHallGrid,
    FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> & momentsGrid,
    FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2> & dMomentsGrid,
    FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2> & BgBGrid,
    FsGrid< fsgrids::technical, 2> & technicalGrid,
    SysBoundary& sysBoundaries,
@@ -767,9 +759,9 @@ void calculateHallTerm(
       sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondHallElectricField(EHallGrid, i, j, k, 1);
       sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondHallElectricField(EHallGrid, i, j, k, 2);
    } else {
-      calculateEdgeHallTermXComponents(perBGrid, EHallGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, technicalGrid, perturbedCoefficients, i, j, k);
-      calculateEdgeHallTermYComponents(perBGrid, EHallGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, technicalGrid, perturbedCoefficients, i, j, k);
-      calculateEdgeHallTermZComponents(perBGrid, EHallGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, technicalGrid, perturbedCoefficients, i, j, k);
+      calculateEdgeHallTermXComponents(perBGrid, EHallGrid, momentsGrid, dPerBGrid, BgBGrid, technicalGrid, perturbedCoefficients, i, j, k);
+      calculateEdgeHallTermYComponents(perBGrid, EHallGrid, momentsGrid, dPerBGrid, BgBGrid, technicalGrid, perturbedCoefficients, i, j, k);
+      calculateEdgeHallTermZComponents(perBGrid, EHallGrid, momentsGrid, dPerBGrid, BgBGrid, technicalGrid, perturbedCoefficients, i, j, k);
    }
 
 }
@@ -784,7 +776,6 @@ void calculateHallTerm(
  * \param momentsGrid fsGrid holding the moment quantities
  * \param momentsDt2Grid fsGrid holding the moment quantities at runge-kutta half step
  * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derviatives of moments
  * \param BgBGrid fsGrid holding the background B quantities
  * \param technicalGrid fsGrid holding technical information (such as boundary types)
  * \param sysBoundaries System boundary condition functions.
@@ -800,12 +791,10 @@ void calculateHallTermSimple(
    FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> & momentsGrid,
    FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> & momentsDt2Grid,
    FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2> & dMomentsGrid,
    FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2> & BgBGrid,
    FsGrid< fsgrids::technical, 2> & technicalGrid,
    SysBoundary& sysBoundaries,
-   cint& RKCase,
-   const bool communicateMomentsDerivatives
+   cint& RKCase
 ) {
    int timer;
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
@@ -816,9 +805,6 @@ void calculateHallTermSimple(
    timer=phiprof::initializeTimer("MPI","MPI");
    phiprof::start(timer);
    dPerBGrid.updateGhostCells();
-   if(communicateMomentsDerivatives) {
-      dMomentsGrid.updateGhostCells();
-   }
    phiprof::stop(timer);
    
    phiprof::start("Compute cells");
@@ -827,9 +813,9 @@ void calculateHallTermSimple(
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
             if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-               calculateHallTerm(perBGrid, EHallGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, technicalGrid,sysBoundaries, i, j, k);
+               calculateHallTerm(perBGrid, EHallGrid, momentsGrid, dPerBGrid, BgBGrid, technicalGrid,sysBoundaries, i, j, k);
             } else {
-               calculateHallTerm(perBDt2Grid, EHallGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, BgBGrid, technicalGrid,sysBoundaries, i, j, k);
+               calculateHallTerm(perBDt2Grid, EHallGrid, momentsDt2Grid, dPerBGrid, BgBGrid, technicalGrid,sysBoundaries, i, j, k);
             }
          }
       }

--- a/fieldsolver/ldz_hall.hpp
+++ b/fieldsolver/ldz_hall.hpp
@@ -27,12 +27,10 @@ void calculateHallTermSimple(
    FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> & momentsGrid,
    FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> & momentsDt2Grid,
    FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2> & dMomentsGrid,
    FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2> & BgBGrid,
    FsGrid< fsgrids::technical, 2> & technicalGrid,
    SysBoundary& sysBoundaries,
-   cint& RKCase,
-   const bool communicateMomentsDerivatives
+   cint& RKCase
 );
 
 #endif

--- a/fieldsolver/ldz_main.cpp
+++ b/fieldsolver/ldz_main.cpp
@@ -107,8 +107,6 @@ bool propagateFields(
       exit(1);
    }
    
-   bool hallTermCommunicateDerivatives = true;
-   
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    
    #pragma omp parallel for collapse(3)
@@ -127,7 +125,6 @@ bool propagateFields(
       calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER1, true);
       if(P::ohmGradPeTerm > 0){
          calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER1);
-         hallTermCommunicateDerivatives = false;
       }
       if(P::ohmHallTerm > 0) {
          calculateHallTermSimple(
@@ -137,12 +134,10 @@ bool propagateFields(
             momentsGrid,
             momentsDt2Grid,
             dPerBGrid,
-            dMomentsGrid,
             BgBGrid,
             technicalGrid,
             sysBoundaries,
             RK_ORDER1,
-            hallTermCommunicateDerivatives
          );
       }
       calculateUpwindedElectricFieldSimple(
@@ -166,7 +161,6 @@ bool propagateFields(
       calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1, true);
       if(P::ohmGradPeTerm > 0) {
          calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1);
-         hallTermCommunicateDerivatives = false;
       }
       if(P::ohmHallTerm > 0) {
          calculateHallTermSimple(
@@ -176,12 +170,10 @@ bool propagateFields(
             momentsGrid,
             momentsDt2Grid,
             dPerBGrid,
-            dMomentsGrid,
             BgBGrid,
             technicalGrid,
             sysBoundaries,
-            RK_ORDER2_STEP1,
-            hallTermCommunicateDerivatives
+            RK_ORDER2_STEP1
          );
       }
       calculateUpwindedElectricFieldSimple(
@@ -205,7 +197,6 @@ bool propagateFields(
       calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2, true);
       if(P::ohmGradPeTerm > 0) {
          calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2);
-         hallTermCommunicateDerivatives = false;
       }
       if(P::ohmHallTerm > 0) {
          calculateHallTermSimple(
@@ -215,12 +206,10 @@ bool propagateFields(
             momentsGrid,
             momentsDt2Grid,
             dPerBGrid,
-            dMomentsGrid,
             BgBGrid,
             technicalGrid,
             sysBoundaries,
-            RK_ORDER2_STEP2,
-            hallTermCommunicateDerivatives
+            RK_ORDER2_STEP2
          );
       }
       calculateUpwindedElectricFieldSimple(
@@ -258,7 +247,6 @@ bool propagateFields(
          calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1, (subcycleCount==0));
          if(P::ohmGradPeTerm > 0 && subcycleCount==0) {
             calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1);
-            hallTermCommunicateDerivatives = false;
          }
          if(P::ohmHallTerm > 0) {
             calculateHallTermSimple(
@@ -268,12 +256,10 @@ bool propagateFields(
                momentsGrid,
                momentsDt2Grid,
                dPerBGrid,
-               dMomentsGrid,
                BgBGrid,
                technicalGrid,
                sysBoundaries,
-               RK_ORDER2_STEP1,
-               hallTermCommunicateDerivatives
+               RK_ORDER2_STEP1
             );
          }
          calculateUpwindedElectricFieldSimple(
@@ -300,7 +286,6 @@ bool propagateFields(
          calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2, (subcycleCount==0));
          if(P::ohmGradPeTerm > 0 && subcycleCount==0) {
             calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2);
-            hallTermCommunicateDerivatives = false;
          }
          if(P::ohmHallTerm > 0) {
             calculateHallTermSimple(
@@ -310,12 +295,10 @@ bool propagateFields(
                momentsGrid,
                momentsDt2Grid,
                dPerBGrid,
-               dMomentsGrid,
                BgBGrid,
                technicalGrid,
                sysBoundaries,
-               RK_ORDER2_STEP2,
-               hallTermCommunicateDerivatives
+               RK_ORDER2_STEP2
             );
          }
          calculateUpwindedElectricFieldSimple(
@@ -406,7 +389,7 @@ bool propagateFields(
       }
    }
    
-   calculateVolumeAveragedFields(perBGrid,EGrid,dPerBGrid,volGrid,technicalGrid);
+   calculateVolumeAveragedFields(perBGrid,dPerBGrid,volGrid,technicalGrid);
    calculateBVOLDerivativesSimple(volGrid, technicalGrid, sysBoundaries);
    return true;
 }

--- a/fieldsolver/ldz_volume.cpp
+++ b/fieldsolver/ldz_volume.cpp
@@ -33,7 +33,6 @@ using namespace std;
 
 void calculateVolumeAveragedFields(
    FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EGrid,
    FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2> & dPerBGrid,
    FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2> & volGrid,
    FsGrid< fsgrids::technical, 2> & technicalGrid

--- a/fieldsolver/ldz_volume.hpp
+++ b/fieldsolver/ldz_volume.hpp
@@ -27,13 +27,12 @@
 
 /*! \brief Top-level field averaging function.
  * 
- * Averages the electric and magnetic fields over the cell volumes.
+ * Averages the magnetic fields over the cell volumes.
  * 
  * \sa reconstructionCoefficients
  */
 void calculateVolumeAveragedFields(
    FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EGrid,
    FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2> & dPerBGrid,
    FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2> & volGrid,
    FsGrid< fsgrids::technical, 2> & technicalGrid

--- a/grid.h
+++ b/grid.h
@@ -41,8 +41,6 @@ void initializeGrids(
    FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> & momentsGrid,
    FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, 2> & momentsDt2Grid,
    FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2> & volGrid,
    FsGrid< fsgrids::technical, 2>& technicalGrid,
    SysBoundary& sysBoundaries,
    Project& project

--- a/ioread.h
+++ b/ioread.h
@@ -39,7 +39,6 @@
 bool readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
       FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2>& EGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid,
               const std::string& name);
 
 

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -901,7 +901,7 @@ bool writeFsGridMetadata(FsGrid< fsgrids::technical, 2>& technicalGrid, vlsv::Wr
 
 
   // writeDomainSizes
-  std::array<uint32_t,2> meshDomainSize({globalIds.size(), 0});
+  std::array<uint32_t,2> meshDomainSize({(uint32_t)globalIds.size(), 0});
   vlsvWriter.writeArray("MESH_DOMAIN_SIZES", xmlAttributes, 1, 2, &meshDomainSize[0]);
 
   // how many MPI ranks we wrote from
@@ -949,7 +949,7 @@ bool writeVelocitySpace(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
 	 // Loop over AMR levels
 	 uint startindex=1;
 	 uint endindex=1;
-	 for (uint AMR = 0; AMR <= P::amrMaxSpatialRefLevel; AMR++) {
+	 for (int AMR = 0; AMR <= P::amrMaxSpatialRefLevel; AMR++) {
 	    uint AMRm = std::floor(std::pow(2,AMR));
 	    uint cellsthislevel = (AMRm*P::xcells_ini)*(AMRm*P::ycells_ini)*(AMRm*P::zcells_ini);
 	    startindex = endindex;

--- a/iowrite.h
+++ b/iowrite.h
@@ -76,7 +76,6 @@ bool writeRestart(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
       FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
       FsGrid< fsgrids::technical, 2>& technicalGrid,
-                  DataReducer& dataReducer,
                   const std::string& name,
                   const uint& fileIndex,
                   const int& stripe);
@@ -94,6 +93,6 @@ bool writeVelocitySpace(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
                         vlsv::Writer& vlsvWriter,int index,const std::vector<uint64_t>& cells);
 
 bool writeVelocityDistributionData(vlsv::Writer& vlsvWriter,dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-                                   const std::vector<uint64_t>& cells,MPI_Comm comm);
+                                   const std::vector<uint64_t>& cells);
 
 #endif

--- a/memoryallocation.h
+++ b/memoryallocation.h
@@ -153,7 +153,7 @@ public:
    // Returns true if and only if storage allocated from *this
    // can be deallocated from other, and vice versa.
    // Always returns true for stateless allocators.
-   bool operator==(const aligned_allocator& other) const
+   bool operator==(const aligned_allocator& other __attribute__((unused))) const
       {
          return true;
       }

--- a/object_wrapper.cpp
+++ b/object_wrapper.cpp
@@ -92,8 +92,6 @@ bool ObjectWrapper::getParameters() {
    typedef Readparameters RP;
    
    // Particle population parameters
-   unsigned int popCounter=0;
-
    for(unsigned int i =0; i < getObjectWrapper().particleSpecies.size(); i++) {
 
       species::Species& species=getObjectWrapper().particleSpecies[i];

--- a/projects/Alfven/Alfven.cpp
+++ b/projects/Alfven/Alfven.cpp
@@ -100,7 +100,9 @@ namespace projects {
 
    /*Real calcPhaseSpaceDensity(creal& z,creal& x,creal& y,creal& dz,creal& dx,creal& dy,
                creal& vz,creal& vx,creal& vy,creal& dvz,creal& dvx,creal& dvy) {*/
-   Real Alfven::getDistribValue(creal& x, creal& y, creal& z, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,const uint popID) const {
+   Real Alfven::getDistribValue(creal& x, creal& y, creal& z __attribute__((unused)),
+         creal& vx, creal& vy, creal& vz,
+         creal& dvx __attribute__((unused)), creal& dvy __attribute__((unused)), creal& dvz __attribute__((unused)),const uint popID) const {
       const AlfvenSpeciesParameters& sP = speciesParams[popID];
       creal mass = getObjectWrapper().particleSpecies[popID].mass;
       creal kb = physicalconstants::K_B;
@@ -138,7 +140,7 @@ namespace projects {
       return avg / pow(this->nSpaceSamples, 3.0) / pow(sP.nVelocitySamples, 3.0);
    }
    
-   void Alfven::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {
+   void Alfven::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t __attribute__((unused))) {
       Real* cellParams = cell->get_cell_parameters();
       creal x = cellParams[CellParams::XCRD];
       creal dx = cellParams[CellParams::DX];
@@ -158,14 +160,14 @@ namespace projects {
          dByavg += sin(2.0 * M_PI * ksi);
          dBzavg += cos(2.0 * M_PI * ksi);
       }
-      cuint nPts = pow(this->nSpaceSamples, 3.0);
+      //cuint nPts = pow(this->nSpaceSamples, 3.0);
       
    }
    
    void Alfven::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       setBackgroundFieldToZero(BgBGrid);
       

--- a/projects/Diffusion/Diffusion.cpp
+++ b/projects/Diffusion/Diffusion.cpp
@@ -83,7 +83,7 @@ namespace projects {
    }
 
    Real Diffusion::getDistribValue(
-      creal& x,creal& y,creal& z,
+      creal& x,creal& y,creal& z __attribute__((unused)),
       creal& vx,creal& vy,creal& vz,
       const uint popID
    ) const {
@@ -119,12 +119,12 @@ namespace projects {
       return avg / (sP.nSpaceSamples*sP.nSpaceSamples*sP.nSpaceSamples) / (sP.nVelocitySamples*sP.nVelocitySamples*sP.nVelocitySamples);
    }
    
-   void Diffusion::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void Diffusion::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
 
    void Diffusion::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       ConstantField bgField;
       bgField.initialize(0,0,this->B0); //bg bx, by,bz

--- a/projects/Dispersion/Dispersion.cpp
+++ b/projects/Dispersion/Dispersion.cpp
@@ -137,7 +137,11 @@ namespace projects {
       return exp(- mass * ((vx-sP.VX0)*(vx-sP.VX0) + (vy-sP.VY0)*(vy-sP.VY0) + (vz-sP.VZ0)*(vz-sP.VZ0)) / (2.0 * kb * sP.TEMPERATURE));
    }
    
-   Real Dispersion::calcPhaseSpaceDensity(creal& x, creal& y, creal& z, creal& dx, creal& dy, creal& dz, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz, const uint popID) const {
+   Real Dispersion::calcPhaseSpaceDensity(creal& x __attribute__((unused)), creal& y __attribute__((unused)), creal& z __attribute__((unused)),
+         creal& dx __attribute__((unused)), creal& dy __attribute__((unused)), creal& dz __attribute__((unused)),
+         creal& vx, creal& vy, creal& vz,
+         creal& dvx, creal& dvy, creal& dvz,
+         const uint popID) const {
       const size_t meshID = getObjectWrapper().particleSpecies[popID].velocityMesh;
       const vmesh::MeshParameters& meshParams = getObjectWrapper().velocityMeshes[meshID];
       if (vx < meshParams.meshMinLimits[0] + 0.5*dvx ||
@@ -182,7 +186,7 @@ namespace projects {
       }
    }
 
-   void Dispersion::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {
+   void Dispersion::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t __attribute__((unused))) {
       Real* cellParams = cell->get_cell_parameters();
       creal x = cellParams[CellParams::XCRD];
       creal dx = cellParams[CellParams::DX];
@@ -207,7 +211,7 @@ namespace projects {
    void Dispersion::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       ConstantField bgField;
       bgField.initialize(this->B0 * cos(this->angleXY) * cos(this->angleXZ),

--- a/projects/Distributions/Distributions.cpp
+++ b/projects/Distributions/Distributions.cpp
@@ -126,7 +126,7 @@ namespace projects {
    Real Distributions::getDistribValue(
       creal& x, creal& y, creal& z,
       creal& vx, creal& vy, creal& vz,
-      const uint popID
+      const uint popID __attribute__((unused))
    ) const {
       Real value = 0.0;
       creal relx = x/(Parameters::xmax - Parameters::xmin);
@@ -149,7 +149,7 @@ namespace projects {
       return getDistribValue(x+0.5*dx, y+0.5*dy,z+0.5*dz,vx+0.5*dvx, vy+0.5*dvy, vz+0.5*dvz, popID);
    }
 
-   void Distributions::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {
+   void Distributions::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t __attribute__((unused))) {
       setRandomCellSeed(cell);
       for (uint i=0; i<2; i++) {
          this->rhoRnd[i] = this->rho[i] + this->rhoPertAbsAmp[i] * (0.5 - getRandomNumber());
@@ -159,7 +159,7 @@ namespace projects {
    void Distributions::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       ConstantField bgField;
       bgField.initialize(this->Bx,
@@ -200,7 +200,7 @@ namespace projects {
       creal x,
       creal y,
       creal z,
-      const uint popID
+      const uint popID __attribute__((unused))
    ) const {
       vector<std::array<Real, 3>> centerPoints;
       creal relx = x/(Parameters::xmax - Parameters::xmin);

--- a/projects/Firehose/Firehose.cpp
+++ b/projects/Firehose/Firehose.cpp
@@ -105,7 +105,7 @@ namespace projects {
       }
    }
 
-   Real Firehose::profile(creal top, creal bottom, creal x) const {
+   Real Firehose::profile(creal top, creal x) const {
       return top * (1.0 + this->amp*cos(2.0*M_PI*x/this->lambda));
    }
 
@@ -118,7 +118,7 @@ namespace projects {
       creal mass = getObjectWrapper().particleSpecies[popID].mass;
       creal kb = physicalconstants::K_B;
       
-      Real Vx = profile(sP.Vx[1],sP.Vx[1], x);
+      Real Vx = profile(sP.Vx[1], x);
       
       return
       sP.rho[1] * pow(mass / (2.0 * M_PI * kb * sP.Tx[1]), 1.5) *

--- a/projects/Firehose/Firehose.cpp
+++ b/projects/Firehose/Firehose.cpp
@@ -110,9 +110,9 @@ namespace projects {
    }
 
    Real Firehose::getDistribValue(
-      creal& x, creal& y,
+      creal& x, creal& y __attribute__((unused)),
       creal& vx, creal& vy, creal& vz,
-      creal& dvx, creal& dvy, creal& dvz,
+      creal& dvx __attribute__((unused)), creal& dvy __attribute__((unused)), creal& dvz __attribute__((unused)),
       const uint popID) const  {
       const FirehoseSpeciesParameters& sP = speciesParams[popID];
       creal mass = getObjectWrapper().particleSpecies[popID].mass;
@@ -131,7 +131,10 @@ namespace projects {
    //           pow(vz - this->Vz[2], 2.0) / (2.0 * kb * this->Tz[2]))); 
    }
 
-   Real Firehose::calcPhaseSpaceDensity(creal& x, creal& y, creal& z, creal& dx, creal& dy, creal& dz, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,const uint popID) const {
+   Real Firehose::calcPhaseSpaceDensity(creal& x, creal& y, creal& z __attribute__((unused)),
+         creal& dx, creal& dy, creal& dz __attribute__((unused)),
+         creal& vx, creal& vy, creal& vz,
+         creal& dvx, creal& dvy, creal& dvz,const uint popID) const {
       const FirehoseSpeciesParameters& sP = speciesParams[popID];
       creal d_x = dx / (sP.nSpaceSamples-1);
       creal d_y = dy / (sP.nSpaceSamples-1);
@@ -151,12 +154,12 @@ namespace projects {
       return avg / pow(sP.nSpaceSamples, 2.0) /  pow(sP.nVelocitySamples, 3.0);
    }
 
-   void Firehose::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void Firehose::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
    
    void Firehose::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       ConstantField bgField;
       bgField.initialize(this->Bx,

--- a/projects/Firehose/Firehose.h
+++ b/projects/Firehose/Firehose.h
@@ -61,7 +61,7 @@ namespace projects {
                            creal& dvx, creal& dvy, creal& dvz,
                            const uint popID
                           ) const;
-      Real profile(creal top, creal bottom, creal x) const;
+      Real profile(creal top, creal x) const;
       virtual void calcCellParameters(spatial_cell::SpatialCell* cell,creal& t);
       virtual Real calcPhaseSpaceDensity(
                                          creal& x, creal& y, creal& z,

--- a/projects/Flowthrough/Flowthrough.cpp
+++ b/projects/Flowthrough/Flowthrough.cpp
@@ -147,7 +147,8 @@ namespace projects {
       }
    }
 
-   Real Flowthrough::getDistribValue(creal& x,creal& y, creal& z, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz, const uint popID) const {
+   Real Flowthrough::getDistribValue(creal& x,creal& y, creal& z, creal& vx, creal& vy, creal& vz,
+         creal& dvx __attribute__((unused)), creal& dvy __attribute__((unused)), creal& dvz __attribute((unused)), const uint popID) const {
 
       Real mass = getObjectWrapper().particleSpecies[popID].mass;
       const FlowthroughSpeciesParameters& sP = speciesParams[popID];
@@ -202,12 +203,12 @@ namespace projects {
       }
    }
 
-   void Flowthrough::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void Flowthrough::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
 
    void Flowthrough::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid __attribute__((unused)),
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       ConstantField bgField;
       bgField.initialize(Bx,By,Bz); //bg bx, by,bz      
@@ -215,9 +216,9 @@ namespace projects {
    }
    
    std::vector<std::array<Real, 3> > Flowthrough::getV0(
-      creal x,
-      creal y,
-      creal z,
+      creal x __attribute__((unused)),
+      creal y __attribute__((unused)),
+      creal z __attribute__((unused)),
       const uint popID
    ) const {
       const FlowthroughSpeciesParameters& sP = speciesParams[popID];

--- a/projects/Fluctuations/Fluctuations.cpp
+++ b/projects/Fluctuations/Fluctuations.cpp
@@ -102,8 +102,8 @@ namespace projects {
    }
 
    Real Fluctuations::calcPhaseSpaceDensity(
-      creal& x, creal& y, creal& z,
-      creal& dx, creal& dy, creal& dz,
+      creal& x __attribute__((unused)), creal& y __attribute__((unused)), creal& z __attribute__((unused)),
+      creal& dx __attribute__((unused)), creal& dy __attribute__((unused)), creal& dz __attribute__((unused)),
       creal& vx, creal& vy, creal& vz,
       creal& dvx, creal& dvy, creal& dvz,const uint popID
    ) const {
@@ -149,7 +149,7 @@ namespace projects {
       }
    }
    
-   void Fluctuations::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {
+   void Fluctuations::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t __attribute__((unused))) {
       Real* cellParams = cell->get_cell_parameters();
       creal x = cellParams[CellParams::XCRD];
       creal dx = cellParams[CellParams::DX];
@@ -173,7 +173,7 @@ namespace projects {
    void Fluctuations::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2>& perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       ConstantField bgField;
       bgField.initialize(this->BX0,
@@ -204,10 +204,10 @@ namespace projects {
    }
    
    std::vector<std::array<Real, 3> > Fluctuations::getV0(
-      creal x,
-      creal y,
-      creal z,
-      const uint popID
+      creal x __attribute__((unused)),
+      creal y __attribute__((unused)),
+      creal z __attribute__((unused)),
+      const uint popID __attribute__((unused))
    ) const {
       std::array<Real, 3> V0 {{0.0, 0.0, 0.0}};
       std::vector<std::array<Real, 3> > centerPoints;

--- a/projects/Harris/Harris.cpp
+++ b/projects/Harris/Harris.cpp
@@ -82,9 +82,9 @@ namespace projects {
    }
    
    Real Harris::getDistribValue(
-      creal& x,creal& y, creal& z,
+      creal& x,creal& y __attribute__((unused)), creal& z __attribute__((unused)),
       creal& vx, creal& vy, creal& vz,
-      creal& dvx, creal& dvy, creal& dvz,
+      creal& dvx __attribute__((unused)), creal& dvy __attribute__((unused)), creal& dvz __attribute__((unused)),
       const uint popID
    ) const {
 
@@ -134,13 +134,13 @@ namespace projects {
       
    }
    
-   void Harris::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void Harris::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
    
    vector<std::array<Real, 3>> Harris::getV0(
-      creal x,
-      creal y,
-      creal z,
-      const uint popID
+      creal x __attribute__((unused)),
+      creal y __attribute__((unused)),
+      creal z __attribute__((unused)),
+      const uint popID __attribute__((unused))
    ) const {
       vector<std::array<Real, 3>> V0;
       std::array<Real, 3> v = {{0.0, 0.0, 0.0 }};
@@ -151,7 +151,7 @@ namespace projects {
    void Harris::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       setBackgroundFieldToZero(BgBGrid);
       

--- a/projects/IPShock/IPShock.cpp
+++ b/projects/IPShock/IPShock.cpp
@@ -339,13 +339,13 @@ namespace projects {
 
   Real IPShock::getDistribValue(creal& x, creal& y, creal& z, 
 				creal& vx, creal& vy, creal& vz, 
-				creal& dvx, creal& dvy, creal& dvz,
+				creal& dvx __attribute__((unused)), creal& dvy __attribute__((unused)), creal& dvz __attribute__((unused)),
         const uint popID) const {
 
     Real mass = getObjectWrapper().particleSpecies[popID].mass;
     Real KB = physicalconstants::K_B;
     Real mu0 = physicalconstants::MU_0;
-    Real adiab = 5./3.;
+    //Real adiab = 5./3.;
     const IPShockSpeciesParameters& sP = this->speciesParams[popID];
 
     // Interpolate density between upstream and downstream
@@ -421,7 +421,7 @@ namespace projects {
     }
   }
   
-  void IPShock::calcCellParameters(spatial_cell::SpatialCell* cell, creal& t) { }
+  void IPShock::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)), creal& t __attribute__((unused))) { }
 
   Real IPShock::interpolate(Real upstream, Real downstream, Real x) const {
     Real coord = 0.5 + x/this->Shockwidth; //Now shock will be from 0 to 1
@@ -440,7 +440,7 @@ namespace projects {
   void IPShock::setProjectBField(
      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-     FsGrid< fsgrids::technical, 2>& technicalGrid
+     FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
   ) {
       setBackgroundFieldToZero(BgBGrid);
       
@@ -455,9 +455,9 @@ namespace projects {
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
                   
                   /* Maintain all values in BPERT for simplicity */
-                  Real KB = physicalconstants::K_B;
+                  //Real KB = physicalconstants::K_B;
                   Real mu0 = physicalconstants::MU_0;
-                  Real adiab = 5./3.;
+                  //Real adiab = 5./3.;
                   
                   // Interpolate density between upstream and downstream
                   // All other values are calculated from jump conditions
@@ -479,7 +479,7 @@ namespace projects {
                   Real BX = this->B0u[0];
                   Real MAsq = std::pow((EffectiveVu0/this->B0u[0]), 2) * MassDensityU * mu0;
                   Real Btang = this->B0utangential * (MAsq - 1.0)/(MAsq*VX/EffectiveVu0 -1.0);
-                  Real Vtang = VX * Btang / BX;
+                  //Real Vtang = VX * Btang / BX;
                   
                   /* Reconstruct Y and Z components using cos(phi) values and signs. Tangential variables are always positive. */
                   Real BY = abs(Btang) * this->Bucosphi * this->Byusign;

--- a/projects/KHB/KHB.cpp
+++ b/projects/KHB/KHB.cpp
@@ -111,7 +111,7 @@ namespace projects {
       }
    }
    
-   Real KHB::getDistribValue(creal& x, creal& z, creal& vx, creal& vy, creal& vz, const uint popID) const {
+   Real KHB::getDistribValue(creal& x, creal& z, creal& vx, creal& vy, creal& vz, const uint popID __attribute__((unused))) const {
       creal mass = physicalconstants::MASS_PROTON;
       creal kb = physicalconstants::K_B;
       Real rho = profile(this->rho[this->BOTTOM], this->rho[this->TOP], x, z);
@@ -124,7 +124,10 @@ namespace projects {
       exp(- mass * (pow(vx - Vx, 2.0) + pow(vy - Vy, 2.0) + pow(vz - Vz, 2.0)) / (2.0 * kb * T));
    }
 
-   Real KHB::calcPhaseSpaceDensity(creal& x, creal& y, creal& z, creal& dx, creal& dy, creal& dz, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,const uint popID) const {   
+   Real KHB::calcPhaseSpaceDensity(creal& x, creal& y __attribute__((unused)), creal& z,
+         creal& dx, creal& dy __attribute__((unused)), creal& dz,
+         creal& vx, creal& vy, creal& vz,
+         creal& dvx, creal& dvy, creal& dvz,const uint popID) const {   
       creal d_x = dx / (this->nSpaceSamples-1);
       creal d_z = dz / (this->nSpaceSamples-1);
       creal d_vx = dvx / (this->nVelocitySamples-1);
@@ -151,12 +154,12 @@ namespace projects {
    }
    
 
-   void KHB::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void KHB::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
    
    void KHB::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       setBackgroundFieldToZero(BgBGrid);
       

--- a/projects/Larmor/Larmor.cpp
+++ b/projects/Larmor/Larmor.cpp
@@ -84,7 +84,7 @@ namespace projects {
       RP::get("Larmor.Scale_y", this->SCA_Y);
     }
 
-    Real Larmor::getDistribValue(creal& x, creal& y, creal& z, creal& vx, creal& vy, creal& vz, const uint popID) const {
+    Real Larmor::getDistribValue(creal& x, creal& y, creal& z __attribute__((unused)), creal& vx, creal& vy, creal& vz, const uint popID) const {
       creal kb = physicalconstants::K_B;
       creal mass = getObjectWrapper().particleSpecies[popID].mass;
       
@@ -138,12 +138,12 @@ namespace projects {
    }
 
 
-   void Larmor::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void Larmor::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
 
     void Larmor::setProjectBField(
-       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
+       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid __attribute__((unused)),
        FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-       FsGrid< fsgrids::technical, 2>& technicalGrid
+       FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
     ) {
       ConstantField bgField;
       bgField.initialize(this->BX0,

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -318,7 +318,7 @@ namespace projects {
    }
    
    /*! Magnetosphere does not set any extra perturbed B. */
-   void Magnetosphere::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void Magnetosphere::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
 
    /* set 0-centered dipole */
    void Magnetosphere::setProjectBField(
@@ -471,7 +471,7 @@ namespace projects {
    Real Magnetosphere::getDistribValue(
            creal& x,creal& y,creal& z,
            creal& vx,creal& vy,creal& vz,
-           creal& dvx,creal& dvy,creal& dvz,
+           creal& dvx __attribute__((unused)),creal& dvy __attribute__((unused)),creal& dvz __attribute__((unused)),
            const uint popID) const
    {
       const MagnetosphereSpeciesParameters& sP = this->speciesParams[popID];

--- a/projects/MultiPeak/MultiPeak.cpp
+++ b/projects/MultiPeak/MultiPeak.cpp
@@ -126,7 +126,8 @@ namespace projects {
       else if (densModelString == "testcase") densityModel = TestCase;
    }
 
-   Real MultiPeak::getDistribValue(creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,const uint popID) const {
+   Real MultiPeak::getDistribValue(creal& vx, creal& vy, creal& vz, 
+         creal& dvx __attribute__((unused)), creal& dvy __attribute__((unused)), creal& dvz __attribute__((unused)),const uint popID) const {
       const MultiPeakSpeciesParameters& sP = speciesParams[popID];
       creal mass = getObjectWrapper().particleSpecies[popID].mass;
       creal kb = physicalconstants::K_B;
@@ -144,9 +145,11 @@ namespace projects {
       return value;
    }
 
-   Real MultiPeak::calcPhaseSpaceDensity(creal& x, creal& y, creal& z, creal& dx, creal& dy, creal& dz, 
-                                         creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,
-                                         const uint popID) const {
+   Real MultiPeak::calcPhaseSpaceDensity(creal& x, creal& y, creal& z __attribute__((unused)),
+         creal& dx __attribute__((unused)), creal& dy __attribute__((unused)), creal& dz __attribute__((unused)), 
+         creal& vx, creal& vy, creal& vz,
+         creal& dvx, creal& dvy, creal& dvz,
+         const uint popID) const {
       // Iterative sampling of the distribution function. Keep track of the 
       // accumulated volume average over the iterations. When the next 
       // iteration improves the average by less than 1%, return the value.
@@ -155,8 +158,6 @@ namespace projects {
       uint N = nVelocitySamples; // Start by using nVelocitySamples
       int N3_sum = 0;           // Sum of sampling points used so far
 
-      const MultiPeakSpeciesParameters& sP = speciesParams[popID];
-                                            
       #warning TODO: Replace getObjectWrapper().particleSpecies[popID].sparseMinValue with SpatialCell::getVelocityBlockMinValue(popID)
       const Real avgLimit = 0.01*getObjectWrapper().particleSpecies[popID].sparseMinValue;
       do {
@@ -212,7 +213,7 @@ namespace projects {
       return avgTotal / N3_sum;
    }
 
-   void MultiPeak::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {
+   void MultiPeak::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t __attribute__((unused))) {
       setRandomCellSeed(cell);
       rhoRnd = 0.5 - getRandomNumber();
    }
@@ -220,7 +221,7 @@ namespace projects {
    void MultiPeak::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       ConstantField bgField;
       bgField.initialize(this->Bx,
@@ -257,9 +258,9 @@ namespace projects {
    }
    
    std::vector<std::array<Real, 3> > MultiPeak::getV0(
-                                                creal x,
-                                                creal y,
-                                                creal z,
+                                                creal x __attribute__((unused)),
+                                                creal y __attribute__((unused)),
+                                                creal z __attribute__((unused)),
                                                 const uint popID
                                                ) const {
       const MultiPeakSpeciesParameters& sP = speciesParams[popID];

--- a/projects/Riemann1/Riemann1.cpp
+++ b/projects/Riemann1/Riemann1.cpp
@@ -90,7 +90,10 @@ namespace projects {
       RP::get("Riemann.nVelocitySamples", this->nVelocitySamples);
    }
 
-   Real Riemann1::getDistribValue(creal& x, creal& y, creal& z, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz, const uint popID) const {
+   Real Riemann1::getDistribValue(creal& x, creal& y __attribute__((unused)), creal& z __attribute__((unused)),
+         creal& vx, creal& vy, creal& vz,
+         creal& dvx __attribute__((unused)), creal& dvy __attribute__((unused)), creal& dvz __attribute__((unused)),
+         const uint popID __attribute__((unused))) const {
       cint side = (x < 0.0) ? this->LEFT : this->RIGHT;
       
       return this->rho[side] * pow(physicalconstants::MASS_PROTON / (2.0 * M_PI * physicalconstants::K_B * this->T[side]), 1.5) *
@@ -117,12 +120,12 @@ namespace projects {
       return avg / pow(this->nSpaceSamples, 3.0) / pow(this->nVelocitySamples, 3.0);
    }
 
-   void Riemann1::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void Riemann1::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
    
    void Riemann1::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       setBackgroundFieldToZero(BgBGrid);
       
@@ -140,7 +143,7 @@ namespace projects {
                   Bxavg = Byavg = Bzavg = 0.0;
                   if(this->nSpaceSamples > 1) {
                      Real d_x = perBGrid.DX / (this->nSpaceSamples - 1);
-                     Real d_z = perBGrid.DZ / (this->nSpaceSamples - 1);
+                     //Real d_z = perBGrid.DZ / (this->nSpaceSamples - 1);
                      for (uint i=0; i<this->nSpaceSamples; ++i) {
                         for (uint k=0; k<this->nSpaceSamples; ++k) {
                            Bxavg += ((xyz[0] + i * d_x) < 0.0) ? this->Bx[this->LEFT] : this->Bx[this->RIGHT];

--- a/projects/Shock/Shock.cpp
+++ b/projects/Shock/Shock.cpp
@@ -88,7 +88,8 @@ namespace projects {
       RP::get("Shock.Sharp_Y", this->Sharp_Y);
    }
 
-   Real Shock::getDistribValue(creal& x, creal& y, creal& z, creal& vx, creal& vy, creal& vz, const uint popID) const {
+   Real Shock::getDistribValue(creal& x __attribute__((unused)), creal& y __attribute__((unused)), creal& z __attribute__((unused)),
+         creal& vx, creal& vy, creal& vz, const uint popID __attribute__((unused))) const {
       creal kb = physicalconstants::K_B;
       creal mass = physicalconstants::MASS_PROTON;
       return exp(- mass * ((vx-this->VX0)*(vx-this->VX0) + (vy-this->VY0)*(vy-this->VY0)+ (vz-this->VZ0)*(vz-this->VZ0)) / (2.0 * kb * this->TEMPERATURE));
@@ -142,12 +143,12 @@ namespace projects {
       }
    }
 
-   void Shock::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void Shock::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
    
    void Shock::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       setBackgroundFieldToZero(BgBGrid);
       

--- a/projects/Shocktest/Shocktest.cpp
+++ b/projects/Shocktest/Shocktest.cpp
@@ -115,7 +115,7 @@ namespace projects {
       RP::get("Shocktest.nVelocitySamples", this->nVelocitySamples);
    }
    
-   Real Shocktest::getDistribValue(creal& x, creal& y, creal& z, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz, const uint popID) const {
+   Real Shocktest::getDistribValue(creal& x, creal& y, creal& z, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz, const uint popID __attribute__((unused))) const {
       creal mass = physicalconstants::MASS_PROTON;
       creal kb = physicalconstants::K_B;
       
@@ -137,9 +137,9 @@ namespace projects {
 
    vector<std::array<Real, 3>> Shocktest::getV0(
       creal x,
-      creal y,
-      creal z,
-      const uint popID
+      creal y __attribute__((unused)),
+      creal z __attribute__((unused)),
+      const uint popID __attribute__((unused))
    ) const {
       vector<std::array<Real, 3>> centerPoints;
       cint side = (x < 0.0) ? this->LEFT : this->RIGHT;
@@ -189,12 +189,12 @@ namespace projects {
     * @param t The current value of time. This is passed as a convenience. If you need more detailed information 
     * of the state of the simulation, you can read it from Parameters.
     */
-   void Shocktest::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void Shocktest::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
    
    void Shocktest::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       setBackgroundFieldToZero(BgBGrid);
       
@@ -212,7 +212,7 @@ namespace projects {
                   Bxavg = Byavg = Bzavg = 0.0;
                   if(this->nSpaceSamples > 1) {
                      Real d_x = perBGrid.DX / (this->nSpaceSamples - 1);
-                     Real d_z = perBGrid.DZ / (this->nSpaceSamples - 1);
+                     //Real d_z = perBGrid.DZ / (this->nSpaceSamples - 1);
                      for (uint i=0; i<this->nSpaceSamples; ++i) {
                         for (uint k=0; k<this->nSpaceSamples; ++k) {
                            Bxavg += ((xyz[0] + i * d_x) < 0.0) ? this->Bx[this->LEFT] : this->Bx[this->RIGHT];

--- a/projects/Template/Template.cpp
+++ b/projects/Template/Template.cpp
@@ -60,7 +60,10 @@ namespace projects {
       return Project::initialize();
    }
 
-   Real Template::calcPhaseSpaceDensity(creal& x, creal& y, creal& z, creal& dx, creal& dy, creal& dz, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,const uint popID) const {
+   Real Template::calcPhaseSpaceDensity(creal& x, creal& y, creal& z,
+         creal& dx __attribute__((unused)), creal& dy __attribute__((unused)), creal& dz __attribute__((unused)),
+         creal& vx, creal& vy, creal& vz,
+         creal& dvx __attribute__((unused)), creal& dvy __attribute__((unused)), creal& dvz __attribute__((unused)),const uint popID) const {
       creal rho = 1.0;
       creal T = 1.0;
       const std::array<Real, 3> V0 = this->getV0(x, y, z, popID)[0];
@@ -72,9 +75,9 @@ namespace projects {
    }
    
    void Template::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid __attribute__((unused)),
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       Dipole bgField;
       bgField.initialize(8e15, 0.0, 0.0, 0.0, 0.0); //set dipole moment and location
@@ -83,9 +86,9 @@ namespace projects {
    
    vector<std::array<Real, 3>> Template::getV0(
       creal x,
-      creal y,
-      creal z,
-      const uint popID
+      creal y __attribute__((unused)),
+      creal z __attribute__((unused)),
+      const uint popID __attribute__((unused))
    ) const {
       vector<std::array<Real, 3>> centerPoints;
       std::array<Real, 3> point {{0.0, 0.0, 0.0}};

--- a/projects/VelocityBox/VelocityBox.cpp
+++ b/projects/VelocityBox/VelocityBox.cpp
@@ -77,7 +77,7 @@ namespace projects {
       RP::get("VelocityBox.Bz", this->Bz);
    }
 
-  Real VelocityBox::getDistribValue(creal& vx, creal& vy, creal& vz, const uint popID) const {
+  Real VelocityBox::getDistribValue(creal& vx, creal& vy, creal& vz, const uint popID __attribute__((unused))) const {
      if (vx >= this->Vx[0] && vx <= this->Vx[1] &&
          vy >= this->Vy[0] && vy <= this->Vy[1] &&
          vz >= this->Vz[0] && vz <= this->Vz[1])
@@ -89,8 +89,8 @@ namespace projects {
 
 
   Real VelocityBox::calcPhaseSpaceDensity(
-     creal& x, creal& y, creal& z,
-     creal& dx, creal& dy, creal& dz,
+     creal& x __attribute__((unused)), creal& y __attribute__((unused)), creal& z __attribute__((unused)),
+     creal& dx __attribute__((unused)), creal& dy __attribute__((unused)), creal& dz __attribute__((unused)),
      creal& vx, creal& vy, creal& vz,
      creal& dvx, creal& dvy, creal& dvz,const uint popID
   ) const {
@@ -99,12 +99,12 @@ namespace projects {
 
 
   
-   void VelocityBox::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void VelocityBox::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
 
    void VelocityBox::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid __attribute__((unused)),
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       ConstantField bgField;
       bgField.initialize(this->Bx,

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -180,9 +180,9 @@ namespace projects {
 
    /*! Print a warning message to stderr and abort, one should not use the base class functions. */
    void Project::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid __attribute__((unused)),
+      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid __attribute__((unused)),
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       int rank;
       MPI_Comm_rank(MPI_COMM_WORLD,&rank);
@@ -193,11 +193,11 @@ namespace projects {
    }
    
    void Project::hook(
-      cuint& stage,
-      const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid
+      cuint& stage __attribute__((unused)),
+      const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid __attribute__((unused))
    ) const { }
 
-   void Project::setupBeforeSetCell(const std::vector<CellID>& cells) {
+   void Project::setupBeforeSetCell(const std::vector<CellID>& cells __attribute__((unused))) {
       // Dummy implementation.
       return;
    }
@@ -411,7 +411,7 @@ namespace projects {
    /** Check if the project wants to rescale densities.
     * @param popID ID of the particle species.
     * @return If true, rescaleDensity is called for this species.*/
-   bool Project::rescalesDensity(const uint popID) const {
+   bool Project::rescalesDensity(const uint popID __attribute__((unused))) const {
       return false;
    }
 
@@ -441,7 +441,7 @@ namespace projects {
    }
 
    /*! Print a warning message to stderr and abort, one should not use the base class functions. */
-   void Project::calcCellParameters(SpatialCell* cell, creal& t) {
+   void Project::calcCellParameters(SpatialCell* cell __attribute__((unused)), creal& t __attribute__((unused))) {
       int rank;
       MPI_Comm_rank(MPI_COMM_WORLD,&rank);
       if (rank == MASTER_RANK) {
@@ -453,7 +453,7 @@ namespace projects {
    /*!
      Get random number between 0 and 1.0. One should always first initialize the rng.
    */
-   Real Project::getCorrectNumberDensity(spatial_cell::SpatialCell* cell,const uint popID) const {
+   Real Project::getCorrectNumberDensity(spatial_cell::SpatialCell* cell __attribute__((unused)),const uint popID __attribute__((unused))) const {
       cerr << "ERROR: Project::getCorrectNumberDensity called instead of derived class function!" << endl;
       exit(1);
       return 0.0;

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -62,39 +62,6 @@ extern Logger logFile;
 char projects::Project::rngStateBuffer[256];
 random_data projects::Project::rngDataBuffer;
 
-/** Struct for creating a new velocity mesh.
- * The values are read from the configuration file and 
- * copied to ObjectWrapper::velocityMeshes.*/
-struct VelocityMeshParams {
-   vector<string> name;
-   vector<double> vx_min;
-   vector<double> vy_min;
-   vector<double> vz_min;
-   vector<double> vx_max;
-   vector<double> vy_max;
-   vector<double> vz_max;
-   vector<vmesh::LocalID> vx_length;
-   vector<vmesh::LocalID> vy_length;
-   vector<vmesh::LocalID> vz_length;
-   vector<unsigned int> maxRefLevels;
-   
-   void resize(const size_t& size) {
-      name.resize(1);
-      vx_min.resize(1);
-      vy_min.resize(1);
-      vz_min.resize(1);
-      vx_max.resize(1);
-      vy_max.resize(1);
-      vz_max.resize(1);
-      vx_length.resize(1);
-      vy_length.resize(1);
-      vz_length.resize(1);
-      maxRefLevels.resize(1);
-   }
-};
-
-static VelocityMeshParams* velMeshParams = NULL;
-
 namespace projects {
    Project::Project() { 
       baseClassInitialized = false;
@@ -135,28 +102,6 @@ namespace projects {
    void Project::getParameters() {
       typedef Readparameters RP;
       RP::get("Project_common.seed", this->seed);
-
-
-      // Note that configuration files need to be re-parsed after this.
-
-      //RP::get("ParticlePopulation.charge",popCharges);
-      //RP::get("ParticlePopulation.mass_units",popMassUnits);
-      //RP::get("ParticlePopulation.mass",popMasses);
-      //RP::get("ParticlePopulation.sparse_min_value",popSparseMinValue);
-      //RP::get("ParticlePopulation.mesh",popMeshNames);
-
-      //if (velMeshParams == NULL) velMeshParams = new VelocityMeshParams();
-      //RP::get("velocitymesh.name",velMeshParams->name);
-      //RP::get("velocitymesh.vx_min",velMeshParams->vx_min);
-      //RP::get("velocitymesh.vy_min",velMeshParams->vy_min);
-      //RP::get("velocitymesh.vz_min",velMeshParams->vz_min);
-      //RP::get("velocitymesh.vx_max",velMeshParams->vx_max);
-      //RP::get("velocitymesh.vy_max",velMeshParams->vy_max);
-      //RP::get("velocitymesh.vz_max",velMeshParams->vz_max);
-      //RP::get("velocitymesh.vx_length",velMeshParams->vx_length);
-      //RP::get("velocitymesh.vy_length",velMeshParams->vy_length);
-      //RP::get("velocitymesh.vz_length",velMeshParams->vz_length);
-      //RP::get("velocitymesh.max_refinement_level",velMeshParams->maxRefLevels);
    }
 
    /** Initialize the Project. Velocity mesh and particle population 
@@ -165,8 +110,6 @@ namespace projects {
     * NOTE: Each project must call this function!
     * @return If true, particle species and velocity meshes were created successfully.*/
    bool Project::initialize() {
-      typedef Readparameters RP;
-      
       // Basic error checking
       bool success = true;
 
@@ -364,7 +307,6 @@ namespace projects {
          const vmesh::LocalID endIndex   = cell->get_number_of_velocity_blocks(popID);
          for (vmesh::LocalID blockLID=startIndex; blockLID<endIndex; ++blockLID) {
             vector<vmesh::GlobalID> nbrs;
-            int32_t refLevelDifference;
             const vmesh::GlobalID blockGID = vmesh.getGlobalID(blockLID);
 
             // Fetch block data and nearest neighbors
@@ -388,7 +330,7 @@ namespace projects {
          // Loop over blocks in map insertedBlocks and recalculate 
          // values of distribution functions
          for (map<vmesh::GlobalID,vmesh::LocalID>::const_iterator it=insertedBlocks.begin(); it!=insertedBlocks.end(); ++it) {
-            const vmesh::GlobalID blockGID = it->first;
+            //const vmesh::GlobalID blockGID = it->first;
             const vmesh::LocalID blockLID = it->second;
             const Real maxValue = setVelocityBlock(cell,blockLID,popID);
             if (maxValue <= getObjectWrapper().particleSpecies[popID].sparseMinValue) 
@@ -536,9 +478,9 @@ namespace projects {
                xyz[1] = P::amrBoxCenterY + (0.5 + j - P::amrBoxHalfWidthY) * P::dy_ini;
                xyz[2] = P::amrBoxCenterZ + (0.5 + k - P::amrBoxHalfWidthZ) * P::dz_ini;
                
-               CellID myCell = mpiGrid.get_existing_cell(xyz);
                if (mpiGrid.refine_completely_at(xyz)) {
                   #ifndef NDEBUG
+                  CellID myCell = mpiGrid.get_existing_cell(xyz);
                   std::cout << "Rank " << myRank << " is refining cell " << myCell << std::endl;
                   #endif
                }
@@ -570,9 +512,9 @@ namespace projects {
                   xyz[1] = P::amrBoxCenterY + 0.5 * (0.5 + j - P::amrBoxHalfWidthY) * P::dy_ini;
                   xyz[2] = P::amrBoxCenterZ + 0.5 * (0.5 + k - P::amrBoxHalfWidthZ) * P::dz_ini;
                   
-                  CellID myCell = mpiGrid.get_existing_cell(xyz);
                   if (mpiGrid.refine_completely_at(xyz)) {
                      #ifndef NDEBUG
+                     CellID myCell = mpiGrid.get_existing_cell(xyz);
                      std::cout << "Rank " << myRank << " is refining cell " << myCell << std::endl;
                      #endif
                   }

--- a/projects/projectTriAxisSearch.cpp
+++ b/projects/projectTriAxisSearch.cpp
@@ -60,9 +60,8 @@ namespace projects {
          // VX search
          search = true;
          counter = 0;
-         #warning TODO: add SpatialCell::getVelocityBlockMinValue() in place of sparseMinValue
          while (search) {
-            if (0.1 * getObjectWrapper().particleSpecies[popID].sparseMinValue >
+            if (0.1 * cell->getVelocityBlockMinValue(popID) >
                 calcPhaseSpaceDensity(x,
                                       y,
                                       z,

--- a/projects/testAmr/testAmr.cpp
+++ b/projects/testAmr/testAmr.cpp
@@ -127,7 +127,9 @@ namespace projects {
       else if (densModelString == "testcase") densityModel = TestCase;
    }
 
-   Real testAmr::getDistribValue(creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,const uint popID) const {
+   Real testAmr::getDistribValue(creal& vx, creal& vy, creal& vz, 
+         creal& dvx __attribute__((unused)), creal& dvy __attribute__((unused)), creal& dvz __attribute__((unused)),
+         const uint popID) const {
       const testAmrSpeciesParameters& sP = speciesParams[popID];
       creal mass = getObjectWrapper().particleSpecies[popID].mass;
       creal kb = physicalconstants::K_B;
@@ -145,9 +147,11 @@ namespace projects {
       return value;
    }
 
-   Real testAmr::calcPhaseSpaceDensity(creal& x, creal& y, creal& z, creal& dx, creal& dy, creal& dz, 
-                                       creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,
-                                       const uint popID) const {
+   Real testAmr::calcPhaseSpaceDensity(creal& x, creal& y, creal& z __attribute__((unused)),
+         creal& dx __attribute__((unused)), creal& dy __attribute__((unused)), creal& dz __attribute__((unused)), 
+         creal& vx, creal& vy, creal& vz,
+         creal& dvx, creal& dvy, creal& dvz,
+         const uint popID) const {
       // Iterative sampling of the distribution function. Keep track of the 
       // accumulated volume average over the iterations. When the next 
       // iteration improves the average by less than 1%, return the value.
@@ -155,8 +159,6 @@ namespace projects {
       bool ok = false;
       uint N = nVelocitySamples; // Start by using nVelocitySamples
       int N3_sum = 0;           // Sum of sampling points used so far
-
-      const testAmrSpeciesParameters& sP = speciesParams[popID];
 
       const Real avgLimit = 0.01*getObjectWrapper().particleSpecies[popID].sparseMinValue;
       do {
@@ -213,7 +215,7 @@ namespace projects {
       return avgTotal / N3_sum;
    }
 
-   void testAmr::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {
+   void testAmr::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t __attribute__((unused))) {
       setRandomCellSeed(cell);
       rhoRnd = 0.5 - getRandomNumber();
    }
@@ -221,7 +223,7 @@ namespace projects {
    void testAmr::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       ConstantField bgField;
       bgField.initialize(this->Bx,
@@ -260,9 +262,9 @@ namespace projects {
    }
    
    std::vector<std::array<Real, 3> > testAmr::getV0(
-                                                creal x,
-                                                creal y,
-                                                creal z,
+                                                creal x __attribute__((unused)),
+                                                creal y __attribute__((unused)),
+                                                creal z __attribute__((unused)),
                                                 const uint popID
                                                ) const {
       const testAmrSpeciesParameters& sP = speciesParams[popID];
@@ -292,9 +294,9 @@ namespace projects {
                xyz[1] = P::amrBoxCenterY + (0.5 + j - P::amrBoxHalfWidthY) * P::dy_ini;
                xyz[2] = P::amrBoxCenterZ + (0.5 + k - P::amrBoxHalfWidthZ) * P::dz_ini;
                
-               CellID myCell = mpiGrid.get_existing_cell(xyz);
                if (mpiGrid.refine_completely_at(xyz)) {
 #ifndef NDEBUG
+                  CellID myCell = mpiGrid.get_existing_cell(xyz);
                   std::cout << "Rank " << myRank << " is refining cell " << myCell << std::endl;
 #endif
                }
@@ -326,9 +328,9 @@ namespace projects {
                   xyz[1] = P::amrBoxCenterY + 0.5 * (0.5 + j - P::amrBoxHalfWidthY) * P::dy_ini;
                   xyz[2] = P::amrBoxCenterZ + 0.5 * (0.5 + k - P::amrBoxHalfWidthZ) * P::dz_ini;
                   
-                  CellID myCell = mpiGrid.get_existing_cell(xyz);
                   if (mpiGrid.refine_completely_at(xyz)) {
 #ifndef NDEBUG
+                     CellID myCell = mpiGrid.get_existing_cell(xyz);
                      std::cout << "Rank " << myRank << " is refining cell " << myCell << std::endl;
 #endif
                   }

--- a/projects/testHall/testHall.cpp
+++ b/projects/testHall/testHall.cpp
@@ -80,10 +80,10 @@ namespace projects {
    }
    
    Real TestHall::calcPhaseSpaceDensity(
-      creal& x,creal& y,creal& z,
-      creal& dx,creal& dy,creal& dz,
+      creal& x __attribute__((unused)),creal& y __attribute__((unused)),creal& z __attribute__((unused)),
+      creal& dx __attribute__((unused)),creal& dy __attribute__((unused)),creal& dz __attribute__((unused)),
       creal& vx,creal& vy,creal& vz,
-      creal& dvx,creal& dvy,creal& dvz,const uint popID
+      creal& dvx,creal& dvy,creal& dvz,const uint popID __attribute__((unused))
    ) const {
       creal mass = physicalconstants::MASS_PROTON;
       creal kb = physicalconstants::K_B;
@@ -92,7 +92,7 @@ namespace projects {
          exp(- mass * (pow(vx + 0.5 * dvx - this->VX0, 2.0) + pow(vy + 0.5 * dvy - this->VY0, 2.0) + pow(vz + 0.5 * dvz - this->VZ0, 2.0)) / (2.0 * kb * this->TEMPERATURE)));
    }
    
-   void TestHall::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void TestHall::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
       
 //       creal r = sqrt((x+Dx)*(x+Dx) + (y+Dy)*(y+Dy));
 //       creal theta = atan2(y+Dy, x+Dx);
@@ -133,7 +133,7 @@ namespace projects {
    void TestHall::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       setBackgroundFieldToZero(BgBGrid);
       

--- a/projects/test_fp/test_fp.cpp
+++ b/projects/test_fp/test_fp.cpp
@@ -108,7 +108,7 @@ namespace projects {
    void test_fp::setProjectBField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       setBackgroundFieldToZero(BgBGrid);
       
@@ -178,9 +178,7 @@ namespace projects {
       }
    }
    
-   void test_fp::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {
-      
-      typedef Parameters P;
+   void test_fp::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) {
       
    }
    
@@ -191,31 +189,32 @@ namespace projects {
       creal dx,
       creal dy,
       creal dz,
-      const uint popID
+      const uint popID __attribute__((unused))
    ) const {
       vector<std::array<Real, 3>> centerPoints;
       
       Real VX=0.0,VY=0.0,VZ=0.0;
       if (this->shear == true)
       {
-         Real ksi,eta;
+         //Real ksi;
+         Real eta;
          switch (this->CASE) {
             case BXCASE:
-               ksi = ((y + 0.5 * dy)  * cos(this->ALPHA) + (z + 0.5 * dz) * sin(this->ALPHA)) / (2.0 * sqrt(2.0));
+               //ksi = ((y + 0.5 * dy)  * cos(this->ALPHA) + (z + 0.5 * dz) * sin(this->ALPHA)) / (2.0 * sqrt(2.0));
                eta = (-(y + 0.5 * dy)  * sin(this->ALPHA) + (z + 0.5 * dz) * cos(this->ALPHA)) / (2.0 * sqrt(2.0));
                VX = 0.0;
                VY = sign(cos(this->ALPHA)) * 0.5 + 0.1*cos(this->ALPHA) * sin(2.0 * M_PI * eta);
                VZ = sign(sin(this->ALPHA)) * 0.5 + 0.1*sin(this->ALPHA) * sin(2.0 * M_PI * eta);
                break;
             case BYCASE:
-               ksi = ((z + 0.5 * dz)  * cos(this->ALPHA) + (x + 0.5 * dx) * sin(this->ALPHA)) / (2.0 * sqrt(2.0));
+               //ksi = ((z + 0.5 * dz)  * cos(this->ALPHA) + (x + 0.5 * dx) * sin(this->ALPHA)) / (2.0 * sqrt(2.0));
                eta = (-(z + 0.5 * dz)  * sin(this->ALPHA) + (x + 0.5 * dx) * cos(this->ALPHA)) / (2.0 * sqrt(2.0));
                VX = sign(sin(this->ALPHA)) * 0.5 + 0.1*sin(this->ALPHA) * sin(2.0 * M_PI * eta);
                VY = 0.0;
                VZ = sign(cos(this->ALPHA)) * 0.5 + 0.1*cos(this->ALPHA) * sin(2.0 * M_PI * eta);
                break;
             case BZCASE:
-               ksi = ((x + 0.5 * dx)  * cos(this->ALPHA) + (y + 0.5 * dy) * sin(this->ALPHA)) / (2.0 * sqrt(2.0));
+               //ksi = ((x + 0.5 * dx)  * cos(this->ALPHA) + (y + 0.5 * dy) * sin(this->ALPHA)) / (2.0 * sqrt(2.0));
                eta = (-(x + 0.5 * dx)  * sin(this->ALPHA) + (y + 0.5 * dy) * cos(this->ALPHA)) / (2.0 * sqrt(2.0));
                VX = sign(cos(this->ALPHA)) * 0.5 + 0.1*cos(this->ALPHA) * sin(2.0 * M_PI * eta);
                VY = sign(sin(this->ALPHA)) * 0.5 + 0.1*sin(this->ALPHA) * sin(2.0 * M_PI * eta);

--- a/projects/test_trans/test_trans.cpp
+++ b/projects/test_trans/test_trans.cpp
@@ -68,7 +68,7 @@ namespace projects {
 
    Real test_trans::calcPhaseSpaceDensity(creal& x,creal& y,creal& z,creal& dx,creal& dy,creal& dz,
                                           creal& vx,creal& vy,creal& vz,creal& dvx,creal& dvy,creal& dvz,
-                                          const uint popID) const {
+                                          const uint popID __attribute__((unused))) const {
       //Please use even number of cells in velocity and real space
       Real xyz[3];
       Real vxyz[3];
@@ -126,12 +126,12 @@ namespace projects {
       return 0.0;
    }
 
-   void test_trans::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void test_trans::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
    
    void test_trans::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid __attribute__((unused)),
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       ConstantField bgField;
       bgField.initialize(0.0,0.0,1e-9);

--- a/projects/verificationLarmor/verificationLarmor.cpp
+++ b/projects/verificationLarmor/verificationLarmor.cpp
@@ -110,12 +110,12 @@ namespace projects {
    }
 
 
-   void verificationLarmor::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
+   void verificationLarmor::calcCellParameters(spatial_cell::SpatialCell* cell __attribute__((unused)),creal& t __attribute__((unused))) { }
 
    void verificationLarmor::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid __attribute__((unused)),
       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
-      FsGrid< fsgrids::technical, 2>& technicalGrid
+      FsGrid< fsgrids::technical, 2>& technicalGrid __attribute__((unused))
    ) {
       ConstantField bgField;
       bgField.initialize(this->BX0,

--- a/spatial_cell.cpp
+++ b/spatial_cell.cpp
@@ -74,16 +74,16 @@ namespace spatial_cell {
    }
 
    SpatialCell::SpatialCell(const SpatialCell& other):
+     populations(other.populations),
+     derivativesBVOL(other.derivativesBVOL),
+     parameters(other.parameters),
+     null_block_data(std::array<Realf,WID3> {}),
      sysBoundaryFlag(other.sysBoundaryFlag),
      sysBoundaryLayer(other.sysBoundaryLayer),
      velocity_block_with_content_list(other.velocity_block_with_content_list),
      velocity_block_with_no_content_list(other.velocity_block_with_no_content_list),
      initialized(other.initialized),
-     mpiTransferEnabled(other.mpiTransferEnabled),
-     populations(other.populations),
-     parameters(other.parameters),
-     derivativesBVOL(other.derivativesBVOL),
-     null_block_data(std::array<Realf,WID3> {}) {
+     mpiTransferEnabled(other.mpiTransferEnabled) {
    }
 
    /** Adds "important" and removes "unimportant" velocity blocks

--- a/spatial_cell.cpp
+++ b/spatial_cell.cpp
@@ -587,7 +587,6 @@ namespace spatial_cell {
 
       std::vector<MPI_Aint> displacements;
       std::vector<int> block_lengths;
-      vmesh::LocalID block_index = 0;
 
       // create datatype for actual data if we are in the first two 
       // layers around a boundary, or if we send for the whole system
@@ -890,7 +889,6 @@ namespace spatial_cell {
       }
       
       // Iterate over all octants, each octant corresponds to a different child:
-      bool removeBlock = false;
       for (int k_oct=0; k_oct<2; ++k_oct) for (int j_oct=0; j_oct<2; ++j_oct) for (int i_oct=0; i_oct<2; ++i_oct) {
          // Copy data belonging to the octant to a temporary array:
          Realf array[WID3];

--- a/spatial_cell.hpp
+++ b/spatial_cell.hpp
@@ -1599,7 +1599,7 @@ namespace spatial_cell {
     functions of the containers in spatial cell
     */
    inline uint64_t SpatialCell::get_cell_memory_size() {
-      const uint64_t VEL_BLOCK_SIZE = 2*WID3*sizeof(Realf) + BlockParams::N_VELOCITY_BLOCK_PARAMS*sizeof(Real);
+      //const uint64_t VEL_BLOCK_SIZE = 2*WID3*sizeof(Realf) + BlockParams::N_VELOCITY_BLOCK_PARAMS*sizeof(Real);
       uint64_t size = 0;
       size += vmeshTemp.sizeInBytes();
       size += blockContainerTemp.sizeInBytes();
@@ -1623,7 +1623,7 @@ namespace spatial_cell {
     the size() functions of the containers in spatial cell
     */
    inline uint64_t SpatialCell::get_cell_memory_capacity() {
-      const uint64_t VEL_BLOCK_SIZE = 2*WID3*sizeof(Realf) + BlockParams::N_VELOCITY_BLOCK_PARAMS*sizeof(Real);
+      //const uint64_t VEL_BLOCK_SIZE = 2*WID3*sizeof(Realf) + BlockParams::N_VELOCITY_BLOCK_PARAMS*sizeof(Real);
       uint64_t capacity = 0;
       
       capacity += vmeshTemp.capacityInBytes();

--- a/spatial_cell.hpp
+++ b/spatial_cell.hpp
@@ -313,6 +313,7 @@ namespace spatial_cell {
       //random_data* get_rng_data_buffer();
 
       // Member variables //
+      std::vector<spatial_cell::Population> populations;                        /**< Particle population variables.*/
       std::array<Real, bvolderivatives::N_BVOL_DERIVATIVES> derivativesBVOL;    /**< Derivatives of BVOL needed by the acceleration.            
                                                                                  * Separate array because it does not need to be communicated.*/
       //Real parameters[CellParams::N_SPATIAL_CELL_PARAMS];                     /**< Bulk variables in this spatial cell.*/
@@ -366,7 +367,6 @@ namespace spatial_cell {
                                                                                  * NOTE: Do not call the get-functions using this mesh as object
                                                                                  * before you have set the correct meshID using setMesh function.*/
       vmesh::VelocityBlockContainer<vmesh::LocalID> blockContainerTemp;
-      std::vector<spatial_cell::Population> populations;                        /**< Particle population variables.*/
    };
 
    /****************************

--- a/sysboundary/donotcompute.cpp
+++ b/sysboundary/donotcompute.cpp
@@ -40,8 +40,8 @@ namespace SBC {
    void DoNotCompute::getParameters() { }
    
    bool DoNotCompute::initSysBoundary(
-      creal& t,
-      Project &project
+      creal& t __attribute__((unused)),
+      Project &project __attribute__((unused))
    ) {
       precedence = 0;
       isThisDynamic = false;
@@ -49,13 +49,13 @@ namespace SBC {
    }
    
    bool DoNotCompute::assignSysBoundary(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&,
-                                        FsGrid< fsgrids::technical, 2> & technicalGrid) {
+                                        FsGrid< fsgrids::technical, 2> & technicalGrid __attribute__((unused))) {
       return true;
    }
    
    bool DoNotCompute::applyInitialState(
       const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid __attribute__((unused)),
       Project&
    ) {
       vector<CellID> cells = mpiGrid.get_cells();

--- a/sysboundary/donotcompute.h
+++ b/sysboundary/donotcompute.h
@@ -60,59 +60,59 @@ namespace SBC {
 
       // Explicit warning functions to inform the user if a doNotCompute cell gets computed
       virtual Real fieldSolverBoundaryCondMagneticField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBDt2Grid,
-         FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EGrid,
-         FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EDt2Grid,
-         FsGrid< fsgrids::technical, 2> & technicalGrid,
-         cint i,
-         cint j,
-         cint k,
-         creal& dt,
-         cuint& RKCase,
-         cuint& component
+         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid __attribute__((unused)),
+         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBDt2Grid __attribute__((unused)),
+         FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EGrid __attribute__((unused)),
+         FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EDt2Grid __attribute__((unused)),
+         FsGrid< fsgrids::technical, 2> & technicalGrid __attribute__((unused)),
+         cint i __attribute__((unused)),
+         cint j __attribute__((unused)),
+         cint k __attribute__((unused)),
+         creal& dt __attribute__((unused)),
+         cuint& RKCase __attribute__((unused)),
+         cuint& component __attribute__((unused))
       ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondMagneticField called!" << std::endl; return 0.;}
       virtual void fieldSolverBoundaryCondElectricField(
-         FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EGrid,
-         cint i,
-         cint j,
-         cint k,
-         cuint component
+         FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EGrid __attribute__((unused)),
+         cint i __attribute__((unused)),
+         cint j __attribute__((unused)),
+         cint k __attribute__((unused)),
+         cuint component __attribute__((unused))
       ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondElectricField called!" << std::endl;}
       virtual void fieldSolverBoundaryCondHallElectricField(
-         FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2> & EHallGrid,
-         cint i,
-         cint j,
-         cint k,
-         cuint component
+         FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, 2> & EHallGrid __attribute__((unused)),
+         cint i __attribute__((unused)),
+         cint j __attribute__((unused)),
+         cint k __attribute__((unused)),
+         cuint component __attribute__((unused))
       ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondHallElectricField called!" << std::endl;}
       virtual void fieldSolverBoundaryCondGradPeElectricField(
-         FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2> & EGradPeGrid,
-         cint i,
-         cint j,
-         cint k,
-         cuint component
+         FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, 2> & EGradPeGrid __attribute__((unused)),
+         cint i __attribute__((unused)),
+         cint j __attribute__((unused)),
+         cint k __attribute__((unused)),
+         cuint component __attribute__((unused))
       ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondGradPeElectricField called!" << std::endl;}
       virtual void fieldSolverBoundaryCondDerivatives(
-         FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2> & dPerBGrid,
-         FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2> & dMomentsGrid,
-         cint i,
-         cint j,
-         cint k,
-         cuint& RKCase,
-         cuint& component
+         FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, 2> & dPerBGrid __attribute__((unused)),
+         FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2> & dMomentsGrid __attribute__((unused)),
+         cint i __attribute__((unused)),
+         cint j __attribute__((unused)),
+         cint k __attribute__((unused)),
+         cuint& RKCase __attribute__((unused)),
+         cuint& component __attribute__((unused))
       ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondDerivatives called!" << std::endl;}
       virtual void fieldSolverBoundaryCondBVOLDerivatives(
-         FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2> & volGrid,
-         cint i,
-         cint j,
-         cint k,
-         cuint& component
+         FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2> & volGrid __attribute__((unused)),
+         cint i __attribute__((unused)),
+         cint j __attribute__((unused)),
+         cint k __attribute__((unused)),
+         cuint& component __attribute__((unused))
       ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondBVOLDerivatives called!" << std::endl;}
       virtual void vlasovBoundaryCondition(
-          const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-          const CellID& cellID,
-          const uint popID
+          const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid __attribute__((unused)),
+          const CellID& cellID __attribute__((unused)),
+          const uint popID __attribute__((unused))
       ) { std::cerr << "ERROR: DoNotCompute::vlasovBoundaryCondition called!" << std::endl;}
    };
 }

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -831,8 +831,7 @@ namespace SBC {
       const vmesh::LocalID* vblocks_ini = cell.get_velocity_grid_length(popID,refLevel);
 
       while (search) {
-         #warning TODO: add SpatialCell::getVelocityBlockMinValue() in place of sparseMinValue ? (if applicable)
-         if (0.1 * getObjectWrapper().particleSpecies[popID].sparseMinValue > 
+         if (0.1 * cell.getVelocityBlockMinValue(popID) >
             shiftedMaxwellianDistribution(popID,counter*cell.get_velocity_grid_block_size(popID,refLevel)[0], 0.0, 0.0)
             || counter > vblocks_ini[0]) {
             search = false;

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -145,7 +145,7 @@ namespace SBC {
    }
    
    bool Ionosphere::initSysBoundary(
-      creal& t,
+      creal& t __attribute__((unused)),
       Project &project
    ) {
       getParameters();
@@ -234,8 +234,8 @@ namespace SBC {
 
    bool Ionosphere::applyInitialState(
       const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
-      Project &project
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid __attribute__((unused)),
+      Project &project __attribute__((unused))
    ) {
       vector<CellID> cells = mpiGrid.get_cells();
       #pragma omp parallel for
@@ -687,7 +687,7 @@ namespace SBC {
       cint i,
       cint j,
       cint k,
-      cuint& RKCase,
+      cuint& RKCase __attribute__((unused)),
       cuint& component
    ) {
       this->setCellDerivativesToZero(dPerBGrid, dMomentsGrid, i, j, k, component);
@@ -706,9 +706,9 @@ namespace SBC {
    }
    
    void Ionosphere::vlasovBoundaryCondition(
-      const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      const CellID& cellID,
-      const uint popID
+      const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid __attribute__((unused)),
+      const CellID& cellID __attribute__((unused)),
+      const uint popID __attribute__((unused))
    ) {
 //       phiprof::start("vlasovBoundaryCondition (Ionosphere)");
 //       const SpatialCell * cell = mpiGrid[cellID];
@@ -720,7 +720,7 @@ namespace SBC {
     * NOTE: This function must initialize all particle species!
     * @param project
     */
-   void Ionosphere::generateTemplateCell(Project &project) {
+   void Ionosphere::generateTemplateCell(Project &project __attribute__((unused))) {
       // WARNING not 0.0 here or the dipole() function fails miserably.
       templateCell.sysBoundaryFlag = this->getIndex();
       templateCell.sysBoundaryLayer = 1;
@@ -748,12 +748,12 @@ namespace SBC {
             creal dvyCell = block_parameters[BlockParams::DVY];
             creal dvzCell = block_parameters[BlockParams::DVZ];
 
-            creal x = templateCell.parameters[CellParams::XCRD];
-            creal y = templateCell.parameters[CellParams::YCRD];
-            creal z = templateCell.parameters[CellParams::ZCRD];
-            creal dx = templateCell.parameters[CellParams::DX];
-            creal dy = templateCell.parameters[CellParams::DY];
-            creal dz = templateCell.parameters[CellParams::DZ];
+            //creal x = templateCell.parameters[CellParams::XCRD];
+            //creal y = templateCell.parameters[CellParams::YCRD];
+            //creal z = templateCell.parameters[CellParams::ZCRD];
+            //creal dx = templateCell.parameters[CellParams::DX];
+            //creal dy = templateCell.parameters[CellParams::DY];
+            //creal dz = templateCell.parameters[CellParams::DZ];
          
             // Calculate volume average of distrib. function for each cell in the block.
             for (uint kc=0; kc<WID; ++kc) for (uint jc=0; jc<WID; ++jc) for (uint ic=0; ic<WID; ++ic) {

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -613,17 +613,20 @@ namespace SBC {
       // Copy each face B-field from the cell on the other side of it
       switch(component) {
          case 0:
-	    return bGrid->get(i-1,j,k)->at(fsgrids::bfield::PERBX + component);
+                 return bGrid->get(i-1,j,k)->at(fsgrids::bfield::PERBX + component);
          case 1:
-	    return bGrid->get(i,j-1,k)->at(fsgrids::bfield::PERBX + component);
+                 return bGrid->get(i,j-1,k)->at(fsgrids::bfield::PERBX + component);
          case 2:
-	    return bGrid->get(i,j,k-1)->at(fsgrids::bfield::PERBX + component);
+                 return bGrid->get(i,j,k-1)->at(fsgrids::bfield::PERBX + component);
          default:
-	    cerr << "ERROR: ionosphere boundary tried to copy nonsensical magnetic field component " << component << endl;
-	    break;
+                 cerr << "ERROR: ionosphere boundary tried to copy nonsensical magnetic field component " << component << endl;
+                 break;
       }
       
 
+      // Under normal conditions, this should never be reached
+      // (but is still here to squelch compiler warnings)
+      return bGrid->get(i,j,k)->at(fsgrids::bfield::PERBX + component);
    }
 
    void Ionosphere::fieldSolverBoundaryCondElectricField(

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -169,8 +169,8 @@ namespace SBC {
    }
    
    bool Outflow::initSysBoundary(
-      creal& t,
-      Project &project
+      creal& t __attribute__((unused)),
+      Project &project __attribute__((unused))
    ) {
       /* The array of bool describes which of the x+, x-, y+, y-, z+, z- faces are to have outflow system boundary conditions.
        * A true indicates the corresponding face will have outflow.
@@ -282,7 +282,7 @@ namespace SBC {
    
    bool Outflow::applyInitialState(
       const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid __attribute__((unused)),
       Project &project
    ) {
       const vector<CellID>& cells = getLocalCells();
@@ -455,7 +455,7 @@ namespace SBC {
       cint i,
       cint j,
       cint k,
-      cuint& RKCase,
+      cuint& RKCase __attribute__((unused)),
       cuint& component
    ) {
       this->setCellDerivativesToZero(dPerBGrid, dMomentsGrid, i, j, k, component);

--- a/sysboundary/setbyuser.cpp
+++ b/sysboundary/setbyuser.cpp
@@ -49,7 +49,7 @@ namespace SBC {
    
    bool SetByUser::initSysBoundary(
       creal& t,
-      Project &project
+      Project &project __attribute__((unused))
    ) {
       /* The array of bool describes which of the x+, x-, y+, y-, z+, z- faces are to have user-set system boundary conditions.
        * A true indicates the corresponding face will have user-set system boundary conditions.
@@ -145,7 +145,7 @@ namespace SBC {
    bool SetByUser::applyInitialState(
       const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
-      Project &project
+      Project &project __attribute__((unused))
    ) {
       bool success = true;
       for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
@@ -157,16 +157,16 @@ namespace SBC {
    }
    
    Real SetByUser::fieldSolverBoundaryCondMagneticField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBDt2Grid,
-      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EGrid,
-      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EDt2Grid,
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBGrid __attribute__((unused)),
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, 2> & perBDt2Grid __attribute__((unused)),
+      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EGrid __attribute__((unused)),
+      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EDt2Grid __attribute__((unused)),
       FsGrid< fsgrids::technical, 2> & technicalGrid,
       cint i,
       cint j,
       cint k,
-      creal& dt,
-      cuint& RKCase,
+      creal& dt __attribute__((unused)),
+      cuint& RKCase __attribute__((unused)),
       cuint& component
    ) {
       Real result = 0.0;
@@ -248,7 +248,7 @@ namespace SBC {
       cint i,
       cint j,
       cint k,
-      cuint& RKCase,
+      cuint& RKCase __attribute__((unused)),
       cuint& component
    ) {
       this->setCellDerivativesToZero(dPerBGrid, dMomentsGrid, i, j, k, component);
@@ -265,9 +265,9 @@ namespace SBC {
    }
 
    void SetByUser::vlasovBoundaryCondition(
-      const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      const CellID& cellID,
-      const uint popID
+      const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid __attribute__((unused)),
+      const CellID& cellID __attribute__((unused)),
+      const uint popID __attribute__((unused))
    ) {
       // No need to do anything in this function, as the propagators do not touch the distribution function   
    }
@@ -467,7 +467,6 @@ namespace SBC {
    bool SetByUser::generateTemplateCells(creal& t) {
       #pragma omp parallel for
       for(uint i=0; i<6; i++) {
-         int index;
          if(facesToProcess[i]) {
             generateTemplateCell(templateCells[i], templateB[i], i, t);
          }

--- a/sysboundary/setbyuser.cpp
+++ b/sysboundary/setbyuser.cpp
@@ -404,9 +404,9 @@ namespace SBC {
          Real readParam;
          ret = 0;
          if ( typeid( readParam ) == typeid(double) ) {
-            for(uint i=0; i<nParams; i++) ret += fscanf(fp, "%lf", &readParam);
+            for(uint i=0; i<nParams; i++) ret += fscanf(fp, "%lf", (double*)&readParam);
          } else if( typeid( readParam ) == typeid(float) ) {
-            for(uint i=0; i<nParams; i++) ret += fscanf(fp, "%f", &readParam);
+            for(uint i=0; i<nParams; i++) ret += fscanf(fp, "%f", (float*)&readParam);
          } else {
             assert( typeid( readParam ) == typeid(float) || typeid( readParam ) == typeid(double) );
             
@@ -431,9 +431,9 @@ namespace SBC {
             Real readParam;
             int ret;
             if ( typeid( readParam ) == typeid(double) ) {
-               ret = fscanf(fp,"%lf",&readParam);
+               ret = fscanf(fp,"%lf",(double*)&readParam);
             } else if( typeid( readParam ) == typeid(float) ) {
-               ret = fscanf(fp,"%f",&readParam);
+               ret = fscanf(fp,"%f",(float*)&readParam);
             } else {
                assert( typeid( readParam ) == typeid(float) || typeid( readParam ) == typeid(double) ); 
             }

--- a/sysboundary/setmaxwellian.cpp
+++ b/sysboundary/setmaxwellian.cpp
@@ -253,12 +253,12 @@ namespace SBC {
             creal dvyCell = block_parameters[BlockParams::DVY];
             creal dvzCell = block_parameters[BlockParams::DVZ];
          
-            creal x = templateCell.parameters[CellParams::XCRD];
-            creal y = templateCell.parameters[CellParams::YCRD];
-            creal z = templateCell.parameters[CellParams::ZCRD];
-            creal dx = templateCell.parameters[CellParams::DX];
-            creal dy = templateCell.parameters[CellParams::DY];
-            creal dz = templateCell.parameters[CellParams::DZ];
+            //creal x = templateCell.parameters[CellParams::XCRD];
+            //creal y = templateCell.parameters[CellParams::YCRD];
+            //creal z = templateCell.parameters[CellParams::ZCRD];
+            //creal dx = templateCell.parameters[CellParams::DX];
+            //creal dy = templateCell.parameters[CellParams::DY];
+            //creal dz = templateCell.parameters[CellParams::DZ];
          
             // Calculate volume average of distrib. function for each cell in the block.
             for (uint kc=0; kc<WID; ++kc) for (uint jc=0; jc<WID; ++jc) for (uint ic=0; ic<WID; ++ic) {

--- a/sysboundary/setmaxwellian.cpp
+++ b/sysboundary/setmaxwellian.cpp
@@ -150,8 +150,7 @@ namespace SBC {
       const vmesh::LocalID* vblocks_ini = cell.get_velocity_grid_length(popID,refLevel);
 
       while (search) {
-         #warning TODO: add SpatialCell::getVelocityBlockMinValue() in place of sparseMinValue?
-         if (0.1 * getObjectWrapper().particleSpecies[popID].sparseMinValue > 
+         if (0.1 * cell.getVelocityBlockMinValue(popID) >
              maxwellianDistribution(
                                     popID,
                                     rho,

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -574,7 +574,7 @@ bool SysBoundary::applyInitialState(
  */
 void SysBoundary::applySysBoundaryVlasovConditions(
    dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-   creal& t
+   creal& t __attribute__((unused))
 ) {
    if(sysBoundaries.size()==0) {
       return; //no system boundaries

--- a/sysboundary/sysboundarycondition.cpp
+++ b/sysboundary/sysboundarycondition.cpp
@@ -791,9 +791,6 @@ namespace SBC {
    ) {
       const std::array<int,3> closestCell = getTheClosestNonsysboundaryCell(technicalGrid, i, j, k);
       
-      const std::array<int32_t, 3> gid = technicalGrid.getGlobalIndices(i, j, k);
-      const std::array<int32_t, 3> ngid = technicalGrid.getGlobalIndices(closestCell[0], closestCell[1], closestCell[2]);
-
       if (closestCell[0] == std::numeric_limits<int>::min()) {
          //cerr << "(" << gid[0] << "," << gid[1] << "," << gid[2] << ")" << __FILE__ << ":" << __LINE__ << ": No closest cell found!" << endl;
          //abort();
@@ -805,6 +802,8 @@ namespace SBC {
       }
 
       #ifndef NDEBUG
+      const std::array<int32_t, 3> gid = technicalGrid.getGlobalIndices(i, j, k);
+      const std::array<int32_t, 3> ngid = technicalGrid.getGlobalIndices(closestCell[0], closestCell[1], closestCell[2]);
       
       if ( technicalGrid.get(closestCell[0], closestCell[1], closestCell[2]) == nullptr ) {
          stringstream ss;

--- a/sysboundary/sysboundarycondition.cpp
+++ b/sysboundary/sysboundarycondition.cpp
@@ -334,7 +334,7 @@ namespace SBC {
    void SysBoundaryCondition::copyCellData(
             SpatialCell* from,
             SpatialCell* to,
-            bool allowBlockAdjustment,
+            bool allowBlockAdjustment __attribute__((unused)),
             const bool& copyMomentsOnly,
             const uint popID
    ) {
@@ -446,12 +446,6 @@ namespace SBC {
             const Realf* fromData = incomingCell->get_data(popID);
             for (vmesh::LocalID incBlockLID=0; incBlockLID<incomingCell->get_number_of_velocity_blocks(popID); ++incBlockLID) {
                // Check where cells are
-               creal vxBlock = blockParameters[BlockParams::VXCRD];
-               creal vyBlock = blockParameters[BlockParams::VYCRD];
-               creal vzBlock = blockParameters[BlockParams::VZCRD];
-               creal dvxCell = blockParameters[BlockParams::DVX];
-               creal dvyCell = blockParameters[BlockParams::DVY];
-               creal dvzCell = blockParameters[BlockParams::DVZ];
                
                // Global ID of the block containing incoming data
                vmesh::GlobalID incBlockGID = incomingCell->get_velocity_block_global_id(incBlockLID,popID);

--- a/velocity_mesh_old.h
+++ b/velocity_mesh_old.h
@@ -160,7 +160,7 @@ namespace vmesh {
    }
    
    template<typename GID,typename LID> inline
-   bool VelocityMesh<GID,LID>::coarsenAllowed(const GID& globalID) const {
+   bool VelocityMesh<GID,LID>::coarsenAllowed(const GID& globalID __attribute__((unused))) const {
       return false;
    }
    
@@ -620,7 +620,7 @@ namespace vmesh {
    }
    
    template<typename GID,typename LID> inline
-   bool VelocityMesh<GID,LID>::refine(const GID& globalID,std::set<GID>& erasedBlocks,std::map<GID,LID>& insertedBlocks) {
+   bool VelocityMesh<GID,LID>::refine(const GID& globalID __attribute__((unused)),std::set<GID>& erasedBlocks __attribute__((unused)),std::map<GID,LID>& insertedBlocks __attribute__((unused))) {
       return false;
    }
 

--- a/velocity_mesh_old.h
+++ b/velocity_mesh_old.h
@@ -183,7 +183,7 @@ namespace vmesh {
    }
    
    template<typename GID,typename LID> inline
-   GID VelocityMesh<GID,LID>::findBlockDown(uint8_t& refLevel,GID cellIndices[3]) const {
+   GID VelocityMesh<GID,LID>::findBlockDown(uint8_t& refLevel __attribute__((unused)),GID cellIndices[3]) const {
       // Calculate i/j/k indices of the block that would own the cell:
       GID i_block = cellIndices[0] / meshParameters[meshID].blockLength[0];
       GID j_block = cellIndices[1] / meshParameters[meshID].blockLength[1];
@@ -269,12 +269,12 @@ namespace vmesh {
    }
 
    template<typename GID,typename LID> inline
-   const Real* VelocityMesh<GID,LID>::getBlockSize(const uint8_t& refLevel) const {
+   const Real* VelocityMesh<GID,LID>::getBlockSize(const uint8_t& refLevel __attribute__((unused))) const {
       return meshParameters[meshID].blockSize;
    }
    
    template<typename GID,typename LID> inline
-   bool VelocityMesh<GID,LID>::getBlockSize(const GID& globalID,Real size[3]) const {
+   bool VelocityMesh<GID,LID>::getBlockSize(const GID& globalID __attribute__((unused)),Real size[3]) const {
       size[0] = meshParameters[meshID].blockSize[0];
       size[1] = meshParameters[meshID].blockSize[1];
       size[2] = meshParameters[meshID].blockSize[2];
@@ -282,12 +282,12 @@ namespace vmesh {
    }
    
    template<typename GID,typename LID> inline
-   const Real* VelocityMesh<GID,LID>::getCellSize(const uint8_t& refLevel) const {
+   const Real* VelocityMesh<GID,LID>::getCellSize(const uint8_t& refLevel __attribute__((unused))) const {
       return meshParameters[meshID].cellSize;
    }
 
    template<typename GID,typename LID> inline
-   bool VelocityMesh<GID,LID>::getCellSize(const GID& globalID,Real size[3]) const {
+   bool VelocityMesh<GID,LID>::getCellSize(const GID& globalID __attribute__((unused)),Real size[3]) const {
       size[0] = meshParameters[meshID].cellSize[0];
       size[1] = meshParameters[meshID].cellSize[1];
       size[2] = meshParameters[meshID].cellSize[2];
@@ -295,7 +295,7 @@ namespace vmesh {
    }
    
    template<typename GID,typename LID> inline
-   void VelocityMesh<GID,LID>::getChildren(const GID& globalID,std::vector<GID>& children) const {
+   void VelocityMesh<GID,LID>::getChildren(const GID& globalID __attribute__((unused)),std::vector<GID>& children) const {
       children.clear();
       return;
    }
@@ -312,7 +312,7 @@ namespace vmesh {
    }
 
    template<typename GID,typename LID> inline
-   GID VelocityMesh<GID,LID>::getGlobalID(const uint8_t& refLevel,const Real* coords) const {
+   GID VelocityMesh<GID,LID>::getGlobalID(const uint8_t& refLevel __attribute__((unused)),const Real* coords) const {
       if (coords[0] < meshParameters[meshID].meshMinLimits[0] || coords[0] >= meshParameters[meshID].meshMaxLimits[0] ||
          (coords[1] < meshParameters[meshID].meshMinLimits[1] || coords[1] >= meshParameters[meshID].meshMaxLimits[1] ||
           coords[2] < meshParameters[meshID].meshMinLimits[2] || coords[2] >= meshParameters[meshID].meshMaxLimits[2])) {
@@ -339,7 +339,7 @@ namespace vmesh {
    }
    
    template<typename GID,typename LID> inline
-   GID VelocityMesh<GID,LID>::getGlobalID(const uint32_t& refLevel,const LID& i,const LID& j,const LID& k) const {
+   GID VelocityMesh<GID,LID>::getGlobalID(const uint32_t& refLevel __attribute__((unused)),const LID& i,const LID& j,const LID& k) const {
       if (i >= meshParameters[meshID].gridLength[0] || j >= meshParameters[meshID].gridLength[1] || k >= meshParameters[meshID].gridLength[2]) {
          return invalidGlobalID();
       }
@@ -358,7 +358,7 @@ namespace vmesh {
    }
 
    template<typename GID,typename LID> inline
-   const LID* VelocityMesh<GID,LID>::getGridLength(const uint8_t& refLevel) const {
+   const LID* VelocityMesh<GID,LID>::getGridLength(const uint8_t& refLevel __attribute__((unused))) const {
       return meshParameters[meshID].gridLength;
    }
    
@@ -479,7 +479,7 @@ namespace vmesh {
    }
    
    template<typename GID,typename LID> inline
-   uint8_t VelocityMesh<GID,LID>::getRefinementLevel(const GID& globalID) const {
+   uint8_t VelocityMesh<GID,LID>::getRefinementLevel(const GID& globalID __attribute__((unused))) const {
       return 0;
    }
 
@@ -506,12 +506,12 @@ namespace vmesh {
    }
    
    template<typename GID,typename LID> inline
-   bool VelocityMesh<GID,LID>::hasChildren(const GID& globalID) const {
+   bool VelocityMesh<GID,LID>::hasChildren(const GID& globalID __attribute__((unused))) const {
       return false;
    }
 
    template<typename GID,typename LID> inline
-   GID VelocityMesh<GID,LID>::hasGrandParent(const GID& globalID) const {
+   GID VelocityMesh<GID,LID>::hasGrandParent(const GID& globalID __attribute__((unused))) const {
       return invalidGlobalID();
    }
       

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -220,7 +220,6 @@ bool computeNewTimeStep(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
       isChanged=true;
 
       //set new timestep to the lowest one of all interval-midpoints
-      const Real half = 0.5;
       newDt = meanVlasovCFL * dtMaxGlobal[0];
       newDt = min(newDt,meanVlasovCFL * dtMaxGlobal[1] * P::maxSlAccelerationSubcycles);
       newDt = min(newDt,meanFieldsCFL * dtMaxGlobal[2] * P::maxFieldSolverSubcycles);
@@ -281,7 +280,6 @@ void recalculateLocalCellsCache() {
 }
 
 int main(int argn,char* args[]) {
-   bool success = true;
    int myRank, doBailout;
    const creal DT_EPSILON=1e-12;
    typedef Parameters P;
@@ -306,7 +304,6 @@ int main(int argn,char* args[]) {
    MPI_Comm comm = MPI_COMM_WORLD;
    MPI_Comm_rank(comm,&myRank);
    SysBoundary sysBoundaries;
-   bool isSysBoundaryCondDynamic;
    
    #ifdef CATCH_FPE
    // WARNING FE_INEXACT is too sensitive to be used. See man fenv.
@@ -451,13 +448,10 @@ int main(int argn,char* args[]) {
       momentsGrid,
       momentsDt2Grid,
       EGrid,
-      EGradPeGrid,
-      volGrid,
       technicalGrid,
       sysBoundaries,
       *project
    );
-   isSysBoundaryCondDynamic = sysBoundaries.isDynamic();
    
    const std::vector<CellID>& cells = getLocalCells();
    
@@ -761,7 +755,7 @@ int main(int argn,char* args[]) {
                   BgBGrid,
                   volGrid,
                   technicalGrid,
-                  outputReducer,"restart",(uint)P::t, P::restartStripeFactor) == false ) {
+                  "restart",(uint)P::t, P::restartStripeFactor) == false ) {
             logFile << "(IO): ERROR Failed to write restart!" << endl << writeVerbose;
             cerr << "FAILED TO WRITE RESTART" << endl;
          }

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -392,9 +392,9 @@ int main(int argn,char* args[]) {
    // Needs to be done here already ad the background field will be set right away, before going to initializeGrid even
    phiprof::start("Init fieldsolver grids");
 
-   const std::array<int,3> fsGridDimensions = {convert<int>(P::xcells_ini) * pow(2,P::amrMaxSpatialRefLevel),
-                                               convert<int>(P::ycells_ini) * pow(2,P::amrMaxSpatialRefLevel),
-                                               convert<int>(P::zcells_ini) * pow(2,P::amrMaxSpatialRefLevel)};
+   const std::array<int,3> fsGridDimensions = {convert<int>(P::xcells_ini) * (1<<P::amrMaxSpatialRefLevel),
+                                               convert<int>(P::ycells_ini) * (1<<P::amrMaxSpatialRefLevel),
+                                               convert<int>(P::zcells_ini) * (1<<P::amrMaxSpatialRefLevel)};
 
    std::array<bool,3> periodicity{sysBoundaries.isBoundaryPeriodic(0),
                                   sysBoundaries.isBoundaryPeriodic(1),
@@ -783,7 +783,6 @@ int main(int argn,char* args[]) {
       
       //Re-loadbalance if needed
       //TODO - add LB measure and do LB if it exceeds threshold
-      #warning Re-loadbalance has been disabled temporarily for amr debugging
       if(((P::tstep % P::rebalanceInterval == 0 && P::tstep > P::tstep_min) || overrideRebalanceNow)) {
          logFile << "(LB): Start load balance, tstep = " << P::tstep << " t = " << P::t << endl << writeVerbose;
          balanceLoad(mpiGrid, sysBoundaries);

--- a/vlasovsolver/cpu_1d_pqm.hpp
+++ b/vlasovsolver/cpu_1d_pqm.hpp
@@ -36,7 +36,6 @@ using namespace std;
 
 /*make sure quartic polynomial is monotonic*/
 inline void filter_pqm_monotonicity(Vec *values, uint k, Vec &fv_l, Vec &fv_r, Vec &fd_l, Vec &fd_r){   
-   const Vec root_outside = Vec(100.0); //fixed values give to roots clearly outside [0,1], or nonexisting ones*/
    /*second derivative coefficients, eq 23 in white et al.*/
    Vec b0 =   60.0 * values[k] - 24.0 * fv_r - 36.0 * fv_l + 3.0 * (fd_r - 3.0 * fd_l);
    Vec b1 = -360.0 * values[k] + 36.0 * fd_l - 24.0 * fd_r + 168.0 * fv_r + 192.0 * fv_l;

--- a/vlasovsolver/cpu_acc_intersections.cpp
+++ b/vlasovsolver/cpu_acc_intersections.cpp
@@ -67,7 +67,7 @@ Intersection z coordinate for (i,j,k) is: intersection + i * intersection_di + j
 \param intersection_dk Change in z-coordinate for a change in k index of 1 */
 void compute_intersections_1st(
         const vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh,
-        const Transform<Real,3,Affine>& bwd_transform,const Transform<Real,3,Affine>& fwd_transform,
+        const Transform<Real,3,Affine>& bwd_transform,const Transform<Real,3,Affine>& fwd_transform __attribute__((unused)),
         uint dimension,const uint8_t& refLevel,
         Real& intersection,Real& intersection_di,Real& intersection_dj,Real& intersection_dk) {
     
@@ -180,7 +180,7 @@ void compute_intersections_1st(
   \param intersection_dk Change in x-coordinate for a change in k index of 1*/
 void compute_intersections_2nd(
         const vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh,
-        const Transform<Real,3,Affine>& bwd_transform,const Transform<Real,3,Affine>& fwd_transform,
+        const Transform<Real,3,Affine>& bwd_transform,const Transform<Real,3,Affine>& fwd_transform __attribute__((unused)),
         uint dimension,const uint8_t& refLevel,
         Real& intersection,Real& intersection_di,Real& intersection_dj,Real& intersection_dk){
        
@@ -309,7 +309,7 @@ void compute_intersections_2nd(
   euclidian y goes from vy_min to vy_max, this is mapped to wherever y plane is in lagrangian.*/
 void compute_intersections_3rd(
     const vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh,
-    const Transform<Real,3,Affine>& bwd_transform,const Transform<Real,3,Affine>& fwd_transform,
+    const Transform<Real,3,Affine>& bwd_transform,const Transform<Real,3,Affine>& fwd_transform __attribute__((unused)),
     uint dimension,const uint8_t& refLevel,
     Real& intersection,Real& intersection_di,Real& intersection_dj,Real& intersection_dk) {
     

--- a/vlasovsolver/cpu_acc_map.cpp
+++ b/vlasovsolver/cpu_acc_map.cpp
@@ -419,9 +419,9 @@ bool map_1d(SpatialCell* spatial_cell,
                i_indices * cell_indices_to_id[0] +
                j_indices * cell_indices_to_id[1];
        
-            const int target_block_index_common =
-               block_indices_begin[0] * block_indices_to_id[0] +
-               block_indices_begin[1] * block_indices_to_id[1];
+            //const int target_block_index_common =
+            //   block_indices_begin[0] * block_indices_to_id[0] +
+            //   block_indices_begin[1] * block_indices_to_id[1];
        
             /* 
                intersection_min is the intersection z coordinate (z after
@@ -503,7 +503,7 @@ bool map_1d(SpatialCell* spatial_cell,
                   const int blockK = gk/WID;
                   const int gk_mod_WID = (gk - blockK * WID);
                   //the block of the Lagrangian cell to which we map
-                  const int target_block(target_block_index_common + blockK * block_indices_to_id[2]);
+                  //const int target_block(target_block_index_common + blockK * block_indices_to_id[2]);
                   
                   //cell indices in the target block  (TODO: to be replaced by
                   //compile time generated scatter write operation)

--- a/vlasovsolver/cpu_acc_map.cpp
+++ b/vlasovsolver/cpu_acc_map.cpp
@@ -311,14 +311,14 @@ bool map_1d(SpatialCell* spatial_cell,
          const int firstBlock_gk = (int)((firstBlockMinV - max_intersectionMin)/intersection_dk);
          const int lastBlock_gk = (int)((lastBlockMaxV - min_intersectionMin)/intersection_dk);
 
-         int firstBlockIndexK = firstBlock_gk/WID;         
+         int firstBlockIndexK = firstBlock_gk/WID;
          int lastBlockIndexK = lastBlock_gk/WID;
          
          //now enforce mesh limits for target column blocks
-         firstBlockIndexK = (firstBlockIndexK >= 0)            ? firstBlockIndexK : 0;
-         firstBlockIndexK = (firstBlockIndexK < max_v_length ) ? firstBlockIndexK : max_v_length - 1;
-         lastBlockIndexK  = (lastBlockIndexK  >= 0)            ? lastBlockIndexK  : 0;
-         lastBlockIndexK  = (lastBlockIndexK  < max_v_length ) ? lastBlockIndexK  : max_v_length - 1;
+         firstBlockIndexK = (firstBlockIndexK >= 0)                 ? firstBlockIndexK : 0;
+         firstBlockIndexK = (firstBlockIndexK < (int)max_v_length ) ? firstBlockIndexK : max_v_length - 1;
+         lastBlockIndexK  = (lastBlockIndexK  >= 0)                 ? lastBlockIndexK  : 0;
+         lastBlockIndexK  = (lastBlockIndexK  < (int)max_v_length ) ? lastBlockIndexK  : max_v_length - 1;
          
          //store source blocks
          for (uint blockK = firstBlockIndices[2]; blockK <= lastBlockIndices[2]; blockK++){

--- a/vlasovsolver/cpu_acc_semilag.cpp
+++ b/vlasovsolver/cpu_acc_semilag.cpp
@@ -76,7 +76,6 @@ uint getAccelerationSubcycles(SpatialCell* spatial_cell, Real dt, const uint pop
  * @param spatial_cell Spatial cell containing the accelerated population.
  * @param popID ID of the accelerated particle species.
  * @param vmesh Velocity mesh.
- * @param blockContainer Velocity block data container.
  * @param map_order Order in which vx,vy,vz mappings are performed. 
  * @param dt Time step of one subcycle.
 */
@@ -88,7 +87,6 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
    double t1 = MPI_Wtime();
 
    vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh    = spatial_cell->get_velocity_mesh(popID);
-   vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = spatial_cell->get_velocity_blocks(popID);
 
    // compute transform, forward in time and backward in time
    phiprof::start("compute-transform");

--- a/vlasovsolver/cpu_face_estimates.hpp
+++ b/vlasovsolver/cpu_face_estimates.hpp
@@ -461,9 +461,9 @@ inline void compute_filtered_face_values_nonuniform_conserving(const Vec * const
   slope_limiter(values[k -1], values[k], values[k + 1], slope_abs, slope_sign);
   
   //check for extrema  
-  Vecb is_extrema = (slope_abs == Vec(0.0));
-  Vecb filter_l = (values[k - 1] - fv_l) * (fv_l - values[k]) < 0 ;
-  Vecb filter_r = (values[k + 1] - fv_r) * (fv_r - values[k]) < 0;
+  //Vecb is_extrema = (slope_abs == Vec(0.0));
+  //Vecb filter_l = (values[k - 1] - fv_l) * (fv_l - values[k]) < 0 ;
+  //Vecb filter_r = (values[k + 1] - fv_r) * (fv_r - values[k]) < 0;
   //  if(horizontal_or(is_extrema) || horizontal_or(filter_l) || horizontal_or(filter_r)) {
   // Colella & Sekora, eq. 20
   if(horizontal_or((fv_r - values[k]) * (values[k] - fv_l) <= Vec(0.0))

--- a/vlasovsolver/cpu_moments.cpp
+++ b/vlasovsolver/cpu_moments.cpp
@@ -154,7 +154,6 @@ void calculateMoments_R(
         const bool& computeSecond) {
  
     phiprof::start("compute-moments-n");
-    creal HALF = 0.5;
 
     for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
        #pragma omp parallel for
@@ -172,10 +171,6 @@ void calculateMoments_R(
              cell->parameters[CellParams::P_22_R] = 0.0;
              cell->parameters[CellParams::P_33_R] = 0.0;
           }
-
-          const Real dx = cell->parameters[CellParams::DX];
-          const Real dy = cell->parameters[CellParams::DY];
-          const Real dz = cell->parameters[CellParams::DZ];
 
           vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = cell->get_velocity_blocks(popID);
           if (blockContainer.size() == 0) continue;

--- a/vlasovsolver/cpu_trans_map.cpp
+++ b/vlasovsolver/cpu_trans_map.cpp
@@ -326,7 +326,7 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
                   const uint popID) {
    // values used with an stencil in 1 dimension, initialized to 0. 
    // Contains a block, and its spatial neighbours in one dimension.
-   Realv dz,z_min, dvz,vz_min;
+   Realv dz,dvz,vz_min;
    uint cell_indices_to_id[3]; /*< used when computing id of target cell in block*/
    unsigned char  cellid_transpose[WID3]; /*< defines the transpose for the solver internal (transposed) id: i + j*WID + k*WID2 to actual one*/
 
@@ -391,7 +391,6 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
    switch (dimension) {
    case 0:
       dz = P::dx_ini;
-      z_min = P::xmin;
       // set values in array that is used to convert block indices 
       // to global ID using a dot product.
       cell_indices_to_id[0]=WID2;
@@ -400,7 +399,6 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
       break;
    case 1:
       dz = P::dy_ini;
-      z_min = P::ymin;
       // set values in array that is used to convert block indices 
       // to global ID using a dot product
       cell_indices_to_id[0]=1;
@@ -409,7 +407,6 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
       break;
    case 2:
       dz = P::dz_ini;
-      z_min = P::zmin;
       // set values in array that is used to convert block indices
       // to global id using a dot product.
       cell_indices_to_id[0]=1;
@@ -460,7 +457,6 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
 
       
          for(uint celli = 0; celli < localPropagatedCells.size(); celli++){
-            SpatialCell *spatial_cell = allCellsPointer[celli];
             const CellID cellID =  localPropagatedCells[celli];
             const vmesh::LocalID blockLID = allCellsBlockLocalID[celli];
             

--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -882,7 +882,7 @@ bool checkPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
       
    }
 
-   for (int ipencil = 0; ipencil < pencils.N; ++ipencil) {
+   for (uint ipencil = 0; ipencil < pencils.N; ++ipencil) {
 
       auto ids = pencils.getIds(ipencil);
 

--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -104,8 +104,6 @@ void computeSpatialSourceCellsForPencil(const dccrg::Dccrg<SpatialCell,dccrg::Ca
    const auto* frontNbrPairs = mpiGrid.get_neighbors_of(ids.front(), neighborhood);
    const auto* backNbrPairs  = mpiGrid.get_neighbors_of(ids.back(),  neighborhood);
 
-   int maxRefLvl = mpiGrid.get_maximum_refinement_level();
-      
    // Create list of unique distances in the negative direction from the first cell in pencil
    std::set< int > distances;
    for (const auto nbrPair : *frontNbrPairs) {

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -65,9 +65,9 @@ creal EPSILON = 1.0e-25;
  */
 void calculateSpatialTranslation(
         dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-        const vector<CellID>& localCells,
+        const vector<CellID>& localCells __attribute__((unused)),
         const vector<CellID>& local_propagated_cells,
-        const vector<CellID>& local_target_cells,
+        const vector<CellID>& local_target_cells __attribute__((unused)),
         const vector<CellID>& remoteTargetCellsx,
         const vector<CellID>& remoteTargetCellsy,
         const vector<CellID>& remoteTargetCellsz,

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -75,7 +75,6 @@ void calculateSpatialTranslation(
         const uint popID) {
 
     int trans_timer;
-    bool localTargetGridGenerated = false;
     
     int myRank;
     MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
@@ -190,7 +189,6 @@ void calculateSpatialTranslation(
 void calculateSpatialTranslation(
         dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
         creal dt) {
-   typedef Parameters P;
    
    phiprof::start("semilag-trans");
 


### PR DESCRIPTION
Since they've been nagging me for quite a while now: This pull request removes a whole lot of compilation warnings.
Mostly in the form of "Warning: unused parameter xyz" (fixed by flagging them as ```__attribute__((unused))```), and a bunch of "signed-unsigned comparisons" (fixed by changing the datatype of the loop counter, in cases where it will not cause integer promotion overflow problems).

This *also* fixes the handwritten warnings in project initialization, where per-population overall sparsity limits were employed instead of per-cell/per-population limits, and still requires testing that it didn't break anything.

Also, there are still a bunch of warnings left to fix.