### PR TITLE
Fieldsolver dt2, boundary, and moment fixes

### DIFF
--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -367,9 +367,11 @@ void calculateDerivativesSimple(
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
             if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) continue;
-            if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+            if (RKCase == RK_ORDER1) {
                calculateDerivatives(i,j,k, perBGrid, momentsGrid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RKCase);
-            } else {
+            } else if (RKCase == RK_ORDER2_STEP1) {
+               calculateDerivatives(i,j,k, perBGrid, momentsGrid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RKCase);
+            } else { //RKCase == RK_ORDER2_STEP2
                calculateDerivatives(i,j,k, perBDt2Grid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RKCase);
             }
          }

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -334,15 +334,6 @@ void calculateDerivativesSimple(
        }
        break;
     case RK_ORDER2_STEP1:
-      // Exchange PERB*_DT2,RHO_DT2,V*_DT2 with neighbours The
-      // update of PERB[XYZ]_DT2 is needed after the system
-      // boundary update of propagateMagneticFieldSimple.
-       perBDt2Grid.updateGhostCells();
-       if(communicateMoments) {
-         momentsDt2Grid.updateGhostCells();
-       }
-       break;
-    case RK_ORDER2_STEP2:
       // Exchange PERB*,RHO,V* with neighbours The update of B
       // is needed after the system boundary update of
       // propagateMagneticFieldSimple.
@@ -351,6 +342,15 @@ void calculateDerivativesSimple(
          momentsGrid.updateGhostCells();
        }
       break;
+    case RK_ORDER2_STEP2:
+      // Exchange PERB*_DT2,RHO_DT2,V*_DT2 with neighbours The
+      // update of PERB[XYZ]_DT2 is needed after the system
+      // boundary update of propagateMagneticFieldSimple.
+       perBDt2Grid.updateGhostCells();
+       if(communicateMoments) {
+         momentsDt2Grid.updateGhostCells();
+       }
+       break;
     default:
       cerr << __FILE__ << ":" << __LINE__ << " Went through switch, this should not happen." << endl;
       abort();

--- a/fieldsolver/ldz_electric_field.cpp
+++ b/fieldsolver/ldz_electric_field.cpp
@@ -1685,7 +1685,7 @@ void calculateUpwindedElectricFieldSimple(
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
-            if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+            if (RKCase == RK_ORDER1) {
                calculateElectricField(
                   perBGrid,
                   EGrid,
@@ -1702,10 +1702,29 @@ void calculateUpwindedElectricFieldSimple(
                   sysBoundaries,
                   RKCase
                );
-            } else { // RKCase == RK_ORDER2_STEP1
+            } else if (RKCase == RK_ORDER2_STEP1) {
+               // sources are at +0, target at +dt/2
+               calculateElectricField(
+                  perBGrid,
+                  EDt2Grid,
+                  EHallGrid,
+                  EGradPeGrid,
+                  momentsDt2Grid,
+                  dPerBGrid,
+                  dMomentsGrid,
+                  BgBGrid,
+                  technicalGrid,
+                  i,
+                  j,
+                  k,
+                  sysBoundaries,
+                  RKCase
+               );
+            } else { // RKCase == RK_ORDER2_STEP2
+               // sources are at +dt/2, target at +dt
                calculateElectricField(
                   perBDt2Grid,
-                  EDt2Grid,
+                  EGrid,
                   EHallGrid,
                   EGradPeGrid,
                   momentsDt2Grid,

--- a/fieldsolver/ldz_electric_field.cpp
+++ b/fieldsolver/ldz_electric_field.cpp
@@ -1709,7 +1709,7 @@ void calculateUpwindedElectricFieldSimple(
                   EDt2Grid,
                   EHallGrid,
                   EGradPeGrid,
-                  momentsDt2Grid,
+                  momentsGrid,
                   dPerBGrid,
                   dMomentsGrid,
                   BgBGrid,

--- a/fieldsolver/ldz_gradpe.cpp
+++ b/fieldsolver/ldz_gradpe.cpp
@@ -177,9 +177,11 @@ void calculateGradPeTermSimple(
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
-            if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+            if (RKCase == RK_ORDER1) {
                calculateGradPeTerm(EGradPeGrid, momentsGrid, dMomentsGrid, technicalGrid, i, j, k, sysBoundaries);
-            } else {
+            } else if (RKCase == RK_ORDER2_STEP1) {
+               calculateGradPeTerm(EGradPeGrid, momentsGrid, dMomentsGrid, technicalGrid, i, j, k, sysBoundaries);
+            } else { //RKCase == RK_ORDER2_STEP2
                calculateGradPeTerm(EGradPeGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, i, j, k, sysBoundaries);
             }
          }

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -826,9 +826,12 @@ void calculateHallTermSimple(
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
-            if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+            if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP1) {
+               // As intermediate perBDt2Grid isn't available, we also don't use momentsDt2Grid.
                calculateHallTerm(perBGrid, EHallGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, technicalGrid,sysBoundaries, i, j, k);
-            } else {
+            } else if (RKCase == RK_ORDER2_STEP1) {
+               calculateHallTerm(perBGrid, EHallGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, technicalGrid,sysBoundaries, i, j, k);
+            } else { // RKCase == RK_ORDER2_STEP2)
                calculateHallTerm(perBDt2Grid, EHallGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, BgBGrid, technicalGrid,sysBoundaries, i, j, k);
             }
          }

--- a/fieldsolver/ldz_magnetic_field.cpp
+++ b/fieldsolver/ldz_magnetic_field.cpp
@@ -84,14 +84,14 @@ void propagateMagneticField(
             EGrid0 = EGrid.get(i,j,k);
             EGrid1 = EGrid.get(i,j+1,k);
             EGrid2 = EGrid.get(i,j,k+1);
-            perBDt2Grid0->at(fsgrids::bfield::PERBX) = perBGrid0->at(fsgrids::bfield::PERBX) + 0.5*dt*(1.0/dz*(EGrid2->at(fsgrids::efield::EY) - EGrid0->at(fsgrids::efield::EY)) + 1.0/dy*(EGrid0->at(fsgrids::efield::EZ) - EGrid1->at(fsgrids::efield::EZ)));
+            perBDt2Grid0->at(fsgrids::bfield::PERBX) += dt/dz*(EGrid2->at(fsgrids::efield::EY) - EGrid0->at(fsgrids::efield::EY)) + dt/dy*(EGrid0->at(fsgrids::efield::EZ) - EGrid1->at(fsgrids::efield::EZ));
             break;
-            
+
          case RK_ORDER2_STEP2:
             EGrid0 = EDt2Grid.get(i,j,k);
             EGrid1 = EDt2Grid.get(i,j+1,k);
             EGrid2 = EDt2Grid.get(i,j,k+1);
-            perBGrid0->at(fsgrids::bfield::PERBX) += dt * (1.0/dz*(EGrid2->at(fsgrids::efield::EY) - EGrid0->at(fsgrids::efield::EY)) + 1.0/dy*(EGrid0->at(fsgrids::efield::EZ) - EGrid1->at(fsgrids::efield::EZ)));
+            perBGrid0->at(fsgrids::bfield::PERBX) += dt/dz*(EGrid2->at(fsgrids::efield::EY) - EGrid0->at(fsgrids::efield::EY)) + dt/dy*(EGrid0->at(fsgrids::efield::EZ) - EGrid1->at(fsgrids::efield::EZ));
             break;
             
          default:
@@ -113,13 +113,13 @@ void propagateMagneticField(
             EGrid0 = EGrid.get(i,j,k);
             EGrid1 = EGrid.get(i,j,k+1);
             EGrid2 = EGrid.get(i+1,j,k);
-            perBDt2Grid0->at(fsgrids::bfield::PERBY) = perBGrid0->at(fsgrids::bfield::PERBY) + 0.5*dt*(1.0/dx*(EGrid2->at(fsgrids::efield::EZ) - EGrid0->at(fsgrids::efield::EZ)) + 1.0/dz*(EGrid0->at(fsgrids::efield::EX) - EGrid1->at(fsgrids::efield::EX)));
+            perBDt2Grid0->at(fsgrids::bfield::PERBY) += dt/dx*(EGrid2->at(fsgrids::efield::EZ) - EGrid0->at(fsgrids::efield::EZ)) + dt/dz*(EGrid0->at(fsgrids::efield::EX) - EGrid1->at(fsgrids::efield::EX));
             break;
          case RK_ORDER2_STEP2:
             EGrid0 = EDt2Grid.get(i,j,k);
             EGrid1 = EDt2Grid.get(i,j,k+1);
             EGrid2 = EDt2Grid.get(i+1,j,k);
-            perBGrid0->at(fsgrids::bfield::PERBY) += dt * (1.0/dx*(EGrid2->at(fsgrids::efield::EZ) - EGrid0->at(fsgrids::efield::EZ)) + 1.0/dz*(EGrid0->at(fsgrids::efield::EX) - EGrid1->at(fsgrids::efield::EX)));
+            perBGrid0->at(fsgrids::bfield::PERBY) += dt/dx*(EGrid2->at(fsgrids::efield::EZ) - EGrid0->at(fsgrids::efield::EZ)) + dt/dz*(EGrid0->at(fsgrids::efield::EX) - EGrid1->at(fsgrids::efield::EX));
             break;
          default:
             std::cerr << __FILE__ << ":" << __LINE__ << ":" << "Invalid RK case." << std::endl;
@@ -140,13 +140,13 @@ void propagateMagneticField(
             EGrid0 = EGrid.get(i,j,k);
             EGrid1 = EGrid.get(i+1,j,k);
             EGrid2 = EGrid.get(i,j+1,k);
-            perBDt2Grid0->at(fsgrids::bfield::PERBZ) = perBGrid0->at(fsgrids::bfield::PERBZ) + 0.5*dt*(1.0/dy*(EGrid2->at(fsgrids::efield::EX) - EGrid0->at(fsgrids::efield::EX)) + 1.0/dx*(EGrid0->at(fsgrids::efield::EY) - EGrid1->at(fsgrids::efield::EY)));
+            perBDt2Grid0->at(fsgrids::bfield::PERBZ) += dt/dy*(EGrid2->at(fsgrids::efield::EX) - EGrid0->at(fsgrids::efield::EX)) + dt/dx*(EGrid0->at(fsgrids::efield::EY) - EGrid1->at(fsgrids::efield::EY));
             break;
          case RK_ORDER2_STEP2:
             EGrid0 = EDt2Grid.get(i,j,k);
             EGrid1 = EDt2Grid.get(i+1,j,k);
             EGrid2 = EDt2Grid.get(i,j+1,k);
-            perBGrid0->at(fsgrids::bfield::PERBZ) += dt  * (1.0/dy*(EGrid2->at(fsgrids::efield::EX) - EGrid0->at(fsgrids::efield::EX)) + 1.0/dx*(EGrid0->at(fsgrids::efield::EY) - EGrid1->at(fsgrids::efield::EY)));
+            perBGrid0->at(fsgrids::bfield::PERBZ) += dt/dy*(EGrid2->at(fsgrids::efield::EX) - EGrid0->at(fsgrids::efield::EX)) + dt/dx*(EGrid0->at(fsgrids::efield::EY) - EGrid1->at(fsgrids::efield::EY));
             break;
          default:
             std::cerr << __FILE__ << ":" << __LINE__ << ":" << "Invalid RK case." << std::endl;
@@ -294,7 +294,7 @@ void propagateMagneticFieldSimple(
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
             cuint bitfield = technicalGrid.get(i,j,k)->SOLVE;
-            // L1 pass
+            // L1 pass, should be just copies and not actual solves
             if (technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) {
                if ((bitfield & compute::BX) != compute::BX) {
                   propagateSysBoundaryMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, technicalGrid, i, j, k, sysBoundaries, dt, RKCase, 0);

--- a/fieldsolver/ldz_main.cpp
+++ b/fieldsolver/ldz_main.cpp
@@ -253,12 +253,12 @@ bool propagateFields(
          // Result of the Summer of Debugging 2016, the behaviour in wave dispersion was much improved with this.
          propagateMagneticFieldSimple(perBGrid, perBDt2Grid, EGrid, EDt2Grid, technicalGrid, sysBoundaries, subcycleDt, RK_ORDER2_STEP1);
          
-         // We need to calculate derivatives of the moments at every substep, but they only
+         // We need to calculate derivatives of the moments at every substep, but the moments only
          // need to be communicated in the first one.
          calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1, (subcycleCount==0));
          if(P::ohmGradPeTerm > 0 && subcycleCount==0) {
             calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1);
-            hallTermCommunicateDerivatives = false;
+            hallTermCommunicateDerivatives = false; // To prevent repeated ghost update of derivatives
          }
          if(P::ohmHallTerm > 0) {
             calculateHallTermSimple(
@@ -295,12 +295,13 @@ bool propagateFields(
          
          propagateMagneticFieldSimple(perBGrid, perBDt2Grid, EGrid, EDt2Grid, technicalGrid, sysBoundaries, subcycleDt, RK_ORDER2_STEP2);
          
-         // We need to calculate derivatives of the moments at every substep, but they only
+         // We need to calculate derivatives of the moments at every substep, but the moments only
          // need to be communicated in the first one.
          calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2, (subcycleCount==0));
+         hallTermCommunicateDerivatives = true; // re-activate for newly calculated derivatives
          if(P::ohmGradPeTerm > 0 && subcycleCount==0) {
             calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2);
-            hallTermCommunicateDerivatives = false;
+            hallTermCommunicateDerivatives = false; // To prevent repeated ghost update of derivatives
          }
          if(P::ohmHallTerm > 0) {
             calculateHallTermSimple(

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -572,6 +572,20 @@ int main(int argn,char* args[]) {
       phiprof::start("propagate-velocity-space-dt/2");
       if (P::propagateVlasovAcceleration) {
          calculateAcceleration(mpiGrid, 0.5*P::dt);
+         // Also update moments. They won't be transmitted to FSgrid until the field solver is called, though.
+         phiprof::start("Compute interp moments");
+         calculateInterpolatedVelocityMoments(
+            mpiGrid,
+            CellParams::RHOM,
+            CellParams::VX,
+            CellParams::VY,
+            CellParams::VZ,
+            CellParams::RHOQ,
+            CellParams::P_11,
+            CellParams::P_22,
+            CellParams::P_33
+            );
+         phiprof::stop("Compute interp moments");
       } else {
          //zero step to set up moments _v
          calculateAcceleration(mpiGrid, 0.0);
@@ -579,7 +593,7 @@ int main(int argn,char* args[]) {
       phiprof::stop("propagate-velocity-space-dt/2");
 
    }
-   
+
    phiprof::stop("Initialization");
 
    // ***********************************

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -477,7 +477,10 @@ void calculateAcceleration(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
           SpatialCell* SC = mpiGrid[cells[c]];
           const vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh = SC->get_velocity_mesh(popID);
           // disregard boundary cells, in preparation for acceleration 
-          if (SC->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ) {
+          if ( (SC->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) ||
+               // Include inflow-Maxwellian L1
+               ((SC->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN)
+                &&(SC->sysBoundaryLayer == 1)) ) {
              if(vmesh.size() != 0){
                 //do not propagate spatial cells with no blocks
                 propagatedCells.push_back(cells[c]);

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -478,9 +478,8 @@ void calculateAcceleration(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
           const vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh = SC->get_velocity_mesh(popID);
           // disregard boundary cells, in preparation for acceleration 
           if ( (SC->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) ||
-               // Include inflow-Maxwellian L1
-               ((SC->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN)
-                &&(SC->sysBoundaryLayer == 1)) ) {
+               // Include inflow-Maxwellian
+               (SC->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN)) {
              if(vmesh.size() != 0){
                 //do not propagate spatial cells with no blocks
                 propagatedCells.push_back(cells[c]);


### PR DESCRIPTION
Several fixes:

1) accelerates inflowing Maxwellian cells so that (in case of low v-space resolution) they are in sync with accelerated inner cells, removing the inflow artefact which was being built at the boundary.

2) Applies boundary conditions and re-calculates moments at end of initialization. This fixes some corner blips in fields.

3) Corrects the ordering of use of moments and moments_dt2 in RK2 fieldsolver. I think this approach is correct and better matches classical 2nd-order-accurate schemes. This includes changes to ghost updates etc to match the requirements.

4) Perhaps controversial: perB_dt2 (at t=t'+dt/2) is now updated as a dt-length step from the previous round perB_dt2 (at t=t'-dt/2), using E at t=t'. Previously, it was built on top of perB at t=t'. This method is more of a proper 2nd-order-accurate method, but I am not yet completely convinced it doesn't contain the risk of diverging B-grids at the full and intermediate steps.

5) re-activate Hall term derivatives communication for phase RK_ORDER2_STEP2 when EgradPe-term is active. This was overlooked in previous approach.