### PR TITLE
Add reccomended modules to the top of vorna makefile

### DIFF
--- a/MAKE/Makefile.vorna_gcc
+++ b/MAKE/Makefile.vorna_gcc
@@ -1,3 +1,10 @@
+# Makefile for University of Helsinki's "vorna" Cluster
+#
+# Reccomended modules in .bashrc:
+# module load GCCcore/8.3.0
+# module load OpenMPI/3.1.4-GCC-8.3.0
+# module load Eigen
+
 CMP = mpic++
 LNK = mpic++
 


### PR DESCRIPTION
Since we had to dig these out of our .bashrc once too often now, it's better to just document them in the obvious place.