### PR TITLE
Write fsgrid domain size as a 64bit number, instead of 32bit.

### DIFF
--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -901,7 +901,7 @@ bool writeFsGridMetadata(FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technic
 
 
   // writeDomainSizes
-  std::array<uint32_t,2> meshDomainSize({globalIds.size(), 0});
+  std::array<uint64_t,2> meshDomainSize({globalIds.size(), 0});
   vlsvWriter.writeArray("MESH_DOMAIN_SIZES", xmlAttributes, 1, 2, &meshDomainSize[0]);
 
   // how many MPI ranks we wrote from

--- a/tools/vlsvdiff.cpp
+++ b/tools/vlsvdiff.cpp
@@ -256,7 +256,7 @@ bool HandleFsGrid(const string& inputFileName,
    patch["vectorsize"]=to_string(vectorsize2);
    
    //Override MESH_DOMAIN_SIZES
-   std::array<uint32_t,2> meshDomainSize({globalIds.size(), 0});
+   std::array<uint64_t,2> meshDomainSize({globalIds.size(), 0});
    output.writeArray("MESH_DOMAIN_SIZES",patch ,1,vectorsize2, &meshDomainSize[0]);
 
 


### PR DESCRIPTION
Without this, writing a 5th refinement level would have silently failed and restarting from those file (or plotting them) would have just given bogus data.

This fixes #517.

Tested with the restart_write and restart_read tests, and by plotting files with visit.