### PR TITLE
Local cells caching consolidation

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -318,9 +318,10 @@ void initializeGrids(
       exit(1);
    }
    
-   //Balance load before we transfer all data below
+   // Balance load before we transfer all data below
    balanceLoad(mpiGrid, sysBoundaries);
-   
+   // Function includes re-calculation of local cells cache
+
    phiprof::initializeTimer("Fetch Neighbour data","MPI");
    phiprof::start("Fetch Neighbour data");
    // update complete cell spatial data for full stencil (

--- a/grid.cpp
+++ b/grid.cpp
@@ -165,7 +165,7 @@ void initializeGrids(
    mpiGrid.set_partitioning_option("IMBALANCE_TOL", P::loadBalanceTolerance);
    phiprof::start("Initial load-balancing");
    if (myRank == MASTER_RANK) logFile << "(INIT): Starting initial load balance." << endl << writeVerbose;
-   mpiGrid.balance_load();
+   mpiGrid.balance_load(); // Direct DCCRG call, recalculate cache afterwards
    recalculateLocalCellsCache();
 
    if(P::amrMaxSpatialRefLevel > 0) {
@@ -399,7 +399,7 @@ Record for each cell which processes own one or more of its face neighbors
  */
 void setFaceNeighborRanks( dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid ) {
 
-   const auto& cells = mpiGrid.get_cells();
+   const vector<CellID>& cells = getLocalCells();
    // TODO: Try a #pragma omp parallel for
    for (const auto& cellid : cells) {
       
@@ -460,7 +460,7 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
 
    phiprof::stop("deallocate boundary data");
    //set weights based on each cells LB weight counter
-   vector<CellID> cells = mpiGrid.get_cells();
+   const vector<CellID>& cells = getLocalCells();
    for (size_t i=0; i<cells.size(); ++i){
       //Set weight. If acceleration is enabled then we use the weight
       //counter which is updated in acceleration, otherwise we just
@@ -565,7 +565,6 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
    //Make sure transfers are enabled for all cells
    recalculateLocalCellsCache();
    getObjectWrapper().meshData.reallocate();
-   cells = mpiGrid.get_cells();
    for (uint i=0; i<cells.size(); ++i) mpiGrid[cells[i]]->set_mpi_transfer_enabled(true);
 
    // Communicate all spatial data for FULL neighborhood, which

--- a/projects/Dispersion/Dispersion.cpp
+++ b/projects/Dispersion/Dispersion.cpp
@@ -113,9 +113,11 @@ namespace projects {
          vector<Real> localRhom(P::xcells_ini, 0.0),
             outputRhom(P::xcells_ini, 0.0);
 
-         for(uint i=0; i<Parameters::localCells.size(); i++) {
-            if(Parameters::localCells[i] <= P::xcells_ini) {
-               localRhom[Parameters::localCells[i] - 1] = mpiGrid[Parameters::localCells[i]]->parameters[CellParams::RHOM];
+         const vector<CellID>& cells = getLocalCells();
+
+         for(uint i=0; i<cells.size(); i++) {
+            if(cells[i] <= P::xcells_ini) {
+               localRhom[cells[i] - 1] = mpiGrid[cells[i]]->parameters[CellParams::RHOM];
             }
          }
          

--- a/projects/Firehose/Firehose_save.cpp
+++ b/projects/Firehose/Firehose_save.cpp
@@ -192,7 +192,7 @@ void calcCellParameters(Real* cellParams,creal& t) {
 
 // TODO use this instead: template <class Grid, class CellData> void calcSimParameters(Grid<CellData>& mpiGrid...
 void calcSimParameters(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, creal& t, Real& /*dt*/) {
-   std::vector<uint64_t> cells = mpiGrid.get_cells();
+   const vector<CellID>& cells = getLocalCells();
    for (uint i = 0; i < cells.size(); ++i) {
       calcCellParameters(mpiGrid[cells[i]]->parameters, t);
    }

--- a/projects/test_fp/test_fp.cpp
+++ b/projects/test_fp/test_fp.cpp
@@ -314,7 +314,7 @@ namespace projects {
                   
       mpiGrid.balance_load();
 
-//       auto cells = mpiGrid.get_cells();           
+//       const vector<CellID>& cells = getLocalCells();
 //       if(cells.empty()) {
 //          std::cout << "Rank " << myRank << " has no cells!" << std::endl;
 //       } else {

--- a/sysboundary/donotcompute.cpp
+++ b/sysboundary/donotcompute.cpp
@@ -58,7 +58,7 @@ namespace SBC {
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
       Project&
    ) {
-      vector<CellID> cells = mpiGrid.get_cells();
+     const vector<CellID>& cells = getLocalCells();
 #pragma omp parallel for
       for (size_t i=0; i<cells.size(); ++i) {
          SpatialCell* cell = mpiGrid[cells[i]];

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -194,7 +194,7 @@ namespace SBC {
    
    bool Ionosphere::assignSysBoundary(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                                       FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid) {
-      vector<CellID> cells = mpiGrid.get_cells();
+      const vector<CellID>& cells = getLocalCells();
       for(uint i=0; i<cells.size(); i++) {
          if(mpiGrid[cells[i]]->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) {
             continue;
@@ -242,7 +242,7 @@ namespace SBC {
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
       Project &project
    ) {
-      vector<CellID> cells = mpiGrid.get_cells();
+      const vector<CellID>& cells = getLocalCells();
       #pragma omp parallel for
       for (uint i=0; i<cells.size(); ++i) {
          SpatialCell* cell = mpiGrid[cells[i]];

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -221,7 +221,7 @@ namespace SBC {
       std::array<bool,6> isThisCellOnAFace;
       
       // Assign boundary flags to local DCCRG cells
-      vector<CellID> cells = mpiGrid.get_cells();
+      const vector<CellID>& cells = getLocalCells();
       for(const auto& dccrgId : cells) {
          if(mpiGrid[dccrgId]->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) continue;
          creal* const cellParams = &(mpiGrid[dccrgId]->parameters[0]);

--- a/sysboundary/setbyuser.cpp
+++ b/sysboundary/setbyuser.cpp
@@ -83,7 +83,7 @@ namespace SBC {
       bool doAssign;
       std::array<bool,6> isThisCellOnAFace;
 
-      vector<CellID> cells = mpiGrid.get_cells();
+      const vector<CellID>& cells = getLocalCells();
       for(uint i = 0; i < cells.size(); i++) {
          if(mpiGrid[cells[i]]->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) continue;
          creal* const cellParams = &(mpiGrid[cells[i]]->parameters[0]);
@@ -318,7 +318,7 @@ namespace SBC {
 
 
    bool SetByUser::setCellsFromTemplate(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,const uint popID) {
-      vector<CellID> cells = mpiGrid.get_cells();
+      const vector<CellID>& cells = getLocalCells();
       #pragma omp parallel for
       for (size_t c=0; c<cells.size(); c++) {
          SpatialCell* cell = mpiGrid[cells[c]];

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -287,8 +287,9 @@ bool SysBoundary::checkRefinement(dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::
    int innerBoundaryRefLvl = -1;
    int outerBoundaryRefLvl = -1;
    
+   const vector<CellID>& local_cells = getLocalCells();
    // Collect cells by sysboundarytype
-   for (auto cellId : mpiGrid.get_cells()) {
+   for (auto cellId : local_cells) {
       SpatialCell* cell = mpiGrid[cellId];
       if(cell) {
          if (cell->sysBoundaryFlag == sysboundarytype::IONOSPHERE) {
@@ -385,7 +386,7 @@ bool belongsToLayer(const int layer, const int x, const int y, const int z,
 bool SysBoundary::classifyCells(dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                                 FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid) {
    bool success = true;
-   vector<CellID> cells = mpiGrid.get_cells();
+   const vector<CellID>& cells = getLocalCells();
    auto localSize = technicalGrid.getLocalSize().data();
    
    /*set all cells to default value, not_sysboundary*/

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -392,9 +392,9 @@ int main(int argn,char* args[]) {
    // Needs to be done here already ad the background field will be set right away, before going to initializeGrid even
    phiprof::start("Init fieldsolver grids");
 
-   const std::array<int,3> fsGridDimensions = {convert<int>(P::xcells_ini) * pow(2,P::amrMaxSpatialRefLevel),
-                                               convert<int>(P::ycells_ini) * pow(2,P::amrMaxSpatialRefLevel),
-                                               convert<int>(P::zcells_ini) * pow(2,P::amrMaxSpatialRefLevel)};
+   const std::array<int,3> fsGridDimensions = {convert<int>(P::xcells_ini * pow(2,P::amrMaxSpatialRefLevel)),
+							    convert<int>(P::ycells_ini * pow(2,P::amrMaxSpatialRefLevel)),
+							    convert<int>(P::zcells_ini * pow(2,P::amrMaxSpatialRefLevel))};
 
    std::array<bool,3> periodicity{sysBoundaries.isBoundaryPeriodic(0),
                                   sysBoundaries.isBoundaryPeriodic(1),

--- a/vlasovsolver/cpu_trans_map.cpp
+++ b/vlasovsolver/cpu_trans_map.cpp
@@ -642,7 +642,7 @@ void update_remote_mapping_contribution(
    int direction,
    const uint popID) {
    
-   const vector<CellID> local_cells = mpiGrid.get_cells();
+   const vector<CellID>& local_cells = getLocalCells();
    const vector<CellID> remote_cells = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_NEIGHBORHOOD_ID);
    vector<CellID> receive_cells;
    vector<CellID> send_cells;

--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -1541,8 +1541,8 @@ void update_remote_mapping_contribution_amr(
    const uint dimension,
    int direction,
    const uint popID) {
-   
-   vector<CellID> local_cells = mpiGrid.get_cells();
+
+   const vector<CellID>& local_cells = getLocalCells();
    const vector<CellID> remote_cells = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_NEIGHBORHOOD_ID);
    vector<CellID> receive_cells;
    set<CellID> send_cells;

--- a/vlasovsolver_amr/cpu_trans_map_amr.hpp
+++ b/vlasovsolver_amr/cpu_trans_map_amr.hpp
@@ -823,7 +823,7 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
 */
 /*
 void update_remote_mapping_contribution(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, const uint dimension, int direction) {
-   const vector<CellID> local_cells = mpiGrid.get_cells();
+   const vector<CellID>& local_cells = getLocalCells();
    const vector<CellID> remote_cells = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_NEIGHBORHOOD_ID);
    vector<CellID> receive_cells;
    vector<CellID> send_cells;

--- a/vlasovsolver_amr/vlasovmover.cpp
+++ b/vlasovsolver_amr/vlasovmover.cpp
@@ -122,7 +122,7 @@ void calculateSpatialTranslation(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geome
    
    //phiprof::start("semilag-trans");
    phiprof::start("compute_cell_lists");
-   const vector<CellID> local_cells = mpiGrid.get_cells();
+   const vector<CellID>& local_cells = getLocalCells();
    phiprof::stop("compute_cell_lists");
 
    // Note: mpiGrid.is_local( cellID ) == true if cell is local
@@ -259,7 +259,7 @@ void calculateAcceleration(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
    return;
    /*
    typedef Parameters P;
-   const vector<CellID> cells = mpiGrid.get_cells();
+   const vector<CellID>& cells = getLocalCells();
    vector<CellID> propagatedCells;
    // Iterate through all local cells and propagate distribution functions 
    // in velocity space. Ghost cells (spatial cells at the boundary of the simulation 
@@ -352,8 +352,7 @@ void calculateInterpolatedVelocityMoments(
                                           const int cp_p22,
                                           const int cp_p33
                                          ) {
-   vector<CellID> cells;
-   cells=mpiGrid.get_cells();
+   const vector<CellID>& cells = getLocalCells();
    
    //Iterate through all local cells (excl. system boundary cells):
 #pragma omp parallel for
@@ -455,8 +454,7 @@ void calculateCellVelocityMoments(SpatialCell* SC,
 }
 
 void calculateInitialVelocityMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid) {
-   /*vector<CellID> cells;
-   cells=mpiGrid.get_cells();
+   /*const vector<CellID>& cells = getLocalCells();
    phiprof::start("Calculate moments"); 
    // Iterate through all local cells (incl. system boundary cells):
    #pragma omp parallel for


### PR DESCRIPTION
Clarification for non-issue #544
Consolidates calls to local cells to use cached value as often as possible. Also consolidates commented out lines in some projects.

Zero testpackage diffs. Might give a miniscule speedup. (Ignore the value in magnetosphere_small, the comparison dev run was likely abnormally slow due to concurrent `make -j 8` or similar.)

Also includes fsgrid dimension int-conversion cleanup to get rid of compiler warnings. 