### PR TITLE
Fieldsolver boundary, and moment fixes (cherry-pick of 589)

### DIFF
--- a/fieldsolver/ldz_electric_field.cpp
+++ b/fieldsolver/ldz_electric_field.cpp
@@ -1666,16 +1666,20 @@ void calculateUpwindedElectricFieldSimple(
    
    timer=phiprof::initializeTimer("MPI","MPI");
    phiprof::start(timer);
+   // Update ghosts if necessary, unless previous terms have already updated them
    if(P::ohmHallTerm > 0) {
       EHallGrid.updateGhostCells();
    }
    if(P::ohmGradPeTerm > 0) {
       EGradPeGrid.updateGhostCells();
    }
-   if(P::ohmHallTerm == 0 && P::ohmGradPeTerm == 0) {
+   if(P::ohmHallTerm == 0) {
       dPerBGrid.updateGhostCells();
+   }
+   if(P::ohmHallTerm == 0 && P::ohmGradPeTerm == 0) {
       dMomentsGrid.updateGhostCells();
    }
+   
    phiprof::stop(timer);
    
    // Calculate upwinded electric field on inner cells

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -804,23 +804,22 @@ void calculateHallTermSimple(
    FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
    FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
    SysBoundary& sysBoundaries,
-   cint& RKCase,
-   const bool communicateMomentsDerivatives
+   cint& RKCase
 ) {
    int timer;
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
-   
+
    phiprof::start("Calculate Hall term");
    timer=phiprof::initializeTimer("MPI","MPI");
    phiprof::start(timer);
    dPerBGrid.updateGhostCells();
-   if(communicateMomentsDerivatives) {
+   if(P::ohmGradPeTerm == 0) {
       dMomentsGrid.updateGhostCells();
    }
    phiprof::stop(timer);
-   
+
    phiprof::start("Compute cells");
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -835,6 +834,6 @@ void calculateHallTermSimple(
       }
    }
    phiprof::stop("Compute cells");
-   
+
    phiprof::stop("Calculate Hall term",N_cells,"Spatial Cells");
 }

--- a/fieldsolver/ldz_hall.hpp
+++ b/fieldsolver/ldz_hall.hpp
@@ -33,8 +33,7 @@ void calculateHallTermSimple(
    FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
    FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
    SysBoundary& sysBoundaries,
-   cint& RKCase,
-   const bool communicateMomentsDerivatives
+   cint& RKCase
 );
 
 #endif

--- a/fieldsolver/ldz_main.cpp
+++ b/fieldsolver/ldz_main.cpp
@@ -298,9 +298,10 @@ bool propagateFields(
          // We need to calculate derivatives of the moments at every substep, but they only
          // need to be communicated in the first one.
          calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2, (subcycleCount==0));
+         hallTermCommunicateDerivatives = true; // re-activate for newly calculated derivatives
          if(P::ohmGradPeTerm > 0 && subcycleCount==0) {
             calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2);
-            hallTermCommunicateDerivatives = false;
+            hallTermCommunicateDerivatives = false; // To prevent repeated ghost update of derivatives
          }
          if(P::ohmHallTerm > 0) {
             calculateHallTermSimple(

--- a/fieldsolver/ldz_main.cpp
+++ b/fieldsolver/ldz_main.cpp
@@ -107,8 +107,6 @@ bool propagateFields(
       exit(1);
    }
    
-   bool hallTermCommunicateDerivatives = true;
-   
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    
    #pragma omp parallel for collapse(3)
@@ -127,7 +125,6 @@ bool propagateFields(
       calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER1, true);
       if(P::ohmGradPeTerm > 0){
          calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER1);
-         hallTermCommunicateDerivatives = false;
       }
       if(P::ohmHallTerm > 0) {
          calculateHallTermSimple(
@@ -141,8 +138,7 @@ bool propagateFields(
             BgBGrid,
             technicalGrid,
             sysBoundaries,
-            RK_ORDER1,
-            hallTermCommunicateDerivatives
+            RK_ORDER1
          );
       }
       calculateUpwindedElectricFieldSimple(
@@ -166,7 +162,6 @@ bool propagateFields(
       calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1, true);
       if(P::ohmGradPeTerm > 0) {
          calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1);
-         hallTermCommunicateDerivatives = false;
       }
       if(P::ohmHallTerm > 0) {
          calculateHallTermSimple(
@@ -180,8 +175,7 @@ bool propagateFields(
             BgBGrid,
             technicalGrid,
             sysBoundaries,
-            RK_ORDER2_STEP1,
-            hallTermCommunicateDerivatives
+            RK_ORDER2_STEP1
          );
       }
       calculateUpwindedElectricFieldSimple(
@@ -205,7 +199,6 @@ bool propagateFields(
       calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2, true);
       if(P::ohmGradPeTerm > 0) {
          calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2);
-         hallTermCommunicateDerivatives = false;
       }
       if(P::ohmHallTerm > 0) {
          calculateHallTermSimple(
@@ -219,8 +212,7 @@ bool propagateFields(
             BgBGrid,
             technicalGrid,
             sysBoundaries,
-            RK_ORDER2_STEP2,
-            hallTermCommunicateDerivatives
+            RK_ORDER2_STEP2
          );
       }
       calculateUpwindedElectricFieldSimple(
@@ -247,18 +239,17 @@ bool propagateFields(
       uint subcycleCount = 0;
       uint maxSubcycleCount = std::numeric_limits<uint>::max();
       int myRank = perBGrid.getRank();
-      
-      while (subcycleCount < maxSubcycleCount ) {         
+
+      while (subcycleCount < maxSubcycleCount ) {
          // In case of subcycling, we decided to go for a blunt Runge-Kutta subcycling even though e.g. moments are not going along.
          // Result of the Summer of Debugging 2016, the behaviour in wave dispersion was much improved with this.
          propagateMagneticFieldSimple(perBGrid, perBDt2Grid, EGrid, EDt2Grid, technicalGrid, sysBoundaries, subcycleDt, RK_ORDER2_STEP1);
-         
-         // We need to calculate derivatives of the moments at every substep, but they only
+
+         // We need to calculate derivatives of the moments at every substep, but the moments only
          // need to be communicated in the first one.
          calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1, (subcycleCount==0));
          if(P::ohmGradPeTerm > 0 && subcycleCount==0) {
             calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1);
-            hallTermCommunicateDerivatives = false;
          }
          if(P::ohmHallTerm > 0) {
             calculateHallTermSimple(
@@ -272,8 +263,7 @@ bool propagateFields(
                BgBGrid,
                technicalGrid,
                sysBoundaries,
-               RK_ORDER2_STEP1,
-               hallTermCommunicateDerivatives
+               RK_ORDER2_STEP1
             );
          }
          calculateUpwindedElectricFieldSimple(
@@ -295,13 +285,11 @@ bool propagateFields(
          
          propagateMagneticFieldSimple(perBGrid, perBDt2Grid, EGrid, EDt2Grid, technicalGrid, sysBoundaries, subcycleDt, RK_ORDER2_STEP2);
          
-         // We need to calculate derivatives of the moments at every substep, but they only
+         // We need to calculate derivatives of the moments at every substep, but the moments only
          // need to be communicated in the first one.
          calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2, (subcycleCount==0));
-         hallTermCommunicateDerivatives = true; // re-activate for newly calculated derivatives
          if(P::ohmGradPeTerm > 0 && subcycleCount==0) {
             calculateGradPeTermSimple(EGradPeGrid, momentsGrid, momentsDt2Grid, dMomentsGrid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2);
-            hallTermCommunicateDerivatives = false; // To prevent repeated ghost update of derivatives
          }
          if(P::ohmHallTerm > 0) {
             calculateHallTermSimple(
@@ -315,8 +303,7 @@ bool propagateFields(
                BgBGrid,
                technicalGrid,
                sysBoundaries,
-               RK_ORDER2_STEP2,
-               hallTermCommunicateDerivatives
+               RK_ORDER2_STEP2
             );
          }
          calculateUpwindedElectricFieldSimple(

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -133,6 +133,7 @@ vector<string> P::diagnosticVariableList;
 
 string P::projectName = string("");
 
+bool P::vlasovAccelerateMaxwellianBoundaries = false;
 Real P::maxSlAccelerationRotation = 10.0;
 Real P::hallMinimumRhom = physicalconstants::MASS_PROTON;
 Real P::hallMinimumRhoq = physicalconstants::CHARGE;
@@ -290,6 +291,9 @@ bool P::addParameters() {
            "The minimum CFL limit for vlasov propagation in ordinary space. Used to set timestep if dynamic_timestep "
            "is true.",
            0.8);
+   RP::add("vlasovsolver.accelerateMaxwellianBoundaries",
+           "Propagate maxwellian boundary cell contents in velocity space. Default false.",
+           false);
 
    // Load balancing parameters
    RP::add("loadBalance.algorithm", "Load balancing algorithm to be used", string("RCB"));
@@ -676,6 +680,7 @@ void Parameters::getParameters() {
    RP::get("vlasovsolver.maxSlAccelerationSubcycles", P::maxSlAccelerationSubcycles);
    RP::get("vlasovsolver.maxCFL", P::vlasovSolverMaxCFL);
    RP::get("vlasovsolver.minCFL", P::vlasovSolverMinCFL);
+   RP::get("vlasovsolver.accelerateMaxwellianBoundaries",  P::vlasovAccelerateMaxwellianBoundaries);
 
    // Get load balance parameters
    RP::get("loadBalance.algorithm", P::loadBalanceAlgorithm);

--- a/parameters.h
+++ b/parameters.h
@@ -137,6 +137,7 @@ struct Parameters {
 
    static Real maxSlAccelerationRotation; /*!< Maximum rotation in acceleration for semilagrangian solver*/
    static int maxSlAccelerationSubcycles; /*!< Maximum number of subcycles in acceleration*/
+   static bool vlasovAccelerateMaxwellianBoundaries; /*!< Accelerate also Maxwellian boundary cells*/
 
    static Real hallMinimumRhom; /*!< Minimum mass density value used in the field solver.*/
    static Real hallMinimumRhoq; /*!< Minimum charge density value used for the Hall and electron pressure gradient terms

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -594,8 +594,29 @@ int main(int argn,char* args[]) {
       }
       phiprof::stop("propagate-velocity-space-dt/2");
 
+      // Apply boundary conditions
+      if (P::propagateVlasovTranslation || P::propagateVlasovAcceleration ) {
+         phiprof::start("Update system boundaries (Vlasov post-acceleration)");
+         sysBoundaries.applySysBoundaryVlasovConditions(mpiGrid, 0.5*P::dt, true);
+         phiprof::stop("Update system boundaries (Vlasov post-acceleration)");
+         addTimedBarrier("barrier-boundary-conditions");
+      }
+      // Also update all moments. They won't be transmitted to FSgrid until the field solver is called, though.
+      phiprof::start("Compute interp moments");
+      calculateInterpolatedVelocityMoments(
+         mpiGrid,
+         CellParams::RHOM,
+         CellParams::VX,
+         CellParams::VY,
+         CellParams::VZ,
+         CellParams::RHOQ,
+         CellParams::P_11,
+         CellParams::P_22,
+         CellParams::P_33
+         );
+      phiprof::stop("Compute interp moments");
    }
-   
+
    phiprof::stop("Initialization");
 
    // ***********************************

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -479,7 +479,7 @@ void calculateAcceleration(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
           // disregard boundary cells, in preparation for acceleration
           if (  (SC->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) ||
                 // Include inflow-Maxwellian
-                (SC->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN)) {
+                (P::vlasovAccelerateMaxwellianBoundaries && (SC->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN)) ) {
              if (vmesh.size() != 0){
                 //do not propagate spatial cells with no blocks
                 propagatedCells.push_back(cells[c]);

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -476,9 +476,11 @@ void calculateAcceleration(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
        for (size_t c=0; c<cells.size(); ++c) {
           SpatialCell* SC = mpiGrid[cells[c]];
           const vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh = SC->get_velocity_mesh(popID);
-          // disregard boundary cells, in preparation for acceleration 
-          if (SC->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ) {
-             if(vmesh.size() != 0){
+          // disregard boundary cells, in preparation for acceleration
+          if (  (SC->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) ||
+                // Include inflow-Maxwellian
+                (SC->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN)) {
+             if (vmesh.size() != 0){
                 //do not propagate spatial cells with no blocks
                 propagatedCells.push_back(cells[c]);
              }


### PR DESCRIPTION
This PR includes the non-controversial parts of #589:

1. accelerates inflowing Maxwellian cells so that (in case of low v-space resolution) they are in sync with accelerated inner cells, removing the inflow artefact which was being built at the boundary.

2. Applies boundary conditions and re-calculates moments at end of initialization. This fixes some corner blips in fields.

3. re-activate Hall term derivatives communication for phase RK_ORDER2_STEP2 when EgradPe-term is active. This was overlooked in previous approach.

The dt2 changes are then pending more testing with interpolated fields, but these should go in soon.