### PR TITLE
Deactivate amr trans comm flag for vdfs

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -572,7 +572,7 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
 
    // flag transfers if AMR
    phiprof::start("compute_amr_transfer_flags");
-   flagSpatialCellsForAmrCommunication(mpiGrid,cells);
+   //flagSpatialCellsForAmrCommunication(mpiGrid,cells);
    phiprof::stop("compute_amr_transfer_flags");
 
    // Communicate all spatial data for FULL neighborhood, which

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -80,7 +80,7 @@ void calculateSpatialTranslation(
     int trans_timer;
     bool localTargetGridGenerated = false;
     bool AMRtranslationActive = false;
-    if (P::amrMaxSpatialRefLevel > 0) AMRtranslationActive = true;
+    //if (P::amrMaxSpatialRefLevel > 0) AMRtranslationActive = true;
 
     double t1;
     


### PR DESCRIPTION
Pending further investigation into diffs being generated near inner boundary, let's deactivate this communication-saving method for now