### PR TITLE
Include the string lib

### DIFF
--- a/item_storage.h
+++ b/item_storage.h
@@ -24,6 +24,7 @@
 #define ITEM_STORAGE_H
 
 #include <map>
+#include <string>
 
 #include "definitions.h"
 

--- a/mesh_data.h
+++ b/mesh_data.h
@@ -29,6 +29,7 @@
 #define MESH_DATA_H
 
 #include <cstdlib>
+#include <string>
 
 namespace mesh {
 


### PR DESCRIPTION
GCC10 complains about missing the inclusion of string header. This fix only helps compilation: there are still errors in the linking stage, probably due to the change in library linking order.

The change has no effect on GCC7. Haven't test on other versions.