### PR TITLE
Recover BC periodicity inputs as strings

### DIFF
--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -80,9 +80,9 @@ void SysBoundary::addParameters() {
        "boundaries.boundary",
        "List of boundary condition (BC) types to be used. Each boundary condition to be used has to be on a new line "
        "boundary = YYY. Available options are: Outflow, Ionosphere, Maxwellian, User.");
-   Readparameters::add("boundaries.periodic_x", "Set the grid periodicity in x-direction. true(default)/false.", true);
-   Readparameters::add("boundaries.periodic_y", "Set the grid periodicity in y-direction. true(default)/false.", true);
-   Readparameters::add("boundaries.periodic_z", "Set the grid periodicity in z-direction. true(default)/false.", true);
+   Readparameters::add("boundaries.periodic_x", "Set the grid periodicity in x-direction. 'yes'(default)/'no'.", "yes");
+   Readparameters::add("boundaries.periodic_y", "Set the grid periodicity in y-direction. 'yes'(default)/'no'.", "yes");
+   Readparameters::add("boundaries.periodic_z", "Set the grid periodicity in z-direction. 'yes'(default)/'no'.", "yes");
    
    //call static addParameter functions in all bc's
    SBC::DoNotCompute::addParameters();


### PR DESCRIPTION
During the last commit, I happened to use boolean type in `add` and string type in `get` for `boundaries.periodic_x`... This won't crash the code, because if the user inputs boolean types, they are still recognized as strings. However, this causes inconsistencies so we'd better fix it.