### PR TITLE
New Makefile for Ukko

### DIFF
--- a/MAKE/Makefile.ukko_gcc_openmpi
+++ b/MAKE/Makefile.ukko_gcc_openmpi
@@ -1,0 +1,97 @@
+# Makefile for the Ukko Cluster at UH.
+#
+# Suggested modules:
+#
+module purge; module load Eigen;  module load GCC/10.2.0 ;module load OpenMPI/4.0.5-GCC-10.2.0
+#
+
+CMP = mpicxx
+LNK = mpicxx
+
+#======== Vectorization ==========
+#Set vector backend type for vlasov solvers, sets precision and length. 
+#Options: 
+# AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
+# AVX512:   VEC8D_AGNER, VEC16F_AGNER
+# Fallback: VEC4D_FALLBACK, VEC4F_FALLBACK, VEC8F_FALLBACK
+
+ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
+#Single-precision        
+	VECTORCLASS = VEC8F_AGNER
+else
+#Double-precision
+	VECTORCLASS = VEC4D_AGNER
+endif
+
+#======= Compiler and compilation flags =========
+# NOTES on compiler flags:
+# CXXFLAGS is for compiler flags, they are always used
+# MATHFLAGS are for special math etc. flags, these are only applied on solver functions
+# LDFLAGS flags for linker
+
+#-DNO_WRITE_AT_ALL:  Define to disable write at all to 
+#                    avoid memleak (much slower IO)
+#-DMPICH_IGNORE_CXX_SEEK: Ignores some multiple definition 
+#                         errors that come up when using 
+#                         mpi.h in c++ on Cray
+#
+# CXXFLAGS = -DMPICH_IGNORE_CXX_SEEK
+
+FLAGS = 
+
+#GNU flags:
+CC_BRAND = gcc
+CC_BRAND_VERSION = 10.2.0
+CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -m64 -march=znver2 -flto
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -m64 -march=znver2
+
+MATHFLAGS = -ffast-math
+LDFLAGS = -lrt -lgfortran -std=c++17 -lgomp
+LIB_MPI = -lgomp -lmpi
+
+#======== PAPI ==========
+#Add PAPI_MEM define to use papi to report memory consumption?
+#CXXFLAGS += -DPAPI_MEM
+
+#======== Allocator =========
+#Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
+#Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
+CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+
+
+# BOOST_VERSION = current trilinos version
+# ZOLTAN_VERSION = current trilinos verson
+#
+#======== Libraries ===========
+
+MPT_BRAND = OpenMPI
+MPT_VERSION = 4.0.5
+
+JEMALLOC_VERSION = 5.2.1
+LIBRARY_PREFIX = /proj/group/spacephysics/ukko_libraries
+
+#compiled libraries mostly in modules
+LIB_PROFILE = -L$(LIBRARY_PREFIX)/phiprof/lib -lphiprof -Wl,-rpath=$(LIBRARY_PREFIX)/phiprof/lib
+INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include
+
+LIB_VLSV = -L$(LIBRARY_PREFIX)/vlsv -lvlsv -Wl,-rpath=$(LIBRARY_PREFIX)/vlsv
+INC_VLSV = -I$(LIBRARY_PREFIX)/vlsv
+
+LIB_JEMALLOC = -L$(LIBRARY_PREFIX)/jemalloc/lib -ljemalloc -Wl,-rpath=$(LIBRARY_PREFIX)/jemalloc/lib
+INC_JEMALLOC = -I$(LIBRARY_PREFIX)/jemalloc/include
+
+LIB_BOOST = -L$(LIBRARY_PREFIX)/boost/lib -lboost_program_options -Wl,-rpath=$(LIBRARY_PREFIX)/boost/lib
+INC_BOOST = -I$(LIBRARY_PREFIX)/boost/include
+
+LIB_ZOLTAN = -L$(LIBRARY_PREFIX)/zoltan/lib -lzoltan -Wl,-rpath=$(LIBRARY_PREFIX)/zoltan/lib
+INC_ZOLTAN = -I$(LIBRARY_PREFIX)/zoltan/include
+
+
+#header libraries
+INC_FSGRID = -I$(LIBRARY_PREFIX)/fsgrid/
+INC_DCCRG = -I$(LIBRARY_PREFIX)/dccrg/
+INC_VECTORCLASS = -I${LIBRARY_PREFIX}/version1
+
+
+
+

--- a/MAKE/Makefile.ukko_gcc_openmpi
+++ b/MAKE/Makefile.ukko_gcc_openmpi
@@ -2,7 +2,7 @@
 #
 # Suggested modules:
 #
-module purge; module load Eigen;  module load GCC/10.2.0 ;module load OpenMPI/4.0.5-GCC-10.2.0
+#module purge; module load Eigen;  module load GCC/10.2.0 ;module load OpenMPI/4.0.5-GCC-10.2.0
 #
 
 CMP = mpicxx


### PR DESCRIPTION
```
Running  on 16 mpi tasks, with 4 threads per task on 1 nodes (2 threads per physical core)
running acctest_2_maxw_500k_100k_20kms_10deg 
Filtering is off and max number of Passes is = 	 0
--------------------------------------------------------------------------------------------
acctest_2_maxw_500k_100k_20kms_10deg  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
3.863        3.837         1.00678
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
proton/vg_rho_0                1.05123e-05                 2.62805e-12    
proton/vg_v_0                0.00893624                 7.33713e-05    
proton/vg_v_1                0.00201312                 6.25649e-06    
proton/vg_v_2                0.0079645                 2.3071e-05    
--------------------------------------------------------------------------------------------
   Distribution function diff                                                               
--------------------------------------------------------------------------------------------
INFO Reading in two files.
File names: /wrk/users/kpapadak/ukko_testpackage/testpackage/refData/3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER/acctest_2_maxw_500k_100k_20kms_10deg/fullf.0000001.vlsv & /wrk/users/kpapadak/ukko_testpackage/testpackage/run_2021.11.22_16.35.50/acctest_2_maxw_500k_100k_20kms_10deg/fullf.0000001.vlsv
NonIdenticalBlocks:      0
IdenticalBlocks:         1573
Absolute_Error:          1.66243e-12
Mean-Absolute-Error:     5.68701e-17
Max-Absolute-Error:      5.94136e-14
Absolute-log-Error:      49.0056
Mean-Absolute-log-Error: 0.00167644
--------------------------------------------------------------------------------------------
running acctest_3_substeps 
Filtering is off and max number of Passes is = 	 0
--------------------------------------------------------------------------------------------
acctest_3_substeps  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
54.56        54.11         1.00832
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
proton/vg_rho_0                0.00022406                 5.60145e-11    
proton/vg_v_0                0.214124                 0.00151358    
proton/vg_v_1                0.804052                 0.00780674    
proton/vg_v_2                0.335372                 0.00204834    
--------------------------------------------------------------------------------------------
   Distribution function diff                                                               
--------------------------------------------------------------------------------------------
INFO Reading in two files.
File names: /wrk/users/kpapadak/ukko_testpackage/testpackage/refData/3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER/acctest_3_substeps/fullf.0000001.vlsv & /wrk/users/kpapadak/ukko_testpackage/testpackage/run_2021.11.22_16.35.50/acctest_3_substeps/fullf.0000001.vlsv
NonIdenticalBlocks:      5
IdenticalBlocks:         2192
Absolute_Error:          4.15634e-11
Mean-Absolute-Error:     9.67017e-16
Max-Absolute-Error:      1.07575e-13
Absolute-log-Error:      427.516
Mean-Absolute-log-Error: 0.00994663
--------------------------------------------------------------------------------------------
running transtest_2_maxw_500k_100k_20kms_20x20 
Filtering is off and max number of Passes is = 	 0
--------------------------------------------------------------------------------------------
transtest_2_maxw_500k_100k_20kms_20x20  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
17.39        18.78         0.925985
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
proton/vg_rho_0                0                 0    
proton/vg_v_0                0                 0    
proton/vg_v_1                0                 0    
proton/vg_v_2                0                 0    
--------------------------------------------------------------------------------------------
   Distribution function diff                                                               
--------------------------------------------------------------------------------------------
INFO Reading in two files.
File names: /wrk/users/kpapadak/ukko_testpackage/testpackage/refData/3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER/transtest_2_maxw_500k_100k_20kms_20x20/fullf.0000001.vlsv & /wrk/users/kpapadak/ukko_testpackage/testpackage/run_2021.11.22_16.35.50/transtest_2_maxw_500k_100k_20kms_20x20/fullf.0000001.vlsv
NonIdenticalBlocks:      0
IdenticalBlocks:         423200
Absolute_Error:          0
Mean-Absolute-Error:     0
Max-Absolute-Error:      0
Absolute-log-Error:      0
Mean-Absolute-log-Error: 0
--------------------------------------------------------------------------------------------
running acctest_4_helium 
Filtering is off and max number of Passes is = 	 0
--------------------------------------------------------------------------------------------
acctest_4_helium  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
18.34        18.29         1.00273
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
helium/vg_rho_0                0.000923795                 4.61897e-10    
helium/vg_v_0                0.78068                 0.00380751    
helium/vg_v_1                0.632901                 1.27047e-06    
helium/vg_v_2                0.115685                 0.000378423    
--------------------------------------------------------------------------------------------
running acctest_5_proton_antiproton 
Filtering is off and max number of Passes is = 	 0
--------------------------------------------------------------------------------------------
acctest_5_proton_antiproton  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
0.1447        0.1414         1.02334
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
proton/vg_rho_0                9.31323e-10                 2.32828e-16    
proton/vg_v_0                1.42319e-07                 2.15579e-08    
proton/vg_v_1                7.99911e-08                 4.80863e-09    
proton/vg_v_2                1.21225e-07                 5.35318e-08    
--------------------------------------------------------------------------------------------
   Distribution function diff                                                               
--------------------------------------------------------------------------------------------
INFO Reading in two files.
File names: /wrk/users/kpapadak/ukko_testpackage/testpackage/refData/3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER/acctest_5_proton_antiproton/fullf.0000001.vlsv & /wrk/users/kpapadak/ukko_testpackage/testpackage/run_2021.11.22_16.35.50/acctest_5_proton_antiproton/fullf.0000001.vlsv
NonIdenticalBlocks:      0
IdenticalBlocks:         1416
Absolute_Error:          2.02343e-18
Mean-Absolute-Error:     7.49002e-23
Max-Absolute-Error:      1.56304e-20
Absolute-log-Error:      1.29415e-07
Mean-Absolute-log-Error: 4.7905e-12
--------------------------------------------------------------------------------------------
running restart_write 
Filtering is off and max number of Passes is = 	 0
Parameter data file (sw1.dat) has 1 values
Parameter data file (sw1.dat) has 1 values
--------------------------------------------------------------------------------------------
restart_write  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
0.04723        0.05934         0.795922
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
proton/vg_rho_0                2.32831e-10                 2.32896e-16    
proton/vg_v_0                1.74623e-10                 3.46299e-16    
proton/vg_v_1                1.45519e-10                 5.58401e-16    
proton/vg_v_2                1.80137e-12                 0.231752    
fg_b_0                0                 0    
fg_b_1                0                 0    
fg_b_2                0                 0    
fg_e_0                0                 0    
fg_e_1                0                 0    
fg_e_2                0                 0    
--------------------------------------------------------------------------------------------
running restart_read 
Filtering is off and max number of Passes is = 	 0
Parameter data file (sw1.dat) has 1 values
Parameter data file (sw1.dat) has 1 values
--------------------------------------------------------------------------------------------
restart_read  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
                 NA
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
proton/vg_rho_0                2.32831e-10                 2.32896e-16    
proton/vg_v_0                1.74623e-10                 3.46299e-16    
proton/vg_v_1                1.45519e-10                 5.58401e-16    
proton/vg_v_2                1.80137e-12                 0.231752    
fg_b_0                0                 0    
fg_b_1                0                 0    
fg_b_2                0                 0    
fg_e_0                1.35525e-19                 5.32214e-16    
fg_e_1                3.25261e-19                 6.45032e-16    
fg_e_2                2.71051e-19                 1.06606e-15    
--------------------------------------------------------------------------------------------
running Magnetosphere_small 
Filtering is off and max number of Passes is = 	 0
Warning: proton_ionosphere.T is zero (default), now setting to the same value as proton_Magnetosphere.T, that is 100000. Set/change proton_ionosphere.T if this is not the expected behavior.
Parameter data file (sw1.dat) has 1 values
--------------------------------------------------------------------------------------------
Magnetosphere_small  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
39.94        57.19         0.698374
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
proton/vg_rho_0                0.0115898                 1.1497e-08    
proton/vg_v_0                0.0106013                 2.10238e-08    
proton/vg_v_1                0.0100628                 4.58917e-07    
proton/vg_v_2                0.00932677                 3.05596e-06    
fg_b_0                1.95217e-18                 4.89746e-10    
fg_b_1                2.00573e-18                 4.98708e-10    
fg_b_2                8.7244e-18                 5.23464e-13    
fg_e_0                1.10262e-10                 4.25865e-08    
fg_e_1                2.79979e-10                 4.38086e-08    
fg_e_2                2.22406e-11                 1.24657e-08    
--------------------------------------------------------------------------------------------
   Distribution function diff                                                               
--------------------------------------------------------------------------------------------
INFO Reading in two files.
File names: /wrk/users/kpapadak/ukko_testpackage/testpackage/refData/3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER/Magnetosphere_small/bulk.0000001.vlsv & /wrk/users/kpapadak/ukko_testpackage/testpackage/run_2021.11.22_16.35.50/Magnetosphere_small/bulk.0000001.vlsv
NonIdenticalBlocks:      0
IdenticalBlocks:         3501
Absolute_Error:          4.93263e-18
Mean-Absolute-Error:     1.63197e-22
Max-Absolute-Error:      1.85926e-19
Absolute-log-Error:      0.00261501
Mean-Absolute-log-Error: 8.65182e-08
--------------------------------------------------------------------------------------------
running Magnetosphere_polar_small 
Filtering is off and max number of Passes is = 	 0
Warning: proton_ionosphere.T is zero (default), now setting to the same value as proton_Magnetosphere.T, that is 500000. Set/change proton_ionosphere.T if this is not the expected behavior.
Parameter data file (sw1.dat) has 1 values
--------------------------------------------------------------------------------------------
Magnetosphere_polar_small  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
45.9        66.94         0.685689
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
proton/vg_rho_0                0.481236                 3.09718e-07    
proton/vg_v_0                0.710977                 9.45626e-07    
proton/vg_v_1                0.894438                 0.00122672    
proton/vg_v_2                1.15559                 2.29549e-05    
fg_b_0                3.20777e-15                 1.58585e-09    
fg_b_1                6.88557e-15                 0.000110208    
fg_b_2                3.53538e-15                 6.7164e-12    
fg_e_0                1.61951e-08                 0.000215619    
fg_e_1                2.34948e-08                 2.01819e-06    
fg_e_2                1.22905e-08                 0.000147094    
proton/vg_v_nonthermal_0                1302.34                 0.00162867    
proton/vg_v_nonthermal_1                3897.45                 0.0994051    
proton/vg_v_nonthermal_2                5473.54                 0.0113055    
proton/vg_ptensor_nonthermal_diagonal_0                7.04472e-17                 2.52126e-05    
proton/vg_ptensor_nonthermal_diagonal_1                3.43823e-17                 6.85514e-06    
proton/vg_ptensor_nonthermal_diagonal_2                3.20934e-17                 6.53194e-06    
--------------------------------------------------------------------------------------------
   Distribution function diff                                                               
--------------------------------------------------------------------------------------------
INFO Reading in two files.
File names: /wrk/users/kpapadak/ukko_testpackage/testpackage/refData/3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER/Magnetosphere_polar_small/bulk.0000001.vlsv & /wrk/users/kpapadak/ukko_testpackage/testpackage/run_2021.11.22_16.35.50/Magnetosphere_polar_small/bulk.0000001.vlsv
NonIdenticalBlocks:      3
IdenticalBlocks:         104343
Absolute_Error:          3.14974e-12
Mean-Absolute-Error:     2.16786e-18
Max-Absolute-Error:      2.01079e-14
Absolute-log-Error:      157.991
Mean-Absolute-log-Error: 0.00010874
--------------------------------------------------------------------------------------------
running test_fp_fsolver_only_3D 
Filtering is off and max number of Passes is = 	 0
--------------------------------------------------------------------------------------------
test_fp_fsolver_only_3D  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
16.9        22.69         0.744822
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
fg_b_0                0                 0    
fg_b_1                0                 0    
fg_b_2                0                 0    
fg_e_0                0                 0    
fg_e_1                0                 0    
fg_e_2                0                 0    
--------------------------------------------------------------------------------------------
running test_fp_substeps 
Filtering is off and max number of Passes is = 	 0
--------------------------------------------------------------------------------------------
test_fp_substeps  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
5.315        6.931         0.766845
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
fg_b_0                0                 0    
fg_b_1                0                 0    
fg_b_2                0                 0    
fg_e_0                0                 0    
fg_e_1                0                 0    
fg_e_2                0                 0    
--------------------------------------------------------------------------------------------
running Flowthrough_trans_periodic 
Filtering is off and max number of Passes is = 	 0
--------------------------------------------------------------------------------------------
Flowthrough_trans_periodic  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
0.7671        0.7279         1.05385
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
proton/vg_rho_0                9.31323e-10                 3.75422e-16    
proton/vg_v_0                5.82077e-10                 1.17277e-15    
proton/vg_v_1                4.07454e-10                 8.21062e-16    
proton/vg_v_2                5.82077e-10                 1.45519e-15    
fg_b_0                0                 0    
fg_b_1                0                 0    
fg_b_2                0                 0    
fg_e_0                0                 0    
fg_e_1                0                 0    
fg_e_2                0                 0    
--------------------------------------------------------------------------------------------
running Flowthrough_x_inflow_y_outflow 
Filtering is off and max number of Passes is = 	 0
Parameter data file (sw1.dat) has 1 values
Parameter data file (sw1.dat) has 1 values
--------------------------------------------------------------------------------------------
Flowthrough_x_inflow_y_outflow  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
1.07        1.188         0.900673
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
proton/vg_rho_0                3.49246e-10                 3.49344e-16    
proton/vg_v_0                4.07454e-10                 8.14958e-16    
proton/vg_v_1                1.74623e-10                 6.98492e-16    
proton/vg_v_2                2.80779e-12                 0.387456    
fg_b_0                0                 0    
fg_b_1                0                 0    
fg_b_2                0                 0    
fg_e_0                0                 0    
fg_e_1                0                 0    
fg_e_2                0                 0    
--------------------------------------------------------------------------------------------
running Flowthrough_x_inflow_y_outflow_acc 
Filtering is off and max number of Passes is = 	 0
Parameter data file (sw1.dat) has 1 values
Parameter data file (sw1.dat) has 1 values
--------------------------------------------------------------------------------------------
Flowthrough_x_inflow_y_outflow_acc  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
65.62        84.95         0.772454
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
proton/vg_rho_0                2.46638e-06                 1.17893e-12    
proton/vg_v_0                1.75845e-07                 3.51713e-13    
proton/vg_v_1                3.55358e-08                 1.42011e-13    
proton/vg_v_2                1.35712e-06                 1.20118e-09    
fg_b_0                0                 -1    
fg_b_1                0                 0    
fg_b_2                0                 -1    
fg_e_0                0                 0    
fg_e_1                0                 -1    
fg_e_2                0                 0    
--------------------------------------------------------------------------------------------
running Flowthrough_amr 
Filtering is off and max number of Passes is = 	 0
(Project.cpp) Base class 'refineSpatialCells' in projects/project.cpp:522 called. Make sure that this is correct.
Maximum refinement level is 2
Finished first level of refinement
Finished second level of refinement
Parameter data file (sw1.dat) has 1 values
--------------------------------------------------------------------------------------------
Flowthrough_amr  -  Verifying 3c10de608b6aae3c36be3be849568bf6f812f72c___DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER against 3c10de608b6aae3c36be3be849568bf6f812f72c__DACC_SEMILAG_PQM__DTRANS_SEMILAG_PPM__DDP__DDPF__DVEC4D_AGNER
--------------------------------------------------------------------------------------------
------------------------------------------------------------
 ref-time     |   new-time       |  speedup                |
------------------------------------------------------------
68.72        87.18         0.788254
------------------------------------------------------------
  variable     |     absolute diff     |     relative diff | 
------------------------------------------------------------
proton/vg_rho_0                2.99315e-05                 1.38836e-11    
proton/vg_v_0                1.75025e-05                 8.09482e-11    
proton/vg_v_1                1.32349e-05                 1.59226e-09    
proton/vg_v_2                8.68866e-06                 1.00532e-09    
fg_b_0                3.03848e-18                 3.03848e-09    
fg_b_1                7.34557e-18                 7.34557e-09    
fg_b_2                5.86671e-18                 5.86671e-09    
fg_e_0                2.29362e-12                 3.18473e-06    
fg_e_1                2.06841e-12                 1.0342e-08    
fg_e_2                1.82165e-12                 9.10826e-09    
--------------------------------------------------------------------------------------------
/var/spool/slurmd/job203559868/slurm_script: line 67: wait: pid 20 is not a child of this shell

```