### PR TITLE
Added zeroing of inflow cells for perB with vector dipole (type 4)

### DIFF
--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -464,6 +464,9 @@ namespace projects {
                      if(technicalGrid.get(x, y, z)->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN ) {
                         for (int i = 0; i < fsgrids::bgbfield::N_BGB; ++i) {
                            BgBGrid.get(x,y,z)->at(i) = 0;
+			   if ( (this->dipoleType==4) && (P::isRestart == false) ) {
+			      perBGrid.get(x,y,z)->at(i) = 0;
+			   }
                         }
                      }
                   }

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -464,7 +464,9 @@ namespace projects {
                      if(technicalGrid.get(x, y, z)->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN ) {
                         for (int i = 0; i < fsgrids::bgbfield::N_BGB; ++i) {
                            BgBGrid.get(x,y,z)->at(i) = 0;
-			   if ( (this->dipoleType==4) && (P::isRestart == false) ) {
+                        }
+			if ( (this->dipoleType==4) && (P::isRestart == false) ) {
+			   for (int i = 0; i < fsgrids::bfield::N_BFIELD; ++i) {
 			      perBGrid.get(x,y,z)->at(i) = 0;
 			   }
                         }


### PR DESCRIPTION
Now it sets type maxwellian cell perB-fields to zero if starting a fresh run. I guess this could be done for all dipole types (for all others it should already be zero) but playing it safe. Due to the way SOLVE::BXYZ works I think the fields should not be reset at a restart so added that check.