### PR TITLE
Remove MPI-2 C++ interface from particle pusher, so that it is MPI-3 compatible

### DIFF
--- a/MAKE/Makefile.taito_gcc
+++ b/MAKE/Makefile.taito_gcc
@@ -46,7 +46,7 @@ FLAGS =
 #GNU flags:
 CC_BRAND = gcc
 CC_BRAND_VERSION = 4.9.3
-CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++0x -W -Wall -Wno-unused -fabi-version=0 -mavx2 
+CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++0x -W -Wall -Wno-unused -fabi-version=0 -mavx
 testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++0x -fabi-version=0  -mavx
 
 MATHFLAGS = -ffast-math

--- a/MAKE/Makefile.taito_gcc
+++ b/MAKE/Makefile.taito_gcc
@@ -1,5 +1,5 @@
-CMP = mpiCC
-LNK = mpiCC
+CMP = mpic++
+LNK = mpic++
 
 #======== Vectorization ==========
 #Set vector backend type for vlasov solvers, sets precision and length. 
@@ -50,7 +50,7 @@ CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++0x -W -Wall -Wno-unused -fabi-ve
 testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++0x -fabi-version=0  -mavx
 
 MATHFLAGS = -ffast-math
-LDFLAGS = -lrt
+LDFLAGS = -lrt -lgfortran
 LIB_MPI = -lgomp
 
 # BOOST_VERSION = current trilinos version
@@ -58,7 +58,7 @@ LIB_MPI = -lgomp
 #
 #======== Libraries ===========
 
-MPT_VERSION = 1.10.2
+MPT_VERSION = 3.1.3
 JEMALLOC_VERSION = 4.0.4
 LIBRARY_PREFIX = /proj/vlasov/libraries
 
@@ -72,12 +72,14 @@ LIB_ZOLTAN = -L$(LIBRARY_PREFIX)/taito/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_B
 
 INC_JEMALLOC = -I$(LIBRARY_PREFIX)/taito/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/jemalloc/$(JEMALLOC_VERSION)/include
 LIB_JEMALLOC = -L$(LIBRARY_PREFIX)/taito/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/jemalloc/$(JEMALLOC_VERSION)/lib -ljemalloc
+LDFLAGS += -Wl,-rpath=$(LIBRARY_PREFIX)/taito/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/jemalloc/$(JEMALLOC_VERSION)/lib
 
 INC_VLSV = -I$(LIBRARY_PREFIX)/taito/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/vlsv
 LIB_VLSV = -L$(LIBRARY_PREFIX)/taito/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/vlsv -lvlsv
 
 LIB_PROFILE = -L$(LIBRARY_PREFIX)/taito/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/phiprof/2.0/lib -lphiprof
 INC_PROFILE = -I$(LIBRARY_PREFIX)/taito/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/phiprof/2.0/include
+LDFLAGS += -Wl,-rpath=$(LIBRARY_PREFIX)/taito/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/phiprof/2.0/lib 
 
 #LIB_PAPI = -L$(LIBRARY_PREFIX)/taito/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/papi/5.5.0/lib -lpapi
 #INC_PAPI = -I$(LIBRARY_PREFIX)/taito/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/papi/5.5.0/include

--- a/particles/histogram.h
+++ b/particles/histogram.h
@@ -49,7 +49,8 @@ class Histogram1D
             return;
          }
 
-         MPI::COMM_WORLD.Allreduce(bins,targetbins,num_bins,MPI::DOUBLE,MPI_SUM);
+         MPI_Allreduce(bins,targetbins,num_bins,MPI_DOUBLE,MPI_SUM, MPI_COMM_WORLD);
+
 
          /* Throw away the old bins. */
          delete[] bins;
@@ -150,7 +151,7 @@ class Histogram2D
             return;
          }
 
-         MPI::COMM_WORLD.Allreduce(bins, targetbins, num_bins[0] * num_bins[1], MPI::DOUBLE, MPI_SUM);
+         MPI_Allreduce(bins,targetbins, num_bins[0] * num_bins[1], MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 
          /* Throw away the old bins. */
          delete[] bins;
@@ -398,7 +399,7 @@ class Histogram3D
             return;
          }
 
-         MPI::COMM_WORLD.Allreduce(bins, targetbins, num_bins[0] * num_bins[1] * num_bins[2], MPI::FLOAT, MPI_SUM);
+         MPI_Allreduce(bins, targetbins, num_bins[0] * num_bins[1] * num_bins[2], MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
 
          /* Throw away the old bins. */
          delete[] bins;

--- a/particles/particle_post_pusher.cpp
+++ b/particles/particle_post_pusher.cpp
@@ -137,6 +137,11 @@ int main(int argc, char** argv) {
          Eval = cur_E(particles[i].x);
          Bval = cur_B(particles[i].x);
 
+         if(dt < 0) {
+           // If propagating backwards in time, flip B-field pseudovector
+           Bval *= -1;
+         }
+
          /* Push them around */
          particles[i].push(Bval,Eval,dt);
 

--- a/particles/particle_post_pusher.cpp
+++ b/particles/particle_post_pusher.cpp
@@ -39,7 +39,7 @@
 
 int main(int argc, char** argv) {
 
-   MPI::Init(argc, argv);
+   MPI_Init(&argc, &argv);
 
    /* Parse commandline and config*/
    Readparameters parameters(argc, argv, MPI_COMM_WORLD);
@@ -47,6 +47,7 @@ int main(int argc, char** argv) {
    parameters.parse(false);  // Parse parameters and don't require run_config
    if(!ParticleParameters::getParameters()) {
       std::cerr << "Parsing parameters failed, aborting." << std::endl;
+      std::cerr << "Did you add a --run_config=file.cfg parameter?" << std::endl;
       return 1;
    }
 
@@ -176,6 +177,6 @@ int main(int argc, char** argv) {
 
    std::cerr << std::endl;
 
-   MPI::Finalize();
+   MPI_Finalize();
    return 0;
 }

--- a/particles/particleparameters.cpp
+++ b/particles/particleparameters.cpp
@@ -40,6 +40,9 @@ Real P::input_dt = 1;
 Real P::start_time = 0;
 Real P::end_time = 0;
 uint64_t P::num_particles = 0;
+std::string P::V_field_name = "V";
+std::string P::rho_field_name = "rho";
+bool P::divide_rhov_by_rho = false;
 
 std::default_random_engine::result_type P::random_seed = 1;
 Distribution* (*P::distribution)(std::default_random_engine&) = NULL;
@@ -88,6 +91,9 @@ bool ParticleParameters::addParameters() {
    Readparameters::add("particles.start_time", "Simulation time (seconds) for particle start.",0);
    Readparameters::add("particles.end_time", "Simulation time (seconds) at which particle simulation stops.",0);
    Readparameters::add("particles.num_particles", "Number of particles to simulate.",10000);
+   Readparameters::add("particles.V_field_name", "Name of the Velocity data set in the input files", "V");
+   Readparameters::add("particles.rho_field_name", "Name of the Density data set in the input files", "rho");
+   Readparameters::add("particles.divide_rhov_by_rho", "Do the input file store rho_v and rho separately?", false);
    Readparameters::add("particles.random_seed", "Random seed for particle creation.",1);
    Readparameters::add("particles.distribution", "Type of distribution function to sample particles from.",
          std::string("maxwell"));
@@ -161,10 +167,13 @@ bool ParticleParameters::getParameters() {
    Readparameters::get("particles.start_time",P::start_time);
    Readparameters::get("particles.end_time",P::end_time);
    Readparameters::get("particles.num_particles",P::num_particles);
-   if(P::dt == 0 || P::end_time <= P::start_time) {
-      std::cerr << "Error end_time <= start_time! Won't do anything (and will probably crash now)." << std::endl;
+   if(P::dt == 0 || P::end_time == P::start_time) {
+      std::cerr << "Error end_time == start_time! Won't do anything (and will probably crash now)." << std::endl;
       return false;
    }
+   Readparameters::get("particles.V_field_name",P::V_field_name);
+   Readparameters::get("particles.rho_field_name",P::rho_field_name);
+   Readparameters::get("particles.divide_rhov_by_rho",P::divide_rhov_by_rho);
 
    Readparameters::get("particles.random_seed",P::random_seed);
 

--- a/particles/particleparameters.h
+++ b/particles/particleparameters.h
@@ -45,6 +45,9 @@ struct ParticleParameters {
    static Real input_dt; /*!< Time interval between input files */
 
    static uint64_t num_particles; /*!< Number of particles to generate */
+   static std::string V_field_name; /*!< Name of the Velocity data set to read */
+   static std::string rho_field_name; /*!< Name of the Density data set to read */
+   static bool divide_rhov_by_rho; /*!< Does the file store rho_v and rho separately? */
 
    static Boundary* boundary_behaviour_x; /*!< What to do with particles that reach the x boundary */
    static Boundary* boundary_behaviour_y; /*!< What to do with particles that reach the y boundary */

--- a/particles/particles.cfg
+++ b/particles/particles.cfg
@@ -4,7 +4,11 @@
 # with an integer argument counting up the input files.
 # Typical vlasiator output files have the form "bulk.%07i.vlsv"
 #input_filename_pattern = /lustre/tmp/alfthan/2D/sisu_equatorial_7/bulk.%07i.vlsv
-input_filename_pattern = /tmp/lustre/tmp/alfthan/2D/ABC/bulk/bulk.%07i.vlsv
+input_filename_pattern = /proj/vlasov/2D/ABC/bulk/bulk.%07i.vlsv
+
+V_field_name = rho_v
+rho_field_name = rho
+divide_rhov_by_rho = 1
 
 # Output filename pattern, similar format as before.
 output_filename_pattern = particles.%07i.vlsv

--- a/particles/readfields.cpp
+++ b/particles/readfields.cpp
@@ -27,6 +27,7 @@
 #include "readfields.h"
 #include "vectorclass.h"
 #include "vector3d.h"
+#include "particleparameters.h"
 #include "../definitions.h"
 
 /* Debugging image output */


### PR DESCRIPTION
This allows it to be built on taito with the openmpi module version 3.
Libraries have been rebuilt to work with that version, too.

(```module load gcc; module load openmpi```)