### PR TITLE
Shells at selected radii where VDFs should be saved

### DIFF
--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -935,7 +935,7 @@ bool writeVelocitySpace(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
       vector<uint64_t> velSpaceCells;
       int lineX, lineY, lineZ;
       Real shellRadiusSquare;
-      Real cellX, cellY, cellZ, halfDX, halfDY, halfDZ;
+      Real cellX, cellY, cellZ, DX, DY, DZ;
       Real minRCornerSquare,maxRCornerSquare,rCornerSquare;
       for (uint i = 0; i < cells.size(); i++) {
          mpiGrid[cells[i]]->parameters[CellParams::ISCELLSAVINGF] = 0.0;
@@ -992,38 +992,38 @@ bool writeVelocitySpace(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
             cellX = mpiGrid[cells[i]]->parameters[CellParams::XCRD];
             cellY = mpiGrid[cells[i]]->parameters[CellParams::YCRD];
             cellZ = mpiGrid[cells[i]]->parameters[CellParams::ZCRD];
-            halfDX = 0.5*mpiGrid[cells[i]]->parameters[CellParams::DX];
-            halfDY = 0.5*mpiGrid[cells[i]]->parameters[CellParams::DY];
-            halfDZ = 0.5*mpiGrid[cells[i]]->parameters[CellParams::DZ];
+            DX = mpiGrid[cells[i]]->parameters[CellParams::DX];
+            DY = mpiGrid[cells[i]]->parameters[CellParams::DY];
+            DZ = mpiGrid[cells[i]]->parameters[CellParams::DZ];
             // First corner
-            minRCornerSquare = (cellX + halfDX) * (cellX + halfDX) + (cellY + halfDY) * (cellY + halfDY) + (cellZ + halfDZ) * (cellZ + halfDZ);
+            minRCornerSquare = cellX * cellX + cellY * cellY + cellZ * cellZ;
             maxRCornerSquare = minRCornerSquare;
             // Second corner
-            rCornerSquare = (cellX - halfDX) * (cellX - halfDX) + (cellY + halfDY) * (cellY + halfDY) + (cellZ + halfDZ) * (cellZ + halfDZ);
+            rCornerSquare = (cellX + DX) * (cellX + DX) + cellY * cellY + cellZ * cellZ;
             if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
             if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
             // Third corner
-            rCornerSquare = (cellX + halfDX) * (cellX + halfDX) + (cellY - halfDY) * (cellY - halfDY) + (cellZ + halfDZ) * (cellZ + halfDZ);
+            rCornerSquare = cellX * cellX + (cellY + DY) * (cellY + DY) + cellZ * cellZ;
             if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
             if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
             // Fourth corner
-            rCornerSquare = (cellX - halfDX) * (cellX - halfDX) + (cellY - halfDY) * (cellY - halfDY) + (cellZ + halfDZ) * (cellZ + halfDZ);
+            rCornerSquare = (cellX + DX) * (cellX + DX) + (cellY + DY) * (cellY + DY) + cellZ * cellZ;
             if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
             if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
             // Fifth corner
-            rCornerSquare = (cellX + halfDX) * (cellX + halfDX) + (cellY + halfDY) * (cellY + halfDY) + (cellZ - halfDZ) * (cellZ - halfDZ);
+            rCornerSquare = cellX * cellX + cellY * cellY + (cellZ + DZ) * (cellZ + DZ);
             if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
             if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
             // Sixth corner
-            rCornerSquare = (cellX - halfDX) * (cellX - halfDX) + (cellY + halfDY) * (cellY + halfDY) + (cellZ - halfDZ) * (cellZ - halfDZ);
+            rCornerSquare = (cellX + DX) * (cellX + DX) + cellY * cellY + (cellZ + DZ) * (cellZ + DZ);
             if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
             if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
             // Seventh corner
-            rCornerSquare = (cellX + halfDX) * (cellX + halfDX) + (cellY - halfDY) * (cellY - halfDY) + (cellZ - halfDZ) * (cellZ - halfDZ);
+            rCornerSquare = cellX * cellX + (cellY + DY) * (cellY + DY) + (cellZ + DZ) * (cellZ + DZ);
             if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
             if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
             // Eighth corner
-            rCornerSquare = (cellX - halfDX) * (cellX - halfDX) + (cellY - halfDY) * (cellY - halfDY) + (cellZ - halfDZ) * (cellZ - halfDZ);
+            rCornerSquare = (cellX + DX) * (cellX + DX) + (cellY + DY) * (cellY + DY) + (cellZ + DZ) * (cellZ + DZ);
             if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
             if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
             if (minRCornerSquare <= shellRadiusSquare && maxRCornerSquare > shellRadiusSquare) {

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -1026,7 +1026,10 @@ bool writeVelocitySpace(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
             rCornerSquare = (cellX + DX) * (cellX + DX) + (cellY + DY) * (cellY + DY) + (cellZ + DZ) * (cellZ + DZ);
             if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
             if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
-            if (minRCornerSquare <= shellRadiusSquare && maxRCornerSquare > shellRadiusSquare) {
+            if (minRCornerSquare <= shellRadiusSquare && maxRCornerSquare > shellRadiusSquare &&
+                P::systemWriteDistributionWriteShellStride[ishell] > 0 && 
+                cells[i] % P::systemWriteDistributionWriteShellStride[ishell] == 0
+               ) {
                velSpaceCells.push_back(cells[i]);
                mpiGrid[cells[i]]->parameters[CellParams::ISCELLSAVINGF] = 1.0;
             }

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -989,12 +989,12 @@ bool writeVelocitySpace(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
          // Loop over spherical shells at defined distances
          for (uint ishell = 0; ishell < P::systemWriteDistributionWriteShellRadius.size(); ishell++) {
             shellRadiusSquare = P::systemWriteDistributionWriteShellRadius[ishell] * P::systemWriteDistributionWriteShellRadius[ishell];
-            cellX = cells[i]->parameters[CellParams::XCRD];
-            cellY = cells[i]->parameters[CellParams::YCRD];
-            cellZ = cells[i]->parameters[CellParams::ZCRD];
-            halfDX = 0.5*cells[i]->parameters[CellParams::DX];
-            halfDY = 0.5*cells[i]->parameters[CellParams::DY];
-            halfDZ = 0.5*cells[i]->parameters[CellParams::DZ];
+            cellX = mpiGrid[cells[i]]->parameters[CellParams::XCRD];
+            cellY = mpiGrid[cells[i]]->parameters[CellParams::YCRD];
+            cellZ = mpiGrid[cells[i]]->parameters[CellParams::ZCRD];
+            halfDX = 0.5*mpiGrid[cells[i]]->parameters[CellParams::DX];
+            halfDY = 0.5*mpiGrid[cells[i]]->parameters[CellParams::DY];
+            halfDZ = 0.5*mpiGrid[cells[i]]->parameters[CellParams::DZ];
             // First corner
             minRCornerSquare = (cellX + halfDX) * (cellX + halfDX) + (cellY + halfDY) * (cellY + halfDY) + (cellZ + halfDZ) * (cellZ + halfDZ);
             maxRCornerSquare = minRCornerSquare;

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -936,7 +936,8 @@ bool writeVelocitySpace(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
       int lineX, lineY, lineZ;
       Real shellRadiusSquare;
       Real cellX, cellY, cellZ, DX, DY, DZ;
-      Real minRCornerSquare,maxRCornerSquare,rCornerSquare;
+      Real dx_rm, dx_rp, dy_rm, dy_rp, dz_rm, dz_rp;
+      Real rsquare_minus,rsquare_plus;
       for (uint i = 0; i < cells.size(); i++) {
          mpiGrid[cells[i]]->parameters[CellParams::ISCELLSAVINGF] = 0.0;
          // CellID stride selection
@@ -995,38 +996,16 @@ bool writeVelocitySpace(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
             DX = mpiGrid[cells[i]]->parameters[CellParams::DX];
             DY = mpiGrid[cells[i]]->parameters[CellParams::DY];
             DZ = mpiGrid[cells[i]]->parameters[CellParams::DZ];
-            // First corner
-            minRCornerSquare = cellX * cellX + cellY * cellY + cellZ * cellZ;
-            maxRCornerSquare = minRCornerSquare;
-            // Second corner
-            rCornerSquare = (cellX + DX) * (cellX + DX) + cellY * cellY + cellZ * cellZ;
-            if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
-            if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
-            // Third corner
-            rCornerSquare = cellX * cellX + (cellY + DY) * (cellY + DY) + cellZ * cellZ;
-            if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
-            if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
-            // Fourth corner
-            rCornerSquare = (cellX + DX) * (cellX + DX) + (cellY + DY) * (cellY + DY) + cellZ * cellZ;
-            if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
-            if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
-            // Fifth corner
-            rCornerSquare = cellX * cellX + cellY * cellY + (cellZ + DZ) * (cellZ + DZ);
-            if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
-            if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
-            // Sixth corner
-            rCornerSquare = (cellX + DX) * (cellX + DX) + cellY * cellY + (cellZ + DZ) * (cellZ + DZ);
-            if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
-            if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
-            // Seventh corner
-            rCornerSquare = cellX * cellX + (cellY + DY) * (cellY + DY) + (cellZ + DZ) * (cellZ + DZ);
-            if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
-            if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
-            // Eighth corner
-            rCornerSquare = (cellX + DX) * (cellX + DX) + (cellY + DY) * (cellY + DY) + (cellZ + DZ) * (cellZ + DZ);
-            if (rCornerSquare > maxRCornerSquare) {maxRCornerSquare = rCornerSquare;}
-            if (rCornerSquare < minRCornerSquare) {minRCornerSquare = rCornerSquare;}
-            if (minRCornerSquare <= shellRadiusSquare && maxRCornerSquare > shellRadiusSquare &&
+
+            dx_rm = cellX < 0 ? DX : 0;
+            dx_rp = cellX < 0 ? 0 : DX;
+            dy_rm = cellY < 0 ? DY : 0;
+            dy_rp = cellY < 0 ? 0 : DY;
+            dz_rm = cellZ < 0 ? DZ : 0;
+            dz_rp = cellZ < 0 ? 0 : DZ;
+            rsquare_minus = (cellX + dx_rm) * (cellX + dx_rm) + (cellY + dy_rm) * (cellY + dy_rm) + (cellZ + dz_rm) * (cellZ + dz_rm);
+            rsquare_plus  = (cellX + dx_rp) * (cellX + dx_rp) + (cellY + dy_rp) * (cellY + dy_rp) + (cellZ + dz_rp) * (cellZ + dz_rp);
+            if (rsquare_minus <= shellRadiusSquare && rsquare_plus > shellRadiusSquare &&
                 P::systemWriteDistributionWriteShellStride[ishell] > 0 && 
                 cells[i] % P::systemWriteDistributionWriteShellStride[ishell] == 0
                ) {

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -84,7 +84,7 @@ vector<int> P::systemWriteDistributionWriteStride;
 vector<int> P::systemWriteDistributionWriteXlineStride;
 vector<int> P::systemWriteDistributionWriteYlineStride;
 vector<int> P::systemWriteDistributionWriteZlineStride;
-vector<Real> P::SystemWriteDistributionWriteShellRadius;
+vector<Real> P::systemWriteDistributionWriteShellRadius;
 vector<int> P::systemWrites;
 std::vector<std::pair<std::string,std::string>> P::systemWriteHints;
 
@@ -335,7 +335,6 @@ bool Parameters::getParameters(){
    maxSize = max(maxSize, P::systemWriteDistributionWriteXlineStride.size());
    maxSize = max(maxSize, P::systemWriteDistributionWriteYlineStride.size());
    maxSize = max(maxSize, P::systemWriteDistributionWriteZlineStride.size());
-   maxSize = max(maxSize, P::systemWriteDistributionWriteShellRadius.size());
    if ( P::systemWriteTimeInterval.size() != maxSize) {
       if(myRank == MASTER_RANK) {
          cerr << "ERROR io.system_write_t_interval should be defined for all file types." << endl;
@@ -375,12 +374,6 @@ bool Parameters::getParameters(){
    if ( P::systemWriteDistributionWriteZlineStride.size() != maxSize) {
       if(myRank == MASTER_RANK) {
          cerr << "ERROR io.system_write_distribution_zline_stride should be defined for all file types." << endl;
-      }
-      return false;
-   }
-   if ( P::systemWriteDistributionWriteShellRadius.size() != maxSize) {
-      if(myRank == MASTER_RANK) {
-         cerr << "ERROR io.system_write_distribution_shell_radius should be defined for all file types." << endl;
       }
       return false;
    }

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -84,6 +84,7 @@ vector<int> P::systemWriteDistributionWriteStride;
 vector<int> P::systemWriteDistributionWriteXlineStride;
 vector<int> P::systemWriteDistributionWriteYlineStride;
 vector<int> P::systemWriteDistributionWriteZlineStride;
+vector<Real> P::SystemWriteDistributionWriteShellRadius;
 vector<int> P::systemWrites;
 std::vector<std::pair<std::string,std::string>> P::systemWriteHints;
 
@@ -154,6 +155,7 @@ bool Parameters::addParameters(){
    Readparameters::addComposing("io.system_write_distribution_xline_stride", "Every this many lines of cells along the x direction write out their velocity space. 0 is none. [Define for all groups.]");
    Readparameters::addComposing("io.system_write_distribution_yline_stride", "Every this many lines of cells along the y direction write out their velocity space. 0 is none. [Define for all groups.]");
    Readparameters::addComposing("io.system_write_distribution_zline_stride", "Every this many lines of cells along the z direction write out their velocity space. 0 is none. [Define for all groups.]");
+   Readparameters::addComposing("io.system_write_distribution_shell_radius", "At cells intersecting spheres with those radii centred at the origin write out their velocity space. 0 is none. [Define for all groups.]");
    Readparameters::addComposing("io.system_write_mpiio_hint_key", "MPI-IO hint key passed to the non-restart IO. Has to be matched by io.system_write_mpiio_hint_value.");
    Readparameters::addComposing("io.system_write_mpiio_hint_value", "MPI-IO hint value passed to the non-restart IO. Has to be matched by io.system_write_mpiio_hint_key.");
 
@@ -306,6 +308,7 @@ bool Parameters::getParameters(){
    Readparameters::get("io.system_write_distribution_xline_stride", P::systemWriteDistributionWriteXlineStride);
    Readparameters::get("io.system_write_distribution_yline_stride", P::systemWriteDistributionWriteYlineStride);
    Readparameters::get("io.system_write_distribution_zline_stride", P::systemWriteDistributionWriteZlineStride);
+   Readparameters::get("io.system_write_distribution_shell_radius", P::systemWriteDistributionWriteShellRadius);
    Readparameters::get("io.write_initial_state", P::writeInitialState);
    Readparameters::get("io.restart_walltime_interval", P::saveRestartWalltimeInterval);
    Readparameters::get("io.number_of_restarts", P::exitAfterRestarts);
@@ -332,6 +335,7 @@ bool Parameters::getParameters(){
    maxSize = max(maxSize, P::systemWriteDistributionWriteXlineStride.size());
    maxSize = max(maxSize, P::systemWriteDistributionWriteYlineStride.size());
    maxSize = max(maxSize, P::systemWriteDistributionWriteZlineStride.size());
+   maxSize = max(maxSize, P::systemWriteDistributionShellRadius.size());
    if ( P::systemWriteTimeInterval.size() != maxSize) {
       if(myRank == MASTER_RANK) {
          cerr << "ERROR io.system_write_t_interval should be defined for all file types." << endl;
@@ -371,6 +375,12 @@ bool Parameters::getParameters(){
    if ( P::systemWriteDistributionWriteZlineStride.size() != maxSize) {
       if(myRank == MASTER_RANK) {
          cerr << "ERROR io.system_write_distribution_zline_stride should be defined for all file types." << endl;
+      }
+      return false;
+   }
+   if ( P::systemWriteDistributionWriteShellRadius.size() != maxSize) {
+      if(myRank == MASTER_RANK) {
+         cerr << "ERROR io.system_write_distribution_shell_radius should be defined for all file types." << endl;
       }
       return false;
    }

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -335,7 +335,7 @@ bool Parameters::getParameters(){
    maxSize = max(maxSize, P::systemWriteDistributionWriteXlineStride.size());
    maxSize = max(maxSize, P::systemWriteDistributionWriteYlineStride.size());
    maxSize = max(maxSize, P::systemWriteDistributionWriteZlineStride.size());
-   maxSize = max(maxSize, P::systemWriteDistributionShellRadius.size());
+   maxSize = max(maxSize, P::systemWriteDistributionWriteShellRadius.size());
    if ( P::systemWriteTimeInterval.size() != maxSize) {
       if(myRank == MASTER_RANK) {
          cerr << "ERROR io.system_write_t_interval should be defined for all file types." << endl;

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -382,8 +382,8 @@ bool Parameters::getParameters(){
    }
    if ( P::systemWriteDistributionWriteShellStride.size() != P::systemWriteDistributionWriteShellRadius.size()) {
       if(myRank == MASTER_RANK) {
-         cerr << "ERROR io.system_write_distribution_shell_stride should have the same size as " <<
-         "io.system_write_distribution_shell_radius." << endl;
+         cerr << "ERROR You should set the same number of io.system_write_distribution_shell_stride " <<
+                 "and io.system_write_distribution_shell_radius." << endl;
       }
       return false;
    }

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -85,6 +85,7 @@ vector<int> P::systemWriteDistributionWriteXlineStride;
 vector<int> P::systemWriteDistributionWriteYlineStride;
 vector<int> P::systemWriteDistributionWriteZlineStride;
 vector<Real> P::systemWriteDistributionWriteShellRadius;
+vector<int> P::systemWriteDistributionWriteShellStride;
 vector<int> P::systemWrites;
 std::vector<std::pair<std::string,std::string>> P::systemWriteHints;
 
@@ -155,7 +156,8 @@ bool Parameters::addParameters(){
    Readparameters::addComposing("io.system_write_distribution_xline_stride", "Every this many lines of cells along the x direction write out their velocity space. 0 is none. [Define for all groups.]");
    Readparameters::addComposing("io.system_write_distribution_yline_stride", "Every this many lines of cells along the y direction write out their velocity space. 0 is none. [Define for all groups.]");
    Readparameters::addComposing("io.system_write_distribution_zline_stride", "Every this many lines of cells along the z direction write out their velocity space. 0 is none. [Define for all groups.]");
-   Readparameters::addComposing("io.system_write_distribution_shell_radius", "At cells intersecting spheres with those radii centred at the origin write out their velocity space. 0 is none. [Define for all groups.]");
+   Readparameters::addComposing("io.system_write_distribution_shell_radius", "At cells intersecting spheres with those radii centred at the origin write out their velocity space. 0 is none.");
+   Readparameters::addComposing("io.system_write_distribution_shell_stride", "Every this many cells for those on selected shells write out their velocity space. 0 is none.");
    Readparameters::addComposing("io.system_write_mpiio_hint_key", "MPI-IO hint key passed to the non-restart IO. Has to be matched by io.system_write_mpiio_hint_value.");
    Readparameters::addComposing("io.system_write_mpiio_hint_value", "MPI-IO hint value passed to the non-restart IO. Has to be matched by io.system_write_mpiio_hint_key.");
 
@@ -309,6 +311,7 @@ bool Parameters::getParameters(){
    Readparameters::get("io.system_write_distribution_yline_stride", P::systemWriteDistributionWriteYlineStride);
    Readparameters::get("io.system_write_distribution_zline_stride", P::systemWriteDistributionWriteZlineStride);
    Readparameters::get("io.system_write_distribution_shell_radius", P::systemWriteDistributionWriteShellRadius);
+   Readparameters::get("io.system_write_distribution_shell_stride", P::systemWriteDistributionWriteShellStride);
    Readparameters::get("io.write_initial_state", P::writeInitialState);
    Readparameters::get("io.restart_walltime_interval", P::saveRestartWalltimeInterval);
    Readparameters::get("io.number_of_restarts", P::exitAfterRestarts);
@@ -374,6 +377,13 @@ bool Parameters::getParameters(){
    if ( P::systemWriteDistributionWriteZlineStride.size() != maxSize) {
       if(myRank == MASTER_RANK) {
          cerr << "ERROR io.system_write_distribution_zline_stride should be defined for all file types." << endl;
+      }
+      return false;
+   }
+   if ( P::systemWriteDistributionWriteShellStride.size() != P::systemWriteDistributionWriteShellRadius.size()) {
+      if(myRank == MASTER_RANK) {
+         cerr << "ERROR io.system_write_distribution_shell_stride should have the same size as " <<
+         "io.system_write_distribution_shell_radius." << endl;
       }
       return false;
    }

--- a/parameters.h
+++ b/parameters.h
@@ -74,7 +74,7 @@ struct Parameters {
    static std::vector<int> systemWriteDistributionWriteXlineStride; /*!< Every this many lines of cells along the x direction write out their velocity space in each class. */
    static std::vector<int> systemWriteDistributionWriteYlineStride; /*!< Every this many lines of cells along the y direction write out their velocity space in each class. */
    static std::vector<int> systemWriteDistributionWriteZlineStride; /*!< Every this many lines of cells along the z direction write out their velocity space in each class. */
-   static std::vector<int> systemWriteDistributionWriteShellRadius; /*!< At cells intersecting spheres with those radii centred at the origin write out their velocity space in each class. */
+   static std::vector<Real> systemWriteDistributionWriteShellRadius; /*!< At cells intersecting spheres with those radii centred at the origin write out their velocity space in each class. */
    static std::vector<int> systemWrites; /*!< How many files have been written of each class*/
    static std::vector<std::pair<std::string,std::string>> systemWriteHints; /*!< Collection of MPI-IO hints passed for non-restart IO. Pairs of key-value strings. */
    

--- a/parameters.h
+++ b/parameters.h
@@ -74,6 +74,7 @@ struct Parameters {
    static std::vector<int> systemWriteDistributionWriteXlineStride; /*!< Every this many lines of cells along the x direction write out their velocity space in each class. */
    static std::vector<int> systemWriteDistributionWriteYlineStride; /*!< Every this many lines of cells along the y direction write out their velocity space in each class. */
    static std::vector<int> systemWriteDistributionWriteZlineStride; /*!< Every this many lines of cells along the z direction write out their velocity space in each class. */
+   static std::vector<int> systemWriteDistributionWriteShellRadius; /*!< At cells intersecting spheres with those radii centred at the origin write out their velocity space in each class. */
    static std::vector<int> systemWrites; /*!< How many files have been written of each class*/
    static std::vector<std::pair<std::string,std::string>> systemWriteHints; /*!< Collection of MPI-IO hints passed for non-restart IO. Pairs of key-value strings. */
    

--- a/parameters.h
+++ b/parameters.h
@@ -75,6 +75,7 @@ struct Parameters {
    static std::vector<int> systemWriteDistributionWriteYlineStride; /*!< Every this many lines of cells along the y direction write out their velocity space in each class. */
    static std::vector<int> systemWriteDistributionWriteZlineStride; /*!< Every this many lines of cells along the z direction write out their velocity space in each class. */
    static std::vector<Real> systemWriteDistributionWriteShellRadius; /*!< At cells intersecting spheres with those radii centred at the origin write out their velocity space in each class. */
+   static std::vector<int> systemWriteDistributionWriteShellStride; /*!< Every this many cells for those on selected shells write out their velocity space in each class. */
    static std::vector<int> systemWrites; /*!< How many files have been written of each class*/
    static std::vector<std::pair<std::string,std::string>> systemWriteHints; /*!< Collection of MPI-IO hints passed for non-restart IO. Pairs of key-value strings. */
    

--- a/parameters.h
+++ b/parameters.h
@@ -73,7 +73,7 @@ struct Parameters {
    static std::vector<int> systemWriteDistributionWriteStride; /*!< Every this many cells write out their velocity space in each class. */
    static std::vector<int> systemWriteDistributionWriteXlineStride; /*!< Every this many lines of cells along the x direction write out their velocity space in each class. */
    static std::vector<int> systemWriteDistributionWriteYlineStride; /*!< Every this many lines of cells along the y direction write out their velocity space in each class. */
-   static std::vector<int> systemWriteDistributionWriteZlineRadius; /*!< Every this many lines of cells along the z direction write out their velocity space in each class. */
+   static std::vector<int> systemWriteDistributionWriteZlineStride; /*!< Every this many lines of cells along the z direction write out their velocity space in each class. */
    static std::vector<Real> systemWriteDistributionWriteShellRadius; /*!< At cells intersecting spheres with those radii centred at the origin write out their velocity space in each class. */
    static std::vector<int> systemWrites; /*!< How many files have been written of each class*/
    static std::vector<std::pair<std::string,std::string>> systemWriteHints; /*!< Collection of MPI-IO hints passed for non-restart IO. Pairs of key-value strings. */

--- a/parameters.h
+++ b/parameters.h
@@ -73,7 +73,7 @@ struct Parameters {
    static std::vector<int> systemWriteDistributionWriteStride; /*!< Every this many cells write out their velocity space in each class. */
    static std::vector<int> systemWriteDistributionWriteXlineStride; /*!< Every this many lines of cells along the x direction write out their velocity space in each class. */
    static std::vector<int> systemWriteDistributionWriteYlineStride; /*!< Every this many lines of cells along the y direction write out their velocity space in each class. */
-   static std::vector<int> systemWriteDistributionWriteZlineStride; /*!< Every this many lines of cells along the z direction write out their velocity space in each class. */
+   static std::vector<int> systemWriteDistributionWriteZlineRadius; /*!< Every this many lines of cells along the z direction write out their velocity space in each class. */
    static std::vector<Real> systemWriteDistributionWriteShellRadius; /*!< At cells intersecting spheres with those radii centred at the origin write out their velocity space in each class. */
    static std::vector<int> systemWrites; /*!< How many files have been written of each class*/
    static std::vector<std::pair<std::string,std::string>> systemWriteHints; /*!< Collection of MPI-IO hints passed for non-restart IO. Pairs of key-value strings. */


### PR DESCRIPTION
This gives the possibility to add a new parameter to the cfg file
     _io.system_write_distribution_shell_radius_
which defines one or several spheres of selected radii (in m) where all VDFs should be saved in output files.
This has been tested with two shells at 5e7 m and 2e8 m in a test-run with 1 level of refinement. The results are shown in the attached screenshots (threeSlice, and three slices).

![threeSlice_fsaved_with_SpatialGrid_mesh](https://user-images.githubusercontent.com/35216514/78293196-e2130a00-7530-11ea-89d9-f0f141f53f06.png)
![slice_XY](https://user-images.githubusercontent.com/35216514/78293207-e6d7be00-7530-11ea-9780-67c24476d695.png)
![slice_YZ](https://user-images.githubusercontent.com/35216514/78293209-e7705480-7530-11ea-8260-38ffb20cef16.png)
![slice_XZ](https://user-images.githubusercontent.com/35216514/78293211-e7705480-7530-11ea-9f56-a69ab19ac776.png)



