### PR TITLE
Add .clang-format and .vimrc files for automatically code formatting.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+---
+BasedOnStyle:  LLVM
+UseTab: Never
+IndentWidth: 3
+TabWidth: 3
+BreakBeforeBraces: Attach
+PointerAlignment: Left
+AlignAfterOpenBracket: true
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+ColumnLimit: 120
+AccessModifierOffset: -3
+...
+

--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,6 @@
+set cindent
+set shiftwidth=3
+set tabstop=3
+set expandtab
+
+set equalprg=clang-format\ -style=file


### PR DESCRIPTION
Related to issue #530, this adds a .clang-format file and a .vimrc to the Vlasiator source tree, to make it easier for code to automatically comply with the [style guidelines](https://github.com/fmihpc/vlasiator/wiki/Coding-Style).