### PR TITLE
MPI datatype trans optimization

### DIFF
--- a/MAKE/Makefile.vorna_gcc
+++ b/MAKE/Makefile.vorna_gcc
@@ -44,14 +44,12 @@ LIB_MPI = -lgomp
 
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
-CXXFLAGS += -DPAPI_MEM
-testpackage: CXXFLAGS += -DPAPI_MEM
+CXXFLAGS +=  -DPAPI_MEM
 
 #======== Allocator =========
 #Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
 #Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
-testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 
 # BOOST_VERSION = current trilinos version

--- a/MAKE/Makefile.vorna_gcc
+++ b/MAKE/Makefile.vorna_gcc
@@ -44,12 +44,14 @@ LIB_MPI = -lgomp
 
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
-CXXFLAGS +=  -DPAPI_MEM
+CXXFLAGS += -DPAPI_MEM
+testpackage: CXXFLAGS += -DPAPI_MEM
 
 #======== Allocator =========
 #Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
 #Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 
 # BOOST_VERSION = current trilinos version

--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,7 @@ vlasiator.o: ${DEPS_COMMON} readparameters.h parameters.h ${DEPS_PROJECTS} grid.
 	${CMP} ${CXXFLAGS} ${FLAG_OPENMP} ${FLAGS} -c vlasiator.cpp ${INC_MPI} ${INC_DCCRG} ${INC_FSGRID} ${INC_BOOST} ${INC_EIGEN} ${INC_ZOLTAN} ${INC_PROFILE} ${INC_VLSV}
 
 grid.o:  ${DEPS_COMMON} parameters.h ${DEPS_PROJECTS} ${DEPS_CELL} grid.cpp grid.h  sysboundary/sysboundary.h
-	${CMP} ${CXXFLAGS} ${FLAG_OPENMP} ${FLAGS} -c grid.cpp ${INC_MPI} ${INC_DCCRG} ${INC_FSGRID} ${INC_BOOST} ${INC_EIGEN} ${INC_ZOLTAN} ${INC_PROFILE} ${INC_VLSV} ${INC_PAPI}
+	${CMP} ${CXXFLAGS} ${FLAG_OPENMP} ${FLAGS} -c grid.cpp ${INC_MPI} ${INC_DCCRG} ${INC_FSGRID} ${INC_BOOST} ${INC_EIGEN} ${INC_ZOLTAN} ${INC_PROFILE} ${INC_VLSV} ${INC_PAPI} ${INC_VECTORCLASS}
 
 ioread.o:  ${DEPS_COMMON} parameters.h  ${DEPS_CELL} ioread.cpp ioread.h 
 	${CMP} ${CXXFLAGS} ${FLAG_OPENMP} ${FLAGS} -c ioread.cpp ${INC_MPI} ${INC_DCCRG} ${INC_BOOST} ${INC_EIGEN} ${INC_ZOLTAN} ${INC_PROFILE} ${INC_VLSV} ${INC_FSGRID}

--- a/common.h
+++ b/common.h
@@ -186,6 +186,9 @@ namespace CellParams {
       FSGRID_BOUNDARYTYPE, /*!< Boundary type of this cell, as stored in the fsGrid */
       CELLID, /*! < DCCRG cell index */
       REFINEMENT_LEVEL, /*! < Refinement level */
+      AMR_TRANSLATE_COMM_X, /*! < Flag to include this cell in AMR pre-translate communication  */
+      AMR_TRANSLATE_COMM_Y, /*! < Flag to include this cell in AMR pre-translate communication  */
+      AMR_TRANSLATE_COMM_Z, /*! < Flag to include this cell in AMR pre-translate communication  */
       N_SPATIAL_CELL_PARAMS
    };
 }

--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -182,6 +182,11 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
 	 outputReducer->addMetadata(outputReducer->size()-1,"kg/m^3","$\\mathrm{kg}\\,\\mathrm{m}^{-3}$","$\\rho_\\mathrm{m}$","1.0");
          continue;
       }
+      if(lowercase == "vg_amr_translate_comm") { // Flag for AMR translation communication
+         outputReducer->addOperator(new DRO::DataReductionOperatorCellParams("vg_amr_translate_comm",CellParams::AMR_TRANSLATE_COMM_X,3));
+	 //outputReducer->addMetadata(outputReducer->size()-1,"","AMR-translate","1.0");
+         continue;
+      }
       if(lowercase == "fg_rhom") { // Overall mass density (summed over all populations)
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rhom",[](
                       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,

--- a/grid.cpp
+++ b/grid.cpp
@@ -567,7 +567,7 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
    recalculateLocalCellsCache();
    getObjectWrapper().meshData.reallocate();
    cells = mpiGrid.get_cells();
-   #pragma parallel for
+   #pragma omp parallel for
    for (uint i=0; i<cells.size(); ++i) mpiGrid[cells[i]]->set_mpi_transfer_enabled(true);
 
    // flag transfers if AMR

--- a/spatial_cell.cpp
+++ b/spatial_cell.cpp
@@ -36,6 +36,7 @@ namespace spatial_cell {
    int SpatialCell::activePopID = 0;
    uint64_t SpatialCell::mpi_transfer_type = 0;
    bool SpatialCell::mpiTransferAtSysBoundaries = false;
+   bool SpatialCell::mpiTransferSpatialAMRskip = false;
 
    SpatialCell::SpatialCell() {
       // Block list and cache always have room for all blocks
@@ -590,7 +591,8 @@ namespace spatial_cell {
 
       // create datatype for actual data if we are in the first two 
       // layers around a boundary, or if we send for the whole system
-      if (this->mpiTransferEnabled && (SpatialCell::mpiTransferAtSysBoundaries==false || this->sysBoundaryLayer ==1 || this->sysBoundaryLayer ==2 )) {
+      if (this->mpiTransferEnabled && (SpatialCell::mpiTransferAtSysBoundaries==false || this->sysBoundaryLayer ==1 || this->sysBoundaryLayer ==2 )
+          && (SpatialCell::mpiTransferSpatialAMRskip==false)) {
          //add data to send/recv to displacement and block length lists
          if ((SpatialCell::mpi_transfer_type & Transfer::VEL_BLOCK_LIST_STAGE1) != 0) {
             //first copy values in case this is the send operation

--- a/spatial_cell.cpp
+++ b/spatial_cell.cpp
@@ -36,8 +36,8 @@ namespace spatial_cell {
    int SpatialCell::activePopID = 0;
    uint64_t SpatialCell::mpi_transfer_type = 0;
    bool SpatialCell::mpiTransferAtSysBoundaries = false;
-   //std::array<bool,3> mpiTransferSpatialAMRskip = {false,false,false};
-   bool SpatialCell::mpiTransferSpatialAMRskip = false;
+   bool SpatialCell::mpiTransferInAMRTranslation = false;
+   int SpatialCell::mpiTransferXYZTranslation = 0;
 
    SpatialCell::SpatialCell() {
       // Block list and cache always have room for all blocks
@@ -592,8 +592,12 @@ namespace spatial_cell {
 
       // create datatype for actual data if we are in the first two 
       // layers around a boundary, or if we send for the whole system
-      if (this->mpiTransferEnabled && (SpatialCell::mpiTransferAtSysBoundaries==false || this->sysBoundaryLayer ==1 || this->sysBoundaryLayer ==2 )
-          && (SpatialCell::mpiTransferSpatialAMRskip==false)) {
+      // in AMR translation, only send the necessary cells
+      if (this->mpiTransferEnabled && ((SpatialCell::mpiTransferAtSysBoundaries==false && SpatialCell::mpiTransferInAMRTranslation==false) ||
+                                       (SpatialCell::mpiTransferAtSysBoundaries==true && (this->sysBoundaryLayer ==1 || this->sysBoundaryLayer ==2)) ||
+                                       (SpatialCell::mpiTransferInAMRTranslation==true &&
+                                        this->parameters[CellParams::AMR_TRANSLATE_COMM_X+SpatialCell::mpiTransferXYZTranslation]==true ))) {
+
          //add data to send/recv to displacement and block length lists
          if ((SpatialCell::mpi_transfer_type & Transfer::VEL_BLOCK_LIST_STAGE1) != 0) {
             //first copy values in case this is the send operation

--- a/spatial_cell.cpp
+++ b/spatial_cell.cpp
@@ -36,6 +36,7 @@ namespace spatial_cell {
    int SpatialCell::activePopID = 0;
    uint64_t SpatialCell::mpi_transfer_type = 0;
    bool SpatialCell::mpiTransferAtSysBoundaries = false;
+   //std::array<bool,3> mpiTransferSpatialAMRskip = {false,false,false};
    bool SpatialCell::mpiTransferSpatialAMRskip = false;
 
    SpatialCell::SpatialCell() {

--- a/spatial_cell.hpp
+++ b/spatial_cell.hpp
@@ -303,7 +303,8 @@ namespace spatial_cell {
       std::tuple<void*, int, MPI_Datatype> get_mpi_datatype(const CellID cellID,const int sender_rank,const int receiver_rank,
                                                             const bool receiving,const int neighborhood);
       static uint64_t get_mpi_transfer_type(void);
-      static void set_mpi_transfer_type(const uint64_t type,bool atSysBoundaries=false);
+      static void set_mpi_transfer_type(const uint64_t type,bool atSysBoundaries=false, bool inAMRtranslation=false);
+      static void set_mpi_transfer_direction(const int dimension);
       void set_mpi_transfer_enabled(bool transferEnabled);
       void updateSparseMinValue(const uint popID);
       Real getVelocityBlockMinValue(const uint popID) const;
@@ -343,9 +344,8 @@ namespace spatial_cell {
                                                                                * over MPI, so is invalid on remote cells.*/
       static uint64_t mpi_transfer_type;                                      /**< Which data is transferred by the mpi datatype given by spatial cells.*/
       static bool mpiTransferAtSysBoundaries;                                 /**< Do we only transfer data at boundaries (true), or in the whole system (false).*/
-
-      //std::array<bool,3> mpiTransferSpatialAMRskip;                /**< Flags, set to skip this cell in spatial AMR translation communications. */
-      static bool mpiTransferSpatialAMRskip;                /**< Flags, set to skip this cell in spatial AMR translation communications. */
+      static bool mpiTransferInAMRTranslation;                                /**< Do we only transfer cells which are required by AMR translation. */
+      static int mpiTransferXYZTranslation;                                   /**< Dimension in which AMR translation is happening */
 
       //SpatialCell& operator=(const SpatialCell& other);
     private:
@@ -1849,10 +1849,19 @@ namespace spatial_cell {
    /*!
     Sets the type of data to transfer by mpi_datatype.
     */
-   inline void SpatialCell::set_mpi_transfer_type(const uint64_t type,bool atSysBoundaries) {
+   inline void SpatialCell::set_mpi_transfer_type(const uint64_t type,bool atSysBoundaries, bool inAMRtranslation) {
       SpatialCell::mpi_transfer_type = type;
       SpatialCell::mpiTransferAtSysBoundaries = atSysBoundaries;
+      SpatialCell::mpiTransferInAMRTranslation = inAMRtranslation;
    }
+
+   /*!
+    Sets the direction of translation for AMR data transfers.
+    */
+   inline void SpatialCell::set_mpi_transfer_direction(const int dimension) {
+      SpatialCell::mpiTransferXYZTranslation = dimension;
+   }
+
 
    /*!
     Gets the type of data that will be transferred by mpi_datatype.

--- a/spatial_cell.hpp
+++ b/spatial_cell.hpp
@@ -344,7 +344,8 @@ namespace spatial_cell {
       static uint64_t mpi_transfer_type;                                      /**< Which data is transferred by the mpi datatype given by spatial cells.*/
       static bool mpiTransferAtSysBoundaries;                                 /**< Do we only transfer data at boundaries (true), or in the whole system (false).*/
 
-      static bool mpiTransferSpatialAMRskip;                                   /**< Flag, set to skip this cell in spatial AMR translation communications. */
+      //std::array<bool,3> mpiTransferSpatialAMRskip;                /**< Flags, set to skip this cell in spatial AMR translation communications. */
+      static bool mpiTransferSpatialAMRskip;                /**< Flags, set to skip this cell in spatial AMR translation communications. */
 
       //SpatialCell& operator=(const SpatialCell& other);
     private:

--- a/spatial_cell.hpp
+++ b/spatial_cell.hpp
@@ -344,6 +344,8 @@ namespace spatial_cell {
       static uint64_t mpi_transfer_type;                                      /**< Which data is transferred by the mpi datatype given by spatial cells.*/
       static bool mpiTransferAtSysBoundaries;                                 /**< Do we only transfer data at boundaries (true), or in the whole system (false).*/
 
+      static bool mpiTransferSpatialAMRskip;                                   /**< Flag, set to skip this cell in spatial AMR translation communications. */
+
       //SpatialCell& operator=(const SpatialCell& other);
     private:
       //SpatialCell& operator=(const SpatialCell&);

--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -72,35 +72,14 @@ int getNeighborhood(const uint dimension, const uint stencil) {
 
 void flagSpatialCellsForAmrCommunication(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                                          const vector<CellID>& localPropagatedCells,
-                                         const vector<CellID>& remoteTargetCells,
-                                         const uint dimension,
-                                         const bool reset) {
+                                         const uint dimension) {
+
    // Only flag/unflag cells if AMR is active
    if (mpiGrid.get_maximum_refinement_level()==0) return;
 
-   // Vector with all cell ids
-   vector<CellID> allCells(localPropagatedCells);
-
    // return if there's no cells to flag
-   if(allCells.size() == 0) {
+   if(localPropagatedCells.size() == 0) {
       std::cerr<<"No cells!"<<std::endl;
-      return;
-   }
-
-   int zerocount=0;
-   if (reset) {
-      allCells.insert(allCells.end(), remoteTargetCells.begin(), remoteTargetCells.end());
-      // set all skip flags to false
-      for (uint i=0; i<allCells.size(); i++) {
-         CellID c = allCells[i];
-         SpatialCell *ccell = mpiGrid[c];
-         if (!ccell) continue;
-         if (mpiGrid[c]->mpiTransferSpatialAMRskip == true) {
-            zerocount++;
-            mpiGrid[c]->mpiTransferSpatialAMRskip = false;
-         }
-      }
-      std::cerr<<"Zerocount "<<zerocount<<std::endl;
       return;
    }
 
@@ -108,19 +87,13 @@ void flagSpatialCellsForAmrCommunication(const dccrg::Dccrg<SpatialCell,dccrg::C
    int neighborhood = getNeighborhood(dimension,VLASOV_STENCIL_WIDTH);
 
    // Set flags: loop over local cells
-   int flag=0;
-   int numcells=0;
-   bool islocal;
-   for (uint i=0; i<allCells.size(); i++) {
-      CellID c = allCells[i];
+#pragma parallel for
+   for (uint i=0; i<localPropagatedCells.size(); i++) {
+      CellID c = localPropagatedCells[i];
       SpatialCell *ccell = mpiGrid[c];
       if (!ccell) continue;
-      numcells++;
-      // Start with true
-      mpiGrid[c]->mpiTransferSpatialAMRskip = true;
-
-      // Is the current cell remote or local?
-      islocal = mpiGrid.is_local(c);
+      // Start with false
+      ccell->SpatialCell::parameters[CellParams::AMR_TRANSLATE_COMM_X+dimension] = false;
 
       // In dimension, check iteratively if any neighbors up to VLASOV_STENCIL_WIDTH distance away are on a different process
       const auto* NbrPairs = mpiGrid.get_neighbors_of(c, neighborhood);
@@ -140,7 +113,7 @@ void flagSpatialCellsForAmrCommunication(const dccrg::Dccrg<SpatialCell,dccrg::C
       int iSrc = VLASOV_STENCIL_WIDTH - 1;
       // Iterate through positive distances for VLASOV_STENCIL_WIDTH elements starting from the smallest distance.
       for (auto it = distancesplus.begin(); it != distancesplus.end(); ++it) {
-         //if (mpiGrid[c]->mpiTransferSpatialAMRskip == false) iSrc = -1;
+         if (ccell->SpatialCell::parameters[CellParams::AMR_TRANSLATE_COMM_X+dimension] == true) iSrc = -1;
          if (iSrc < 0) break; // found enough elements
          // Check all neighbors at distance *it
          for (const auto nbrPair : *NbrPairs) {
@@ -148,11 +121,9 @@ void flagSpatialCellsForAmrCommunication(const dccrg::Dccrg<SpatialCell,dccrg::C
             if (!ncell) continue;
             int distanceInRefinedCells = nbrPair.second[dimension];
             if (distanceInRefinedCells == *it) {
-               if (mpiGrid.is_local(nbrPair.first) != islocal) {
-                  mpiGrid[c]->mpiTransferSpatialAMRskip = false;
-                  mpiGrid[nbrPair.first]->mpiTransferSpatialAMRskip = false;
-                  flag++;
-//                  break;
+               if (!mpiGrid.is_local(nbrPair.first)) {
+                  ccell->SpatialCell::parameters[CellParams::AMR_TRANSLATE_COMM_X+dimension] = true;
+                  break;
                }
             }
          } // end loop over neighbors
@@ -162,7 +133,7 @@ void flagSpatialCellsForAmrCommunication(const dccrg::Dccrg<SpatialCell,dccrg::C
       iSrc = VLASOV_STENCIL_WIDTH - 1;
       // Iterate through negtive distances for VLASOV_STENCIL_WIDTH elements starting from the smallest distance.
       for (auto it = distancesminus.begin(); it != distancesminus.end(); ++it) {
-         //if (mpiGrid[c]->mpiTransferSpatialAMRskip == false) iSrc = -1;
+         if (ccell->SpatialCell::parameters[CellParams::AMR_TRANSLATE_COMM_X+dimension] == true) iSrc = -1;
          if (iSrc < 0) break; // found enough elements
          // Check all neighbors at distance *it
          for (const auto nbrPair : *NbrPairs) {
@@ -170,11 +141,9 @@ void flagSpatialCellsForAmrCommunication(const dccrg::Dccrg<SpatialCell,dccrg::C
             if (!ncell) continue;
             int distanceInRefinedCells = -nbrPair.second[dimension];
             if (distanceInRefinedCells == *it) {
-               if (mpiGrid.is_local(nbrPair.first) != islocal) {
-                  mpiGrid[c]->mpiTransferSpatialAMRskip = false;
-                  mpiGrid[nbrPair.first]->mpiTransferSpatialAMRskip = false;
-                  flag++;
-//                  break;
+               if (!mpiGrid.is_local(nbrPair.first)) {
+                  ccell->SpatialCell::parameters[CellParams::AMR_TRANSLATE_COMM_X+dimension] = true;
+                  break;
                }
             }
          } // end loop over neighbors
@@ -182,8 +151,6 @@ void flagSpatialCellsForAmrCommunication(const dccrg::Dccrg<SpatialCell,dccrg::C
       } // end loop over negative distances
 
    } // end loop over local propagated cells
-   std::cerr<<"Numcells "<<numcells<<" flags "<<flag<<std::endl;
-
    return;
 }
 

--- a/vlasovsolver/cpu_trans_map_amr.hpp
+++ b/vlasovsolver/cpu_trans_map_amr.hpp
@@ -189,7 +189,6 @@ void update_remote_mapping_contribution_amr(dccrg::Dccrg<spatial_cell::SpatialCe
 
 
 void flagSpatialCellsForAmrCommunication(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-                                         const std::vector<CellID>& localPropagatedCells,
-                                         const uint dimension);
+                                         const std::vector<CellID>& localPropagatedCells);
 
 #endif

--- a/vlasovsolver/cpu_trans_map_amr.hpp
+++ b/vlasovsolver/cpu_trans_map_amr.hpp
@@ -188,4 +188,9 @@ void update_remote_mapping_contribution_amr(dccrg::Dccrg<spatial_cell::SpatialCe
                                             const uint popID);
 
 
+void flagSpatialCellsForAmrCommunication(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
+                                         const std::vector<CellID>& localPropagatedCells,
+                                         const uint dimension,
+                                         const bool reset);
+
 #endif

--- a/vlasovsolver/cpu_trans_map_amr.hpp
+++ b/vlasovsolver/cpu_trans_map_amr.hpp
@@ -190,6 +190,7 @@ void update_remote_mapping_contribution_amr(dccrg::Dccrg<spatial_cell::SpatialCe
 
 void flagSpatialCellsForAmrCommunication(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                                          const std::vector<CellID>& localPropagatedCells,
+                                         const std::vector<CellID>& remoteTargetCells,
                                          const uint dimension,
                                          const bool reset);
 

--- a/vlasovsolver/cpu_trans_map_amr.hpp
+++ b/vlasovsolver/cpu_trans_map_amr.hpp
@@ -190,8 +190,6 @@ void update_remote_mapping_contribution_amr(dccrg::Dccrg<spatial_cell::SpatialCe
 
 void flagSpatialCellsForAmrCommunication(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                                          const std::vector<CellID>& localPropagatedCells,
-                                         const std::vector<CellID>& remoteTargetCells,
-                                         const uint dimension,
-                                         const bool reset);
+                                         const uint dimension);
 
 #endif

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -94,8 +94,10 @@ void calculateSpatialTranslation(
    if(P::zcells_ini > 1){
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-z","MPI");
       phiprof::start(trans_timer);
+      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,2,false); // flag transfers if AMR
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
+      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,2,true); // reset flag
       phiprof::stop(trans_timer);
 
       // bt=phiprof::initializeTimer("barrier-trans-pre-trans_map_1d-z","Barriers","MPI");
@@ -141,10 +143,11 @@ void calculateSpatialTranslation(
       
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-x","MPI");
       phiprof::start(trans_timer);
+      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,0,false); // flag transfers if AMR
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA);
-
       mpiGrid.set_send_single_cells(false);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
+      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,0,true); // reset flag
       phiprof::stop(trans_timer);
       
       // bt=phiprof::initializeTimer("barrier-trans-pre-trans_map_1d-x","Barriers","MPI");
@@ -190,10 +193,11 @@ void calculateSpatialTranslation(
       
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-y","MPI");
       phiprof::start(trans_timer);
-      SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA);
-      
+      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,0,false); // flag transfers if AMR
+      SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA);      
       mpiGrid.set_send_single_cells(false);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
+      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,1,true); // reset flag
       phiprof::stop(trans_timer);
       
       // bt=phiprof::initializeTimer("barrier-trans-pre-trans_map_1d-y","Barriers","MPI");

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -95,8 +95,8 @@ void calculateSpatialTranslation(
 
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-z","MPI");
       phiprof::start(trans_timer);
-      updateRemoteVelocityBlockLists(mpiGrid,popID,FULL_NEIGHBORHOOD_ID);
-      //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
+      //updateRemoteVelocityBlockLists(mpiGrid,popID,FULL_NEIGHBORHOOD_ID);
+      updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(2);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,true);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
@@ -145,8 +145,8 @@ void calculateSpatialTranslation(
       
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-x","MPI");
       phiprof::start(trans_timer);
-      updateRemoteVelocityBlockLists(mpiGrid,popID,FULL_NEIGHBORHOOD_ID);
-      //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
+      //updateRemoteVelocityBlockLists(mpiGrid,popID,FULL_NEIGHBORHOOD_ID);
+      updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(0);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,true);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
@@ -195,8 +195,8 @@ void calculateSpatialTranslation(
       
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-y","MPI");
       phiprof::start(trans_timer);
-      updateRemoteVelocityBlockLists(mpiGrid,popID,FULL_NEIGHBORHOOD_ID);
-      //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
+      //updateRemoteVelocityBlockLists(mpiGrid,popID,FULL_NEIGHBORHOOD_ID);
+      updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(1);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,true);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -95,6 +95,8 @@ void calculateSpatialTranslation(
 
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-z","MPI");
       phiprof::start(trans_timer);
+      updateRemoteVelocityBlockLists(mpiGrid,popID,FULL_NEIGHBORHOOD_ID);
+      //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(2);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,true);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
@@ -143,6 +145,8 @@ void calculateSpatialTranslation(
       
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-x","MPI");
       phiprof::start(trans_timer);
+      updateRemoteVelocityBlockLists(mpiGrid,popID,FULL_NEIGHBORHOOD_ID);
+      //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(0);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,true);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
@@ -191,6 +195,8 @@ void calculateSpatialTranslation(
       
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-y","MPI");
       phiprof::start(trans_timer);
+      updateRemoteVelocityBlockLists(mpiGrid,popID,FULL_NEIGHBORHOOD_ID);
+      //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(1);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,true);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -95,8 +95,7 @@ void calculateSpatialTranslation(
 
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-z","MPI");
       phiprof::start(trans_timer);
-      //updateRemoteVelocityBlockLists(mpiGrid,popID,FULL_NEIGHBORHOOD_ID);
-      updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
+      //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(2);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,true);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
@@ -145,8 +144,7 @@ void calculateSpatialTranslation(
       
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-x","MPI");
       phiprof::start(trans_timer);
-      //updateRemoteVelocityBlockLists(mpiGrid,popID,FULL_NEIGHBORHOOD_ID);
-      updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
+      //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(0);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,true);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
@@ -195,8 +193,7 @@ void calculateSpatialTranslation(
       
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-y","MPI");
       phiprof::start(trans_timer);
-      //updateRemoteVelocityBlockLists(mpiGrid,popID,FULL_NEIGHBORHOOD_ID);
-      updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
+      //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(1);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,true);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -90,15 +90,6 @@ void calculateSpatialTranslation(
    // MPI_Barrier(MPI_COMM_WORLD);
    // phiprof::stop(bt);
  
-    // flag transfers if AMR
-    phiprof::start("compute_amr_transfer_flags");
-    flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,0); 
-    flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,1); 
-    flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,2); 
-    SpatialCell::set_mpi_transfer_type(Transfer::CELL_PARAMETERS);
-    mpiGrid.update_copies_of_remote_neighbors(FULL_NEIGHBORHOOD_ID);
-    phiprof::stop("compute_amr_transfer_flags");
-
     // ------------- SLICE - map dist function in Z --------------- //
    if(P::zcells_ini > 1){
 

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -92,12 +92,15 @@ void calculateSpatialTranslation(
  
     // ------------- SLICE - map dist function in Z --------------- //
    if(P::zcells_ini > 1){
+
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-z","MPI");
       phiprof::start(trans_timer);
-      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,2,false); // flag transfers if AMR
+      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,remoteTargetCellsz,2,false); // flag transfers if AMR
+      //SpatialCell::set_mpi_transfer_type(Transfer::CELL_PARAMETERS|Transfer::POP_METADATA);
+      //mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
-      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,2,true); // reset flag
+      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,remoteTargetCellsz,2,true); // reset flag
       phiprof::stop(trans_timer);
 
       // bt=phiprof::initializeTimer("barrier-trans-pre-trans_map_1d-z","Barriers","MPI");
@@ -143,11 +146,12 @@ void calculateSpatialTranslation(
       
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-x","MPI");
       phiprof::start(trans_timer);
-      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,0,false); // flag transfers if AMR
+      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,remoteTargetCellsx,0,false); // flag transfers if AMR
+      //SpatialCell::set_mpi_transfer_type(Transfer::CELL_PARAMETERS|Transfer::POP_METADATA);
+      //mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA);
-      mpiGrid.set_send_single_cells(false);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
-      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,0,true); // reset flag
+      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,remoteTargetCellsx,0,true); // reset flag
       phiprof::stop(trans_timer);
       
       // bt=phiprof::initializeTimer("barrier-trans-pre-trans_map_1d-x","Barriers","MPI");
@@ -193,11 +197,12 @@ void calculateSpatialTranslation(
       
       trans_timer=phiprof::initializeTimer("transfer-stencil-data-y","MPI");
       phiprof::start(trans_timer);
-      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,0,false); // flag transfers if AMR
-      SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA);      
-      mpiGrid.set_send_single_cells(false);
+      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,remoteTargetCellsy,1,false); // flag transfers if AMR
+      //SpatialCell::set_mpi_transfer_type(Transfer::CELL_PARAMETERS|Transfer::POP_METADATA);
+      //mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
+      SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
-      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,1,true); // reset flag
+      flagSpatialCellsForAmrCommunication(mpiGrid,local_propagated_cells,remoteTargetCellsy,1,true); // reset flag
       phiprof::stop(trans_timer);
       
       // bt=phiprof::initializeTimer("barrier-trans-pre-trans_map_1d-y","Barriers","MPI");
@@ -232,6 +237,13 @@ void calculateSpatialTranslation(
       phiprof::stop("update_remote-y");
      
    }
+
+   // Restore population metadata
+   phiprof::start(trans_timer);
+   SpatialCell::set_mpi_transfer_type(Transfer::CELL_PARAMETERS|Transfer::POP_METADATA);
+   mpiGrid.set_send_single_cells(false);
+   mpiGrid.update_copies_of_remote_neighbors(FULL_NEIGHBORHOOD_ID);
+   phiprof::stop(trans_timer);
 
    // bt=phiprof::initializeTimer("barrier-trans-post-trans","Barriers","MPI");
    // phiprof::start(bt);


### PR DESCRIPTION
Currently we use a large neighbourhood when doing AMR to ensure we have all necessary cells for the vlasov solver. This update ensures the VDFs are transferred only for those cells which are actually needed.

Diffs (using a 100-second 843-timestep 1 AMR level IPshock run):
```
markusb@turso01:/wrk/users/markusb/AMRpaper2$ /proj/markusb/vlsvdiff_DP AMR1_tp/bulk.0000100.vlsv AMR1B2/bulk.0000100.vlsv proton/vg_rho 0
INFO Reading in two files.
Statistics on file: size 6.95303e-310 min = 4.94066e-324 max = 6.95303e-310 average = 6.95303e-310 standard deviation 0
Statistics on file: size 9000 min = 1.00011e+06 max = 2.27098e+06 average = 1.7351e+06 standard deviation 3091.99
The absolute 0-distance between both datasets is 209.829
The relative 0-distance between both datasets is 9.23959e-05
The average-shifted absolute 0-distance between both datasets is 211.274
The average-shifted relative 0-distance between both datasets is 9.30323e-05
The absolute 1-distance between both datasets is 345875
The relative 1-distance between both datasets is 2.21489e-05
The average-shifted absolute 1-distance between both datasets is 345580
The average-shifted relative 1-distance between both datasets is 2.213e-05
The absolute 2-distance between both datasets is 4771.79
The relative 2-distance between both datasets is 2.85836e-05
The average-shifted absolute 2-distance between both datasets is 4769.82
The average-shifted relative 2-distance between both datasets is 2.85718e-05
```

speedup:
```
AMR1_tp 
(TIME) total run time 3951.27 s, total simulated time 100.044 s
Propagate 3798s, imbalance 0.1668, 3.142e+06 Cells/s
translate proton 2634s, imbalance 0.007595

AMR1B2
(TIME) total run time 3854.56 s, total simulated time 100.044 s
Propagate 3704s, imbalance 0.1687, 3.222e+06 Cells/s
translate proton 2555s, imbalance 0.006713
```
