### PR TITLE
Fix vector dipole limit distance checks

### DIFF
--- a/backgroundfield/vectordipole.cpp
+++ b/backgroundfield/vectordipole.cpp
@@ -153,7 +153,7 @@ double VectorDipole::operator()( double x, double y, double z, coordinate compon
    IMFdS2cart[1] = 0;     //(r[1]/r1)*dS2dr;
    IMFdS2cart[2] = 0;     //(r[2]/r1)*dS2dr;      
 
-   if((derivative == 0) && (r1 > xlimit[0])) {
+   if((derivative == 0) && (r[0] > xlimit[0])) {
      /* Within transition range (between xlimit[0] and xlimit[1]) we
         multiply the magnetic field with the S2 smootherstep function
         and add an additional corrective term to remove divergence. This
@@ -205,7 +205,7 @@ double VectorDipole::operator()( double x, double y, double z, coordinate compon
        return S2*B + delS2crossA[component] + IMFS2*IMFB + IMFdelS2crossA[component];
    }
 
-   else if((derivative == 1) && (r1 > xlimit[0])) {
+   else if((derivative == 1) && (r[0] > xlimit[0])) {
        /* first derivatives of field calculated from diminishing vector potential
 
           del B'(r) = S2(s) del B(r) + B(r) del S2(s) + del (del S2(s) cross A(r))

--- a/backgroundfield/vectordipole.cpp
+++ b/backgroundfield/vectordipole.cpp
@@ -153,7 +153,7 @@ double VectorDipole::operator()( double x, double y, double z, coordinate compon
    IMFdS2cart[1] = 0;     //(r[1]/r1)*dS2dr;
    IMFdS2cart[2] = 0;     //(r[2]/r1)*dS2dr;      
 
-   if((derivative == 0) && (r[0] > xlimit[0])) {
+   if(derivative == 0) {
      /* Within transition range (between xlimit[0] and xlimit[1]) we
         multiply the magnetic field with the S2 smootherstep function
         and add an additional corrective term to remove divergence. This
@@ -205,7 +205,7 @@ double VectorDipole::operator()( double x, double y, double z, coordinate compon
        return S2*B + delS2crossA[component] + IMFS2*IMFB + IMFdelS2crossA[component];
    }
 
-   else if((derivative == 1) && (r[0] > xlimit[0])) {
+   else if(derivative == 1) {
        /* first derivatives of field calculated from diminishing vector potential
 
           del B'(r) = S2(s) del B(r) + B(r) del S2(s) + del (del S2(s) cross A(r))


### PR DESCRIPTION
This was discovered as part of #579

The vector dipole has some wrong (and anyway probably useless) tests for the range limit in there. This commit corrects them, but should be tested whether it actually is still identical.