### PR TITLE
Make writeAsFloat more flexible for fsgrids, don't float them in restart

### DIFF
--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -1196,8 +1196,8 @@ bool DataReducer::writeFsGridData(
                       FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
                       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
                       FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
-                      FsGrid< fsgrids::technical, 2>& technicalGrid, const
-                      std::string& meshName, const unsigned int operatorID,
+                      FsGrid< fsgrids::technical, 2>& technicalGrid,
+                      const std::string& meshName, const unsigned int operatorID,
                       vlsv::Writer& vlsvWriter,
                       const bool writeAsFloat) {
    

--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -1196,13 +1196,16 @@ bool DataReducer::writeFsGridData(
                       FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
                       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
                       FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
-                      FsGrid< fsgrids::technical, 2>& technicalGrid, const std::string& meshName, const unsigned int operatorID, vlsv::Writer& vlsvWriter) {
+                      FsGrid< fsgrids::technical, 2>& technicalGrid, const
+                      std::string& meshName, const unsigned int operatorID,
+                      vlsv::Writer& vlsvWriter,
+                      const bool writeAsFloat) {
    
    if (operatorID >= operators.size()) return false;
    DRO::DataReductionOperatorFsGrid* DROf = dynamic_cast<DRO::DataReductionOperatorFsGrid*>(operators[operatorID]);
    if(!DROf) {
       return false;
    } else {
-      return DROf->writeFsGridData(perBGrid, EGrid, EHallGrid, EGradPeGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, volGrid, technicalGrid, meshName, vlsvWriter);
+      return DROf->writeFsGridData(perBGrid, EGrid, EHallGrid, EGradPeGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, volGrid, technicalGrid, meshName, vlsvWriter, writeAsFloat);
    }
 }

--- a/datareduction/datareducer.h
+++ b/datareduction/datareducer.h
@@ -68,8 +68,8 @@ class DataReducer {
                       FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
                       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
                       FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
-                      FsGrid< fsgrids::technical, 2>& technicalGrid, const
-                      std::string& meshName, const unsigned int operatorID,
+                      FsGrid< fsgrids::technical, 2>& technicalGrid,
+                      const std::string& meshName, const unsigned int operatorID,
                       vlsv::Writer& vlsvWriter,
                       const bool writeAsFloat = false);
 

--- a/datareduction/datareducer.h
+++ b/datareduction/datareducer.h
@@ -68,7 +68,10 @@ class DataReducer {
                       FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
                       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
                       FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
-                      FsGrid< fsgrids::technical, 2>& technicalGrid, const std::string& meshName, const unsigned int operatorID, vlsv::Writer& vlsvWriter);
+                      FsGrid< fsgrids::technical, 2>& technicalGrid, const
+                      std::string& meshName, const unsigned int operatorID,
+                      vlsv::Writer& vlsvWriter,
+                      const bool writeAsFloat = false);
 
  private:
    /** Private copy-constructor to prevent copying the class.

--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -143,7 +143,9 @@ namespace DRO {
                       FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
                       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
                       FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
-                      FsGrid< fsgrids::technical, 2>& technicalGrid, const std::string& meshName, vlsv::Writer& vlsvWriter) {
+                      FsGrid< fsgrids::technical, 2>& technicalGrid, const
+                      std::string& meshName, vlsv::Writer& vlsvWriter,
+                      const bool writeAsFloat) {
 
       std::map<std::string,std::string> attribs;
       attribs["mesh"]=meshName;
@@ -159,7 +161,7 @@ namespace DRO {
       std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
       int vectorSize = varBuffer.size() / (gridSize[0]*gridSize[1]*gridSize[2]);
 
-      if(P::writeAsFloat==1) {
+      if(writeAsFloat) {
          // Convert down to 32bit floats to save output space
          std::vector<float> varBufferFloat(varBuffer.size());
          for(int i=0; i<varBuffer.size(); i++) {

--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -113,12 +113,9 @@ namespace DRO {
 
    std::string DataReductionOperatorFsGrid::getName() const {return variableName;}
    bool DataReductionOperatorFsGrid::getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const {
+      // These are only set to dmmy values, as this reducer writes its own vlsv dataset anyway
       dataType = "float";
-      if(P::writeAsFloat==1) {
-         dataSize = sizeof(float);
-      } else {
-         dataSize = sizeof(double);
-      }
+      dataSize = sizeof(double);
       vectorSize = 1;
       return true;
    }

--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -143,8 +143,8 @@ namespace DRO {
                       FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
                       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
                       FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
-                      FsGrid< fsgrids::technical, 2>& technicalGrid, const
-                      std::string& meshName, vlsv::Writer& vlsvWriter,
+                      FsGrid< fsgrids::technical, 2>& technicalGrid,
+                      const std::string& meshName, vlsv::Writer& vlsvWriter,
                       const bool writeAsFloat) {
 
       std::map<std::string,std::string> attribs;

--- a/datareduction/datareductionoperator.h
+++ b/datareduction/datareductionoperator.h
@@ -134,7 +134,9 @@ namespace DRO {
                       FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
                       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
                       FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
-                      FsGrid< fsgrids::technical, 2>& technicalGrid, const std::string& meshName, vlsv::Writer& vlsvWriter);
+                      FsGrid< fsgrids::technical, 2>& technicalGrid, const
+                      std::string& meshName, vlsv::Writer& vlsvWriter,
+                      const bool writeAsFloat=false);
    };
 
    class DataReductionOperatorCellParams: public DataReductionOperator {

--- a/datareduction/datareductionoperator.h
+++ b/datareduction/datareductionoperator.h
@@ -134,8 +134,8 @@ namespace DRO {
                       FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, 2>& dMomentsGrid,
                       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, 2>& BgBGrid,
                       FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2>& volGrid,
-                      FsGrid< fsgrids::technical, 2>& technicalGrid, const
-                      std::string& meshName, vlsv::Writer& vlsvWriter,
+                      FsGrid< fsgrids::technical, 2>& technicalGrid,
+                      const std::string& meshName, vlsv::Writer& vlsvWriter,
                       const bool writeAsFloat=false);
    };
 

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -1180,8 +1180,9 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
       exitOnError(false, "(RESTART) FSGrid writing rank number not found in restart file", MPI_COMM_WORLD);
    }
    
-   success = readFsGridVariable(file, "fg_PERB", fsgridInputRanks, perBGrid);
-   success = readFsGridVariable(file, "fg_E", fsgridInputRanks, EGrid);
+   if(success) { success = readFsGridVariable(file, "fg_PERB", fsgridInputRanks, perBGrid); }
+   if(success) { success = readFsGridVariable(file, "fg_E", fsgridInputRanks, EGrid); }
+   exitOnError(success,"(RESTART) Failure reading fsgrid restart variables",MPI_COMM_WORLD);
    
    success = file.close();
    phiprof::stop("readGrid");

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -431,7 +431,7 @@ bool writeDataReducer(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
       // If the data reducer didn't want to write dccrg data, maybe it will be happy
       // dumping data straight from fsgrid into our file.
       phiprof::start("writeFsGrid");
-      success = dataReducer.writeFsGridData(perBGrid,EGrid,EHallGrid,EGradPeGrid,momentsGrid,dPerBGrid,dMomentsGrid,BgBGrid,volGrid, technicalGrid, "fsgrid", dataReducerIndex, vlsvWriter);
+      success = dataReducer.writeFsGridData(perBGrid,EGrid,EHallGrid,EGradPeGrid,momentsGrid,dPerBGrid,dMomentsGrid,BgBGrid,volGrid, technicalGrid, "fsgrid", dataReducerIndex, vlsvWriter, writeAsFloat);
       phiprof::stop("writeFsGrid");
    }
    


### PR DESCRIPTION
Before, their behaviour was globally defined in the P::writeAsFloat
variable, now it can be changed on a call-by-call manner.