### PR TITLE
At ionosphere, retain only boundary-normal components of copied perB values

### DIFF
--- a/MAKE/Makefile.vorna_gcc
+++ b/MAKE/Makefile.vorna_gcc
@@ -21,7 +21,7 @@ FLAGS =
 #GNU flags:
 CC_BRAND = gcc
 CC_BRAND_VERSION = 8.3.0
-CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mavx
+CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mavx
 testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17  -mavx
 
 MATHFLAGS = -ffast-math

--- a/fieldsolver/ldz_magnetic_field.cpp
+++ b/fieldsolver/ldz_magnetic_field.cpp
@@ -192,6 +192,36 @@ void propagateSysBoundaryMagneticField(
    }
 }
 
+/*! \brief Low-level magnetic field projection function.
+ *
+ * Projects the magnetic field according to the system boundary conditions.
+ *
+ * \param perBGrid fsGrid holding the perturbed B quantities at runge-kutta t=0
+ * \param perBDt2Grid fsGrid holding the perturbed B quantities at runge-kutta t=0.5
+ * \param technicalGrid fsGrid holding technical information (such as boundary types)
+ * \param i,j,k fsGrid cell coordinates for the current cell
+ * \param sysBoundaries System boundary conditions existing
+ * \param RKCase Element in the enum defining the Runge-Kutta method steps
+ *
+ * \sa propagateMagneticFieldSimple propagateMagneticField
+ */
+void projectSysBoundaryMagneticField(
+   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
+   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
+   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   cint i,
+   cint j,
+   cint k,
+   SysBoundary& sysBoundaries,
+   cint& RKCase
+) {
+   if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+      sysBoundaries.getSysBoundary(technicalGrid.get(i,j,k)->sysBoundaryFlag)->fieldSolverBoundaryCondMagneticFieldProject(perBGrid, technicalGrid, i, j, k);
+   } else {
+      sysBoundaries.getSysBoundary(technicalGrid.get(i,j,k)->sysBoundaryFlag)->fieldSolverBoundaryCondMagneticFieldProject(perBDt2Grid, technicalGrid, i, j, k);
+   }
+}
+
 /*! \brief High-level magnetic field propagation function.
  * 
  * Propagates the magnetic field and applies the field boundary conditions defined in project.h where needed.
@@ -305,6 +335,24 @@ void propagateMagneticFieldSimple(
                for (uint component = 0; component < 3; component++) {
                   propagateSysBoundaryMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, technicalGrid, i, j, k, sysBoundaries, dt, RKCase, component);
                }
+            }
+         }
+      }
+   }
+   phiprof::stop(timer,N_cells,"Spatial Cells");
+
+   // Project magnetic field to normal of boundary, if necessary
+   timer=phiprof::initializeTimer("Compute system boundary cells");
+   phiprof::start(timer);
+   #pragma omp parallel for collapse(3)
+   for (int k=0; k<gridDims[2]; k++) {
+      for (int j=0; j<gridDims[1]; j++) {
+         for (int i=0; i<gridDims[0]; i++) {
+            if (technicalGrid.get(i,j,k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY &&
+                ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
+                 (technicalGrid.get(i,j,k)->sysBoundaryLayer == 1))
+               ) {
+               projectSysBoundaryMagneticField(perBGrid, perBDt2Grid, technicalGrid, i, j, k, sysBoundaries, RKCase);
             }
          }
       }

--- a/fieldsolver/ldz_magnetic_field.cpp
+++ b/fieldsolver/ldz_magnetic_field.cpp
@@ -205,7 +205,7 @@ void propagateSysBoundaryMagneticField(
  *
  * \sa propagateMagneticFieldSimple propagateMagneticField
  */
-void projectSysBoundaryMagneticField(
+void SysBoundaryMagneticFieldProjection(
    FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
    FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
    FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
@@ -216,9 +216,9 @@ void projectSysBoundaryMagneticField(
    cint& RKCase
 ) {
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-      sysBoundaries.getSysBoundary(technicalGrid.get(i,j,k)->sysBoundaryFlag)->fieldSolverBoundaryCondMagneticFieldProject(perBGrid, technicalGrid, i, j, k);
+      sysBoundaries.getSysBoundary(technicalGrid.get(i,j,k)->sysBoundaryFlag)->fieldSolverBoundaryCondMagneticFieldProjection(perBGrid, technicalGrid, i, j, k);
    } else {
-      sysBoundaries.getSysBoundary(technicalGrid.get(i,j,k)->sysBoundaryFlag)->fieldSolverBoundaryCondMagneticFieldProject(perBDt2Grid, technicalGrid, i, j, k);
+      sysBoundaries.getSysBoundary(technicalGrid.get(i,j,k)->sysBoundaryFlag)->fieldSolverBoundaryCondMagneticFieldProjection(perBDt2Grid, technicalGrid, i, j, k);
    }
 }
 
@@ -341,7 +341,7 @@ void propagateMagneticFieldSimple(
    }
    phiprof::stop(timer,N_cells,"Spatial Cells");
 
-   // Project magnetic field to normal of boundary, if necessary
+   // Projection of magnetic field to normal of boundary, if necessary
    timer=phiprof::initializeTimer("Compute system boundary cells");
    phiprof::start(timer);
    #pragma omp parallel for collapse(3)
@@ -352,7 +352,7 @@ void propagateMagneticFieldSimple(
                 ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
                  (technicalGrid.get(i,j,k)->sysBoundaryLayer == 1))
                ) {
-               projectSysBoundaryMagneticField(perBGrid, perBDt2Grid, technicalGrid, i, j, k, sysBoundaries, RKCase);
+               SysBoundaryMagneticFieldProjection(perBGrid, perBDt2Grid, technicalGrid, i, j, k, sysBoundaries, RKCase);
             }
          }
       }

--- a/sysboundary/donotcompute.h
+++ b/sysboundary/donotcompute.h
@@ -68,6 +68,13 @@ namespace SBC {
          creal& dt,
          cuint& component
       ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondMagneticField called!" << std::endl; return 0.;}
+      virtual void fieldSolverBoundaryCondMagneticFieldProject(
+         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
+         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+         cint i,
+         cint j,
+         cint k
+      ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondMagneticFieldProject called!" << std::endl;}
       virtual void fieldSolverBoundaryCondElectricField(
          FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
          cint i,

--- a/sysboundary/donotcompute.h
+++ b/sysboundary/donotcompute.h
@@ -68,13 +68,13 @@ namespace SBC {
          creal& dt,
          cuint& component
       ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondMagneticField called!" << std::endl; return 0.;}
-      virtual void fieldSolverBoundaryCondMagneticFieldProject(
+      virtual void fieldSolverBoundaryCondMagneticFieldProjection(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
          cint i,
          cint j,
          cint k
-      ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondMagneticFieldProject called!" << std::endl;}
+      ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondMagneticFieldProjection called!" << std::endl;}
       virtual void fieldSolverBoundaryCondElectricField(
          FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
          cint i,

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -718,26 +718,26 @@ namespace SBC {
    ) {
       // Projection of B-field to normal direction
       Real BdotN = 0;
-      // std::array<Real, 3> normalDirection = fieldSolverGetNormalDirection(technicalGrid, i, j, k);
-      // for(uint component=0; component<3; component++) {
-      //    BdotN += bGrid.get(i,j,k)->at(fsgrids::bfield::PERBX+component) * normalDirection[component];
-      // }
-      // // Apply to any components that were not solved
-      // if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
-      //     ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BX) != compute::BX))
-      //    ) {
-      //    bGrid.get(i,j,k)->at(fsgrids::bfield::PERBX) = BdotN*normalDirection[0];
-      // }
-      // if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
-      //     ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BY) != compute::BY))
-      //    ) {
-      //    bGrid.get(i,j,k)->at(fsgrids::bfield::PERBY) = BdotN*normalDirection[1];
-      // }
-      // if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
-      //     ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BZ) != compute::BZ))
-      //    ) {
-      //    bGrid.get(i,j,k)->at(fsgrids::bfield::PERBZ) = BdotN*normalDirection[2];
-      // }
+      std::array<Real, 3> normalDirection = fieldSolverGetNormalDirection(technicalGrid, i, j, k);
+      for(uint component=0; component<3; component++) {
+         BdotN += bGrid.get(i,j,k)->at(fsgrids::bfield::PERBX+component) * normalDirection[component];
+      }
+      // Apply to any components that were not solved
+      if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
+          ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BX) != compute::BX))
+         ) {
+         bGrid.get(i,j,k)->at(fsgrids::bfield::PERBX) = BdotN*normalDirection[0];
+      }
+      if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
+          ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BY) != compute::BY))
+         ) {
+         bGrid.get(i,j,k)->at(fsgrids::bfield::PERBY) = BdotN*normalDirection[1];
+      }
+      if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
+          ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BZ) != compute::BZ))
+         ) {
+         bGrid.get(i,j,k)->at(fsgrids::bfield::PERBZ) = BdotN*normalDirection[2];
+      }
    }
 
    void Ionosphere::fieldSolverBoundaryCondElectricField(

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -709,7 +709,7 @@ namespace SBC {
     *
     * -- Retain only the boundary-normal projection of perturbed face B
     */
-   void Ionosphere::fieldSolverBoundaryCondMagneticFieldProject(
+   void Ionosphere::fieldSolverBoundaryCondMagneticFieldProjection(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
       FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
       cint i,

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -530,8 +530,6 @@ namespace SBC {
    /*! We want here to
     * 
     * -- Average perturbed face B from the nearest neighbours
-    * 
-    * -- Retain only the normal components of perturbed face B
     */
    Real Ionosphere::fieldSolverBoundaryCondMagneticField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
@@ -705,6 +703,41 @@ namespace SBC {
          }
          return retval / nCells;
       }
+   }
+
+   /*! We want here to
+    *
+    * -- Retain only the boundary-normal projection of perturbed face B
+    */
+   void Ionosphere::fieldSolverBoundaryCondMagneticFieldProject(
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
+      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+      cint i,
+      cint j,
+      cint k
+   ) {
+      // Projection of B-field to normal direction
+      Real BdotN = 0;
+      // std::array<Real, 3> normalDirection = fieldSolverGetNormalDirection(technicalGrid, i, j, k);
+      // for(uint component=0; component<3; component++) {
+      //    BdotN += bGrid.get(i,j,k)->at(fsgrids::bfield::PERBX+component) * normalDirection[component];
+      // }
+      // // Apply to any components that were not solved
+      // if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
+      //     ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BX) != compute::BX))
+      //    ) {
+      //    bGrid.get(i,j,k)->at(fsgrids::bfield::PERBX) = BdotN*normalDirection[0];
+      // }
+      // if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
+      //     ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BY) != compute::BY))
+      //    ) {
+      //    bGrid.get(i,j,k)->at(fsgrids::bfield::PERBY) = BdotN*normalDirection[1];
+      // }
+      // if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
+      //     ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BZ) != compute::BZ))
+      //    ) {
+      //    bGrid.get(i,j,k)->at(fsgrids::bfield::PERBZ) = BdotN*normalDirection[2];
+      // }
    }
 
    void Ionosphere::fieldSolverBoundaryCondElectricField(

--- a/sysboundary/ionosphere.h
+++ b/sysboundary/ionosphere.h
@@ -80,6 +80,13 @@ namespace SBC {
          creal& dt,
          cuint& component
       );
+      virtual void fieldSolverBoundaryCondMagneticFieldProject(
+         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
+         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+         cint i,
+         cint j,
+         cint k
+      );
       virtual void fieldSolverBoundaryCondElectricField(
          FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
          cint i,

--- a/sysboundary/ionosphere.h
+++ b/sysboundary/ionosphere.h
@@ -80,7 +80,7 @@ namespace SBC {
          creal& dt,
          cuint& component
       );
-      virtual void fieldSolverBoundaryCondMagneticFieldProject(
+      virtual void fieldSolverBoundaryCondMagneticFieldProjection(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
          FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
          cint i,

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -357,6 +357,14 @@ namespace SBC {
       }
    }
 
+   void Outflow::fieldSolverBoundaryCondMagneticFieldProject(
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
+      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+      cint i,
+      cint j,
+      cint k
+   ) {
+   }
    void Outflow::fieldSolverBoundaryCondElectricField(
       FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
       cint i,

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -357,7 +357,7 @@ namespace SBC {
       }
    }
 
-   void Outflow::fieldSolverBoundaryCondMagneticFieldProject(
+   void Outflow::fieldSolverBoundaryCondMagneticFieldProjection(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
       FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
       cint i,

--- a/sysboundary/outflow.h
+++ b/sysboundary/outflow.h
@@ -79,6 +79,13 @@ namespace SBC {
          creal& dt,
          cuint& component
       );
+      virtual void fieldSolverBoundaryCondMagneticFieldProject(
+         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
+         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+         cint i,
+         cint j,
+         cint k
+      );
       virtual void fieldSolverBoundaryCondElectricField(
          FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
          cint i,

--- a/sysboundary/outflow.h
+++ b/sysboundary/outflow.h
@@ -79,7 +79,7 @@ namespace SBC {
          creal& dt,
          cuint& component
       );
-      virtual void fieldSolverBoundaryCondMagneticFieldProject(
+      virtual void fieldSolverBoundaryCondMagneticFieldProjection(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
          FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
          cint i,

--- a/sysboundary/setbyuser.cpp
+++ b/sysboundary/setbyuser.cpp
@@ -156,6 +156,15 @@ namespace SBC {
       return success;
    }
    
+   void SetByUser::fieldSolverBoundaryCondMagneticFieldProject(
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
+      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+      cint i,
+      cint j,
+      cint k
+   ) {
+   }
+
    Real SetByUser::fieldSolverBoundaryCondMagneticField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
       FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,

--- a/sysboundary/setbyuser.cpp
+++ b/sysboundary/setbyuser.cpp
@@ -156,7 +156,7 @@ namespace SBC {
       return success;
    }
    
-   void SetByUser::fieldSolverBoundaryCondMagneticFieldProject(
+   void SetByUser::fieldSolverBoundaryCondMagneticFieldProjection(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
       FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
       cint i,

--- a/sysboundary/setbyuser.h
+++ b/sysboundary/setbyuser.h
@@ -84,6 +84,13 @@ namespace SBC {
          creal& dt,
          cuint& component
       );
+      virtual void fieldSolverBoundaryCondMagneticFieldProject(
+         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
+         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+         cint i,
+         cint j,
+         cint k
+      );
       virtual void fieldSolverBoundaryCondElectricField(
          FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
          cint i,

--- a/sysboundary/setbyuser.h
+++ b/sysboundary/setbyuser.h
@@ -84,7 +84,7 @@ namespace SBC {
          creal& dt,
          cuint& component
       );
-      virtual void fieldSolverBoundaryCondMagneticFieldProject(
+      virtual void fieldSolverBoundaryCondMagneticFieldProjection(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
          FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
          cint i,

--- a/sysboundary/sysboundarycondition.h
+++ b/sysboundary/sysboundarycondition.h
@@ -82,7 +82,7 @@ namespace SBC {
             creal& dt,
             cuint& component
          )=0;
-         virtual void fieldSolverBoundaryCondMagneticFieldProject(
+         virtual void fieldSolverBoundaryCondMagneticFieldProjection(
             FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
             FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
             cint i,

--- a/sysboundary/sysboundarycondition.h
+++ b/sysboundary/sysboundarycondition.h
@@ -82,6 +82,13 @@ namespace SBC {
             creal& dt,
             cuint& component
          )=0;
+         virtual void fieldSolverBoundaryCondMagneticFieldProject(
+            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
+            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+            cint i,
+            cint j,
+            cint k
+         )=0;
          virtual void fieldSolverBoundaryCondElectricField(
             FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
             cint i,


### PR DESCRIPTION
Testing is underway but looks promising in reverting near-inner boundary behaviour to Vlasiator 4 -style. Perhaps code approach can still be cleaned up?