### PR TITLE
Added ghost cell updates for volumetric field calculation

### DIFF
--- a/fieldsolver/ldz_volume.cpp
+++ b/fieldsolver/ldz_volume.cpp
@@ -38,6 +38,11 @@ void calculateVolumeAveragedFields(
    FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2> & volGrid,
    FsGrid< fsgrids::technical, 2> & technicalGrid
 ) {
+   // Update ghosts
+   dPerBGrid.updateGhostCells();
+   perBGrid.updateGhostCells();
+   EGrid.updateGhostCells();
+
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];


### PR DESCRIPTION
At the end of ldz_main.cpp, after fields have been propagated, volumetric fields and bvol derivatives are updated, but the volumetric field calculation uses non-updated ghost information. This fixes it. Tested to compile but didn't check further yet.