### PR TITLE
Update of Dispersion project to modern standards.

### DIFF
--- a/projects/Dispersion/Dispersion.h
+++ b/projects/Dispersion/Dispersion.h
@@ -58,7 +58,8 @@ namespace projects {
       );
       virtual void hook(
          cuint& stage,
-         const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid
+         const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
+         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid
       ) const;
     protected:
       Real getDistribValue(creal& vx, creal& vy, creal& vz, const uint popID) const;

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -194,7 +194,8 @@ namespace projects {
    
    void Project::hook(
       cuint& stage,
-      const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid
+      const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid
    ) const { }
 
    void Project::setupBeforeSetCell(const std::vector<CellID>& cells) {

--- a/projects/project.h
+++ b/projects/project.h
@@ -49,7 +49,8 @@ namespace projects {
       /*! Perform some operation at each time step in the main program loop. */
       virtual void hook(
          cuint& stage,
-         const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid
+         const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
+         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid
       ) const;
       
       bool initialized();

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -980,7 +980,7 @@ int main(int argn,char* args[]) {
       phiprof::stop("Propagate",computedCells,"Cells");
       
       phiprof::start("Project endTimeStep");
-      project->hook(hook::END_OF_TIME_STEP, mpiGrid);
+      project->hook(hook::END_OF_TIME_STEP, mpiGrid, perBGrid);
       phiprof::stop("Project endTimeStep");
 
       // Check timestep


### PR DESCRIPTION
Now passing perBGrid to the hook() function to allow direct output of perB components.

I wrote this update as I ran some dispersion tests lately (which ended up to be the chase for the lasers in parallel dispersion). So it runs OK.