### PR TITLE
Only access the GPU from one openmp thread.

### DIFF
--- a/MAKE/Makefile.puhti_pgi
+++ b/MAKE/Makefile.puhti_pgi
@@ -21,7 +21,7 @@ endif
 
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
-#CXXFLAGS +=  -DPAPI_MEM
+CXXFLAGS +=  -DPAPI_MEM
 CXXFLAGS += -DMAX_VECTOR_LENGTH=256
 
 #======== Allocator =========
@@ -80,7 +80,7 @@ LIB_VLSV = -L$(LIBRARY_PREFIX)/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VER
 LIB_PROFILE = -L$(LIBRARY_PREFIX)/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/phiprof_nvtx/lib -lphiprof -lgfortran -Wl,-rpath=$(LIBRARY_PREFIX)/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/phiprof_nvtx/lib -L$(CUDA_INSTALL_ROOT)/lib64 -lnvToolsExt
 INC_PROFILE = -I$(LIBRARY_PREFIX)/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/phiprof_nvtx/include 
 
-#LIB_PAPI = -L$(LIBRARY_PREFIX)/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/papi/lib -lpapi -Wl,-rpath=$(LIBRARY_PREFIX)/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/papi/lib
+LIB_PAPI = -L/appl/opt/papi/gcc-4.8.5/5.7.0/lib -lpapi 
 #INC_PAPI = -I$(LIBRARY_PREFIX)/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VERSION)/papi/include
 
 

--- a/vlasovsolver/cpu_acc_map.cpp
+++ b/vlasovsolver/cpu_acc_map.cpp
@@ -228,7 +228,8 @@ bool map_1d(SpatialCell* spatial_cell,
       int minBlockK,maxBlockK;    // Column parallel coordinate limits
       int kBegin;                 // Actual un-sheared starting block index
       int i,j;                    // Blocks' perpendicular coordinates
-   } columns[totalColumns];
+   }* columns;
+   columns = new Column[totalColumns];
 
    // Iterate through all identified columns and shovel them into the values array.
    uint valuesColumnOffset = 0; //offset to values array for data in a column in this set
@@ -609,6 +610,7 @@ bool map_1d(SpatialCell* spatial_cell,
    #pragma acc exit data copyout(blockData[:blockContainer.size()*WID3]) delete(columns[:totalColumns]) delete(values[:valuesSizeRequired]) async(openacc_async_queue_id)
 
    delete [] blocks;
+   delete [] columns;
    return true;
 }
 

--- a/vlasovsolver/cpu_acc_map.cpp
+++ b/vlasovsolver/cpu_acc_map.cpp
@@ -108,16 +108,11 @@ void inline swapBlockIndices(velocity_block_indices_t &blockIndices, const uint 
    is the lagrangian departure grid (so th grid at timestep +dt,
    tracked backwards by -dt)
 
-   TODO: parallelize with openMP over block-columns. If one also
-   pre-creates new blocks in a separate loop first (serial operation),
-   then the openmp parallization would scale well (better than over
-   spatial cells), and would not need synchronization.
-
 */
 bool map_1d(SpatialCell* spatial_cell,
             const uint popID,
             Realv intersection, Realv intersection_di, Realv intersection_dj,Realv intersection_dk,
-            const uint dimension) {
+            const uint dimension, const bool useAccelerator) {
    no_subnormals();
 
    Realv dv,v_min;
@@ -135,7 +130,7 @@ bool map_1d(SpatialCell* spatial_cell,
 
    const int NUM_ASYNC_QUEUES=P::openaccQueueNum;
    int openacc_async_queue_id = (int)(spatial_cell->parameters[CellParams::CELLID]) % NUM_ASYNC_QUEUES;
-   openacc_async_queue_id += omp_get_thread_num() * NUM_ASYNC_QUEUES;
+   //openacc_async_queue_id += omp_get_thread_num() * NUM_ASYNC_QUEUES;
 
    // Velocity grid refinement level, has no effect but is
    // needed in some vmesh::VelocityMesh function calls.
@@ -254,7 +249,9 @@ bool map_1d(SpatialCell* spatial_cell,
    // Now the velocity space has been emptied and all data is lying in the value array
    // (TODO: Double-check this for consistency?)
    // Upload that to the GPU.
-   #pragma acc enter data copyin(values[:valuesSizeRequired]) async(openacc_async_queue_id)
+   if(useAccelerator) {
+      #pragma acc enter data copyin(values[:valuesSizeRequired]) async(openacc_async_queue_id)
+   }
 
    // Calculate target column extents
    for( uint setIndex=0; setIndex< setColumnOffsets.size(); ++setIndex) {
@@ -391,10 +388,12 @@ bool map_1d(SpatialCell* spatial_cell,
    // Create empty velocity space on the GPU and fill it with zeros
    Realf* blockData = blockContainer.getData();
    size_t blockDataSize = blockContainer.size();
-   #pragma acc enter data create(blockData[:blockDataSize*WID3]) async(openacc_async_queue_id)
-   #pragma acc parallel loop present(blockData[:blockDataSize*WID3]) async(openacc_async_queue_id)
-   for( int cell=0; cell < blockDataSize*WID3; cell++) {
-      blockData[cell] = 0;
+   if(useAccelerator) {
+      #pragma acc enter data create(blockData[:blockDataSize*WID3]) async(openacc_async_queue_id)
+      #pragma acc parallel loop present(blockData[:blockDataSize*WID3]) async(openacc_async_queue_id)
+      for( int cell=0; cell < blockDataSize*WID3; cell++) {
+         blockData[cell] = 0;
+      }
    }
 
    // Now we iterate through target columns again, identifying their block offsets
@@ -417,81 +416,82 @@ bool map_1d(SpatialCell* spatial_cell,
    }
 
    // loop over columns in set and do the mapping
-   #pragma acc parallel loop copyin(columns[:totalColumns]) present(blockData[:blockContainer.size()*WID3], values[:valuesSizeRequired]) async(openacc_async_queue_id)
-   for( uint column=0; column < totalColumns; column++) {
+   if(useAccelerator) {
+      #pragma acc parallel loop copyin(columns[:totalColumns]) present(blockData[:blockContainer.size()*WID3], values[:valuesSizeRequired]) async(openacc_async_queue_id)
+      for( uint column=0; column < totalColumns; column++) {
 
-      // i,j,k are relative to the order in which we copied data to the values array.
-      // After this point in the k,j,i loops there should be no branches based on dimensions
-      //
-      // Note that the i dimension is vectorized, and thus there are no loops over i
+         // i,j,k are relative to the order in which we copied data to the values array.
+         // After this point in the k,j,i loops there should be no branches based on dimensions
+         //
+         // Note that the i dimension is vectorized, and thus there are no loops over i
 
-      // Iterate through the perpendicular directions of the column
-      #pragma acc loop
-      for (uint j = 0; j < WID; j += VECL/WID){
-         const vmesh::LocalID nblocks = columns[column].nblocks;
-         // create vectors with the i and j indices in the vector position on the plane.
-         #if VECL == 4
-         const Veci i_indices = Veci(0, 1, 2, 3);
-         const Veci j_indices = Veci(j, j, j, j);
-         #elif VECL == 8
-         const Veci i_indices = Veci(0, 1, 2, 3,
-                                     0, 1, 2, 3);
-         const Veci j_indices = Veci(j, j, j, j,
-                                     j + 1, j + 1, j + 1, j + 1);
-         #elif VECL == 16
-         const Veci i_indices = Veci(0, 1, 2, 3,
-                                     0, 1, 2, 3,
-                                     0, 1, 2, 3,
-                                     0, 1, 2, 3);
-         const Veci j_indices = Veci(j, j, j, j,
-                                     j + 1, j + 1, j + 1, j + 1,
-                                     j + 2, j + 2, j + 2, j + 2,
-                                     j + 3, j + 3, j + 3, j + 3);
-         #endif
+         // Iterate through the perpendicular directions of the column
+         #pragma acc loop
+         for (uint j = 0; j < WID; j += VECL/WID){
+            const vmesh::LocalID nblocks = columns[column].nblocks;
+            // create vectors with the i and j indices in the vector position on the plane.
+            #if VECL == 4
+            const Veci i_indices = Veci(0, 1, 2, 3);
+            const Veci j_indices = Veci(j, j, j, j);
+            #elif VECL == 8
+            const Veci i_indices = Veci(0, 1, 2, 3,
+                                        0, 1, 2, 3);
+            const Veci j_indices = Veci(j, j, j, j,
+                                        j + 1, j + 1, j + 1, j + 1);
+            #elif VECL == 16
+            const Veci i_indices = Veci(0, 1, 2, 3,
+                                        0, 1, 2, 3,
+                                        0, 1, 2, 3,
+                                        0, 1, 2, 3);
+            const Veci j_indices = Veci(j, j, j, j,
+                                        j + 1, j + 1, j + 1, j + 1,
+                                        j + 2, j + 2, j + 2, j + 2,
+                                        j + 3, j + 3, j + 3, j + 3);
+            #endif
 
-         const Veci  target_cell_index_common =
-            i_indices * cell_indices_to_id[0] +
-            j_indices * cell_indices_to_id[1];
+            const Veci  target_cell_index_common =
+               i_indices * cell_indices_to_id[0] +
+               j_indices * cell_indices_to_id[1];
 
-         //const int target_block_index_common =
-         //   columns[column].i * block_indices_to_id[0] +
-         //   columns[column].j * block_indices_to_id[1];
+            //const int target_block_index_common =
+            //   columns[column].i * block_indices_to_id[0] +
+            //   columns[column].j * block_indices_to_id[1];
 
-         // intersection_min is the intersection z coordinate (z after
-         // swaps that is) of the lowest possible z plane for each i,j
-         // index (i in vector)
-         const Vec intersection_min =
-            intersection +
-            (columns[column].i * WID + to_realv(i_indices)) * intersection_di +
-            (columns[column].j * WID + to_realv(j_indices)) * intersection_dj;
+            // intersection_min is the intersection z coordinate (z after
+            // swaps that is) of the lowest possible z plane for each i,j
+            // index (i in vector)
+            const Vec intersection_min =
+               intersection +
+               (columns[column].i * WID + to_realv(i_indices)) * intersection_di +
+               (columns[column].j * WID + to_realv(j_indices)) * intersection_dj;
 
-         /*compute some initial values, that are used to set up the
-          * shifting of values as we go through all blocks in
-          * order. See comments where they are shifted for
-          * explanations of their meaning*/
-         Vec v_r0((WID * columns[column].kBegin) * dv + v_min);
-         Vec lagrangian_v_r0((v_r0-intersection_min)/intersection_dk);
+            /*compute some initial values, that are used to set up the
+             * shifting of values as we go through all blocks in
+             * order. See comments where they are shifted for
+             * explanations of their meaning*/
+            Vec v_r0((WID * columns[column].kBegin) * dv + v_min);
+            Vec lagrangian_v_r0((v_r0-intersection_min)/intersection_dk);
 
-         // compute location of min and max, this does not change for one
-         //  column (or even for this set of intersections, and can be used
-         //  to quickly compute max and min later on*/
-         //TODO, these can be computed much earlier, since they are
-         //identiacal for each set of intersections
-         int minGkIndex=0, maxGkIndex=0; // 0 for compiler
-         {
-            Realv maxV = std::numeric_limits<Realv>::min();
-            Realv minV = std::numeric_limits<Realv>::max();
-            for(int i = 0; i < VECL; i++) {
-               if ( lagrangian_v_r0[i] > maxV) {
-                  maxV = lagrangian_v_r0[i];
-                  maxGkIndex = i;
-               }
-               if ( lagrangian_v_r0[i] < minV) {
-                  minV = lagrangian_v_r0[i];
-                  minGkIndex = i;
+            // compute location of min and max, this does not change for one
+            //  column (or even for this set of intersections, and can be used
+            //  to quickly compute max and min later on*/
+            //TODO, these can be computed much earlier, since they are
+            //identiacal for each set of intersections
+            int minGkIndex=0, maxGkIndex=0; // 0 for compiler
+            {
+               Realv maxV = std::numeric_limits<Realv>::min();
+               Realv minV = std::numeric_limits<Realv>::max();
+               for(int i = 0; i < VECL; i++) {
+                  if ( lagrangian_v_r0[i] > maxV) {
+                     maxV = lagrangian_v_r0[i];
+                     maxGkIndex = i;
+                  }
+                  if ( lagrangian_v_r0[i] < minV) {
+                     minV = lagrangian_v_r0[i];
+                     minGkIndex = i;
+                  }
                }
             }
-         }
 
             // loop through all blocks in column and compute the mapping as integrals.
             #pragma acc loop
@@ -605,9 +605,198 @@ bool map_1d(SpatialCell* spatial_cell,
                } // for loop over target k-indices of current source block
             } // for-loop over source blocks
          } //for loop over j index
-   } //for loop over columns
+      } //for loop over columns
 
-   #pragma acc exit data copyout(blockData[:blockContainer.size()*WID3]) delete(columns[:totalColumns]) delete(values[:valuesSizeRequired]) async(openacc_async_queue_id)
+      #pragma acc exit data copyout(blockData[:blockContainer.size()*WID3]) delete(columns[:totalColumns]) delete(values[:valuesSizeRequired]) async(openacc_async_queue_id)
+   } else {
+
+      // CPU version
+      for( uint column=0; column < totalColumns; column++) {
+
+         // i,j,k are relative to the order in which we copied data to the values array.
+         // After this point in the k,j,i loops there should be no branches based on dimensions
+         //
+         // Note that the i dimension is vectorized, and thus there are no loops over i
+
+         // Iterate through the perpendicular directions of the column
+         for (uint j = 0; j < WID; j += VECL/WID){
+            const vmesh::LocalID nblocks = columns[column].nblocks;
+            // create vectors with the i and j indices in the vector position on the plane.
+            #if VECL == 4
+            const Veci i_indices = Veci(0, 1, 2, 3);
+            const Veci j_indices = Veci(j, j, j, j);
+            #elif VECL == 8
+            const Veci i_indices = Veci(0, 1, 2, 3,
+                                        0, 1, 2, 3);
+            const Veci j_indices = Veci(j, j, j, j,
+                                        j + 1, j + 1, j + 1, j + 1);
+            #elif VECL == 16
+            const Veci i_indices = Veci(0, 1, 2, 3,
+                                        0, 1, 2, 3,
+                                        0, 1, 2, 3,
+                                        0, 1, 2, 3);
+            const Veci j_indices = Veci(j, j, j, j,
+                                        j + 1, j + 1, j + 1, j + 1,
+                                        j + 2, j + 2, j + 2, j + 2,
+                                        j + 3, j + 3, j + 3, j + 3);
+            #endif
+
+            const Veci  target_cell_index_common =
+               i_indices * cell_indices_to_id[0] +
+               j_indices * cell_indices_to_id[1];
+
+            //const int target_block_index_common =
+            //   columns[column].i * block_indices_to_id[0] +
+            //   columns[column].j * block_indices_to_id[1];
+
+            // intersection_min is the intersection z coordinate (z after
+            // swaps that is) of the lowest possible z plane for each i,j
+            // index (i in vector)
+            const Vec intersection_min =
+               intersection +
+               (columns[column].i * WID + to_realv(i_indices)) * intersection_di +
+               (columns[column].j * WID + to_realv(j_indices)) * intersection_dj;
+
+            /*compute some initial values, that are used to set up the
+             * shifting of values as we go through all blocks in
+             * order. See comments where they are shifted for
+             * explanations of their meaning*/
+            Vec v_r0((WID * columns[column].kBegin) * dv + v_min);
+            Vec lagrangian_v_r0((v_r0-intersection_min)/intersection_dk);
+
+            // compute location of min and max, this does not change for one
+            //  column (or even for this set of intersections, and can be used
+            //  to quickly compute max and min later on*/
+            //TODO, these can be computed much earlier, since they are
+            //identiacal for each set of intersections
+            int minGkIndex=0, maxGkIndex=0; // 0 for compiler
+            {
+               Realv maxV = std::numeric_limits<Realv>::min();
+               Realv minV = std::numeric_limits<Realv>::max();
+               for(int i = 0; i < VECL; i++) {
+                  if ( lagrangian_v_r0[i] > maxV) {
+                     maxV = lagrangian_v_r0[i];
+                     maxGkIndex = i;
+                  }
+                  if ( lagrangian_v_r0[i] < minV) {
+                     minV = lagrangian_v_r0[i];
+                     minGkIndex = i;
+                  }
+               }
+            }
+
+            // loop through all blocks in column and compute the mapping as integrals.
+            for (uint k=0; k < WID * nblocks; ++k ){
+               // Compute reconstructions
+               // values + i_pcolumnv(n_cblocks, -1, j, 0) is the starting point of the column data for fixed j
+               // k + WID is the index where we have stored k index, WID amount of padding.
+#ifdef ACC_SEMILAG_PLM
+               Vec a[2];
+               compute_plm_coeff(values + columns[column].valuesOffset + i_pcolumnv(j, 0, -1, nblocks), k + WID , a);
+#endif
+#ifdef ACC_SEMILAG_PPM
+               Vec a[3];
+               compute_ppm_coeff(values + columns[column].valuesOffset  + i_pcolumnv(j, 0, -1, nblocks), h4, k + WID, a);
+#endif
+#ifdef ACC_SEMILAG_PQM
+               Vec a[5];
+               compute_pqm_coeff(values + columns[column].valuesOffset  + i_pcolumnv(j, 0, -1, nblocks), h8, k + WID, a);
+#endif
+
+               // set the initial value for the integrand at the boundary at v = 0
+               // (in reduced cell units), this will be shifted to target_density_1, see below.
+               Vec target_density_r(0.0);
+               // v_l, v_r are the left and right velocity coordinates of source cell.
+               Vec v_r = v_r0  + (k+1)* dv;
+               Vec v_l = v_r0  + k* dv;
+
+               // left(l) and right(r) k values (global index) in the target
+               // Lagrangian grid, the intersecting cells. Again old right is new left.
+               Veci lagrangian_gk_l,lagrangian_gk_r;
+#if VECTORCLASS_H >= 20000
+               lagrangian_gk_r = truncatei((v_l-intersection_min)/intersection_dk);
+               lagrangian_gk_r = truncatei((v_r-intersection_min)/intersection_dk);
+#else
+               lagrangian_gk_l = truncate_to_int((v_l-intersection_min)/intersection_dk);
+               lagrangian_gk_r = truncate_to_int((v_r-intersection_min)/intersection_dk);
+
+#endif
+
+               //limits in lagrangian k for target column. Also take into
+               //account limits of target column
+               int minGk = max(int(lagrangian_gk_l[minGkIndex]), int(columns[column].minBlockK * WID));
+               int maxGk = min(int(lagrangian_gk_r[maxGkIndex]), int((columns[column].maxBlockK + 1) * WID - 1));
+
+               // Run along the column and perform the polynomial reconstruction
+               //for(int gk = minGk; gk <= maxGk; gk++){
+               for(int gk = columns[column].minBlockK * WID; gk <= columns[column].maxBlockK * WID; gk++) {
+                  if(gk < minGk || gk > maxGk) {
+                     continue;
+                  }
+               
+                  const int blockK = gk/WID;
+                  const int gk_mod_WID = (gk - blockK * WID);
+                  //the block of the Lagrangian cell to which we map
+                  //const int target_block(target_block_index_common + blockK * block_indices_to_id[2]);
+
+                  //cell indices in the target block  (TODO: to be replaced by
+                  //compile time generated scatter write operation)
+                  const Veci target_cell(target_cell_index_common + gk_mod_WID * cell_indices_to_id[2]);
+
+                  //the velocity between which we will integrate to put mass
+                  //in the targe cell. If both v_r and v_l are in same cell
+                  //then v_1,v_2 should be between v_l and v_r.
+                  //v_1 and v_2 normalized to be between 0 and 1 in the cell.
+                  //For vector elements where gk is already larger than needed (lagrangian_gk_r), v_2=v_1=v_r and thus the value is zero.
+                  const Vec v_norm_r = (  min(  max( (gk + 1) * intersection_dk + intersection_min, v_l), v_r) - v_l) * i_dv;
+                  /*shift, old right is new left*/
+                  const Vec target_density_l = target_density_r;
+
+                  // compute right integrand
+                  #ifdef ACC_SEMILAG_PLM
+                  target_density_r =
+                     v_norm_r * ( a[0] + v_norm_r * a[1] );
+                  #endif
+                  #ifdef ACC_SEMILAG_PPM
+                  target_density_r =
+                     v_norm_r * ( a[0] + v_norm_r * ( a[1] + v_norm_r * a[2] ) );
+
+                  #endif
+                  #ifdef ACC_SEMILAG_PQM
+                  target_density_r =
+                     v_norm_r * ( a[0] + v_norm_r * ( a[1] + v_norm_r * ( a[2] + v_norm_r * ( a[3] + v_norm_r * a[4] ) ) ) );
+                  #endif
+
+                  //store values, one element at a time. All blocks
+                  //have been created by now.
+                  //TODO replace by vector version & scatter & gather operation
+
+
+                  //if(dimension == 2) {
+                  //   Realf* targetDataPointer = blockData + columns[column].targetBlockOffsets[blockK] + j * cell_indices_to_id[1] + gk_mod_WID * cell_indices_to_id[2];
+                  //   Vec targetData;
+                  //   targetData.load_a(targetDataPointer);
+                  //   targetData += target_density_r - target_density_l;
+                  //   targetData.store_a(targetDataPointer);
+                  //}
+                  //else{
+                     // total value of integrand
+                     const Vec target_density = target_density_r - target_density_l;
+   #pragma ivdep
+   #pragma GCC ivdep
+                     for (int target_i=0; target_i < VECL; ++target_i) {
+                        // do the conversion from Realv to Realf here, faster than doing it in accumulation
+                        const Realf tval = target_density[target_i];
+                        const uint tcell = target_cell[target_i];
+                        (&blockData[columns[column].targetBlockOffsets[blockK]])[tcell] += tval;
+                     }  // for-loop over vector elements
+                  //}
+               } // for loop over target k-indices of current source block
+            } // for-loop over source blocks
+         } //for loop over j index
+      } //for loop over columns
+   }
+
 
    delete [] blocks;
    delete [] columns;

--- a/vlasovsolver/cpu_acc_map.cpp
+++ b/vlasovsolver/cpu_acc_map.cpp
@@ -24,6 +24,7 @@
 #include <math.h>
 #include <algorithm>
 #include <utility>
+#include <omp.h>
 
 #include "vec.h"
 #include "cpu_acc_sort_blocks.hpp"
@@ -133,7 +134,8 @@ bool map_1d(SpatialCell* spatial_cell,
       return true;
 
    const int NUM_ASYNC_QUEUES=P::openaccQueueNum;
-   const int openacc_async_queue_id = (int)(spatial_cell->parameters[CellParams::CELLID]) % NUM_ASYNC_QUEUES;
+   int openacc_async_queue_id = (int)(spatial_cell->parameters[CellParams::CELLID]) % NUM_ASYNC_QUEUES;
+   openacc_async_queue_id += omp_get_thread_num() * NUM_ASYNC_QUEUES;
 
    // Velocity grid refinement level, has no effect but is
    // needed in some vmesh::VelocityMesh function calls.

--- a/vlasovsolver/cpu_acc_map.hpp
+++ b/vlasovsolver/cpu_acc_map.hpp
@@ -31,6 +31,6 @@ using namespace spatial_cell;
 
 bool map_1d(SpatialCell* spatial_cell, const uint popID,     
             Realv intersection, Realv intersection_di, Realv intersection_dj,Realv intersection_dk,
-            const uint dimension) ;
+            const uint dimension, const bool useAccelerator) ;
 
 #endif

--- a/vlasovsolver/cpu_acc_semilag.cpp
+++ b/vlasovsolver/cpu_acc_semilag.cpp
@@ -86,7 +86,8 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
                          const uint popID,     
                          const uint map_order,
                          const uint order_step,
-                         const Real& dt) {
+                         const Real& dt,
+                         const bool useAccelerator) {
    double t1 = MPI_Wtime();
 
    vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh    = spatial_cell->get_velocity_mesh(popID);
@@ -116,9 +117,9 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
                                     intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk);
           phiprof::stop("compute-intersections");
           phiprof::start("compute-mapping");
-          if(order_step==0) map_1d(spatial_cell, popID, intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk,0); // map along x
-          if(order_step==1) map_1d(spatial_cell, popID, intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk,1); // map along y
-          if(order_step==2) map_1d(spatial_cell, popID, intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk,2); // map along z
+          if(order_step==0) map_1d(spatial_cell, popID, intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk,0, useAccelerator); // map along x
+          if(order_step==1) map_1d(spatial_cell, popID, intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk,1, useAccelerator); // map along y
+          if(order_step==2) map_1d(spatial_cell, popID, intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk,2, useAccelerator); // map along z
           phiprof::stop("compute-mapping");
           break;
           
@@ -133,9 +134,9 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
                                     intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk);
           phiprof::stop("compute-intersections");
           phiprof::start("compute-mapping");
-          if(order_step==0) map_1d(spatial_cell, popID, intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk,1); // map along y
-          if(order_step==1) map_1d(spatial_cell, popID, intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk,2); // map along z
-          if(order_step==2) map_1d(spatial_cell, popID, intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk,0); // map along x
+          if(order_step==0) map_1d(spatial_cell, popID, intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk,1, useAccelerator); // map along y
+          if(order_step==1) map_1d(spatial_cell, popID, intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk,2, useAccelerator); // map along z
+          if(order_step==2) map_1d(spatial_cell, popID, intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk,0, useAccelerator); // map along x
           phiprof::stop("compute-mapping");
           break;
 
@@ -150,9 +151,9 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
                                     intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk);
           phiprof::stop("compute-intersections");
           phiprof::start("compute-mapping");
-          if(order_step==0) map_1d(spatial_cell, popID, intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk,2); // map along z
-          if(order_step==1) map_1d(spatial_cell, popID, intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk,0); // map along x
-          if(order_step==2) map_1d(spatial_cell, popID, intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk,1); // map along y
+          if(order_step==0) map_1d(spatial_cell, popID, intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk,2, useAccelerator); // map along z
+          if(order_step==1) map_1d(spatial_cell, popID, intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk,0, useAccelerator); // map along x
+          if(order_step==2) map_1d(spatial_cell, popID, intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk,1, useAccelerator); // map along y
           phiprof::stop("compute-mapping");
           break;
    }

--- a/vlasovsolver/cpu_acc_semilag.hpp
+++ b/vlasovsolver/cpu_acc_semilag.hpp
@@ -36,7 +36,8 @@ void cpu_accelerate_cell(
         const uint popID,
         const uint map_order,
         const uint order_step,
-        const Real& dt);
+        const Real& dt,
+        const bool useAccelerator = false);
 
 #endif
 

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -312,8 +312,12 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
          #endif
             
          uint map_order=rndInt%3;
+
+         // If we are the "first" thread, we get to use the accelerator.
+         bool isThreadZero = omp_get_thread_num() == 0;
+
          phiprof::start("cell-semilag-acc");
-         cpu_accelerate_cell(mpiGrid[cellID],popID,map_order,order_step,subcycleDt);
+         cpu_accelerate_cell(mpiGrid[cellID],popID,map_order,order_step,subcycleDt,isThreadZero);
          phiprof::stop("cell-semilag-acc");
       }
       // Wait for all of the async GPU stuff to be done before continuing


### PR DESCRIPTION
When multiple openacc threads are trying to access the GPU, it looks like they are all blocking each other, waiting most of the time.

Instead, this branch restricts GPU access to openmp task #0, while the others happily crunch away the acceleration on their CPU cores.

This is faster, but maybe not the most elegant approach.

Also, quite a bit of code duplication in map_1d now. Discuss.