### PR TITLE
Fix trans amr empty cell skip

### DIFF
--- a/testpackage/tests/Flowthrough_amr/Flowthrough_amr.cfg
+++ b/testpackage/tests/Flowthrough_amr/Flowthrough_amr.cfg
@@ -107,3 +107,7 @@ nVelocitySamples = 2
 
 [loadBalance]
 algorithm = RCB
+
+[bailout]
+velocity_space_wall_block_margin = 0
+

--- a/testpackage/tests/Flowthrough_trans_periodic/Flowthrough_trans_periodic.cfg
+++ b/testpackage/tests/Flowthrough_trans_periodic/Flowthrough_trans_periodic.cfg
@@ -82,3 +82,6 @@ VY0 = 4e5
 VZ0 = 4e5
 nSpaceSamples = 2
 nVelocitySamples = 2
+
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/Flowthrough_x_inflow_y_outflow/Flowthrough_x_inflow_y_outflow.cfg
+++ b/testpackage/tests/Flowthrough_x_inflow_y_outflow/Flowthrough_x_inflow_y_outflow.cfg
@@ -104,3 +104,6 @@ VZ0 = 0
 nSpaceSamples = 2
 nVelocitySamples = 2
 
+[bailout]
+velocity_space_wall_block_margin = 0
+

--- a/testpackage/tests/Flowthrough_x_inflow_y_outflow_acc/Flowthrough_x_inflow_y_outflow_acc.cfg
+++ b/testpackage/tests/Flowthrough_x_inflow_y_outflow_acc/Flowthrough_x_inflow_y_outflow_acc.cfg
@@ -103,3 +103,6 @@ VY0 = 0
 VZ0 = 0
 nSpaceSamples = 2
 nVelocitySamples = 2
+
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/Magnetosphere_3D_small/Magnetosphere_3D_small.cfg
+++ b/testpackage/tests/Magnetosphere_3D_small/Magnetosphere_3D_small.cfg
@@ -140,3 +140,5 @@ taperInnerRadius = 70e6
 nSpaceSamples = 1
 nVelocitySamples = 1
 
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
+++ b/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
@@ -19,7 +19,8 @@ system_write_distribution_xline_stride = 10
 system_write_distribution_yline_stride = 10
 system_write_distribution_zline_stride = 1
 
-#[bailout]
+[bailout]
+velocity_space_wall_block_margin = 0
 #write_restart = 0
 
 [gridbuilder]

--- a/testpackage/tests/Magnetosphere_small/Magnetosphere_small.cfg
+++ b/testpackage/tests/Magnetosphere_small/Magnetosphere_small.cfg
@@ -121,3 +121,5 @@ taperInnerRadius = 38.2e6
 nSpaceSamples = 1
 nVelocitySamples = 1
 
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/Selfgen_Waves_Periodic/Selfgen_Waves_Periodic.cfg
+++ b/testpackage/tests/Selfgen_Waves_Periodic/Selfgen_Waves_Periodic.cfg
@@ -99,3 +99,6 @@ Ty = 500000.0
 Tz = 500000.0
 rho  = 1000000.0
 rhoPertAbsAmp = 0
+
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/acctest_1_maxw_500k_30kms_1deg/acctest_1_maxw_500k_30kms_1deg.cfg
+++ b/testpackage/tests/acctest_1_maxw_500k_30kms_1deg/acctest_1_maxw_500k_30kms_1deg.cfg
@@ -125,3 +125,6 @@ Ty = 500000.0
 Tz = 500000.0
 rho  = 2000000.0
 rhoPertAbsAmp = 0
+
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/acctest_2_maxw_500k_100k_20kms_10deg/acctest_2_maxw_500k_100k_20kms_10deg.cfg
+++ b/testpackage/tests/acctest_2_maxw_500k_100k_20kms_10deg/acctest_2_maxw_500k_100k_20kms_10deg.cfg
@@ -99,3 +99,5 @@ Tz = 100000.0
 rho = 2000000
 rhoPertAbsAmp = 0
 
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/acctest_3_substeps/acctest_3_substeps.cfg
+++ b/testpackage/tests/acctest_3_substeps/acctest_3_substeps.cfg
@@ -103,3 +103,5 @@ Tz = 100000.0
 rho = 2000000
 rhoPertAbsAmp = 0
 
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/acctest_4_helium/acctest_4_helium.cfg
+++ b/testpackage/tests/acctest_4_helium/acctest_4_helium.cfg
@@ -92,3 +92,6 @@ Ty = 500000.0
 Tz = 500000.0
 rho  = 2000000.0
 rhoPertAbsAmp = 0
+
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/acctest_5_proton_antiproton/acctest_5_proton_antiproton.cfg
+++ b/testpackage/tests/acctest_5_proton_antiproton/acctest_5_proton_antiproton.cfg
@@ -138,3 +138,6 @@ Ty = 100000.0
 Tz = 100000.0
 rho = 2000000
 rhoPertAbsAmp = 0
+
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/restart_read/restart_read.cfg
+++ b/testpackage/tests/restart_read/restart_read.cfg
@@ -107,3 +107,5 @@ VZ0 = 0
 nSpaceSamples = 2
 nVelocitySamples = 2
 
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/restart_write/restart_write.cfg
+++ b/testpackage/tests/restart_write/restart_write.cfg
@@ -110,3 +110,5 @@ VZ0 = 0
 nSpaceSamples = 2
 nVelocitySamples = 2
 
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/test_fp_fsolver_only_3D/test_fp_fsolver_only_3D.cfg
+++ b/testpackage/tests/test_fp_fsolver_only_3D/test_fp_fsolver_only_3D.cfg
@@ -75,3 +75,5 @@ angle = 0.0
 Bdirection = 3
 shear = 0
 
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/test_fp_substeps/test_fp_substeps.cfg
+++ b/testpackage/tests/test_fp_substeps/test_fp_substeps.cfg
@@ -80,3 +80,5 @@ maxSubcycles = 20
 maxCFL = .15
 minCFL = .05
 
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/transtest_2_maxw_500k_100k_20kms_20x20/transtest_2_maxw_500k_100k_20kms_20x20.cfg
+++ b/testpackage/tests/transtest_2_maxw_500k_100k_20kms_20x20/transtest_2_maxw_500k_100k_20kms_20x20.cfg
@@ -90,3 +90,5 @@ Tz = 500000.0
 rho  = 1000000.0
 rhoPertAbsAmp = 10000
 
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/testpackage/tests/transtest_amr/transtest_amr.cfg
+++ b/testpackage/tests/transtest_amr/transtest_amr.cfg
@@ -100,3 +100,6 @@ rhoPertAbsAmp = 1.0e5
 
 [loadBalance]
 algorithm = RCB
+
+[bailout]
+velocity_space_wall_block_margin = 0

--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -697,7 +697,7 @@ setOfPencils buildPencilsWithNeighbors( const dccrg::Dccrg<SpatialCell,dccrg::Ca
 }
 
 bool check_skip_remapping(Vec* values) {
-   for (int index=-VLASOV_STENCIL_WIDTH; index<VLASOV_STENCIL_WIDTH+1; ++index) {
+   for (int index=0; index<2*VLASOV_STENCIL_WIDTH+1; ++index) {
       if (horizontal_or(values[index] > Vec(0))) return false;
    }
    return true;


### PR DESCRIPTION
PR #543 had a bug in it - the indexing when searching for empty vectors was slightly off. This should correct it. Testpackage is clean - also added flag to set 
```
[bailout]
velocity_space_wall_block_margin = 0
```
in all testpackage tests so they don't bail out.