### PR TITLE
Amr filtering update

### DIFF
--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -104,9 +104,9 @@ void filterMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
 
 
    // Kernel Characteristics
-   const int stencilWidth = 5;   // dimension size of a 3D kernel
+   const int stencilWidth = 5;   // Stencil width of a 3D 5-tap triangle kernel
    const int kernelOffset = 2;   // offset of 5 pointstencil 3D kernel => (floor(stencilWidth/2);)
-   const Real kernelSum=729.0;
+   const Real kernelSum=729.0;   // the total kernel's sum 
    const static Real kernel[5][5][5] ={
                                  {{ 1,  2,  3,  2,  1},
                                  { 2,  4,  6,  4,  2},

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -186,11 +186,15 @@ void filterMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                      for (int a=-kernelOffset; a<=kernelOffset; a++){
                         cell = momentsGrid.get(i+a,j+b,k+c);
                         for (int e = 0; e < fsgrids::moments::N_MOMENTS; ++e) {
-                           swap->at(e)+=cell->at(e) *kernel[kernelOffset+a][kernelOffset+b][kernelOffset+c]/kernelSum;
+                           swap->at(e)+=cell->at(e) *kernel[kernelOffset+a][kernelOffset+b][kernelOffset+c];
                         } 
                      }
                   }
                }//inner filtering loop
+               //divide by the total kernel sum
+               for (int e = 0; e < fsgrids::moments::N_MOMENTS; ++e) {
+                  swap->at(e)/=kernelSum;
+               }
             }
          }
       } //spatial loops

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -92,6 +92,121 @@ template <typename T, int stencil> void computeCoupling(dccrg::Dccrg<SpatialCell
   }
 }
 
+/*
+Filter moments after feeding them to FsGrid to alleviate the staircase effect caused in AMR runs.
+This is using a 3D, 5-point stencil triangle kernel.
+*/
+void filterMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
+                           FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
+                           FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid) 
+{
+
+
+
+   // Kernel Characteristics
+   const int stencilWidth = 5;   // dimension size of a 3D kernel
+   const int kernelOffset = 2;   // offset of 5 pointstencil 3D kernel => (floor(stencilWidth/2);)
+   const Real kernelSum=729.0;
+   const Real kernel[5][5][5] ={
+                                 {{ 1,  2,  3,  2,  1},
+                                 { 2,  4,  6,  4,  2},
+                                 { 3,  6,  9,  6,  3},
+                                 { 2,  4,  6,  4,  2},
+                                 { 1,  2,  3,  2,  1}},
+
+                                 {{ 2,  4,  6,  4,  2},
+                                 { 4,  8, 12,  8,  4},
+                                 { 6, 12, 18, 12,  6},
+                                 { 4,  8, 12,  8,  4},
+                                 { 2,  4,  6,  4,  2}},
+
+                                 {{ 3,  6,  9,  6,  3},
+                                 { 6, 12, 18, 12,  6},
+                                 { 9, 18, 27, 18,  9},
+                                 { 6, 12, 18, 12,  6},
+                                 { 3,  6,  9,  6,  3}},
+
+                                 {{ 2,  4,  6,  4,  2},
+                                 { 4,  8, 12,  8,  4},
+                                 { 6, 12, 18, 12,  6},
+                                 { 4,  8, 12,  8,  4},
+                                 { 2,  4,  6,  4,  2}},
+
+                                 {{ 1,  2,  3,  2,  1},
+                                 { 2,  4,  6,  4,  2},
+                                 { 3,  6,  9,  6,  3},
+                                 { 2,  4,  6,  4,  2},
+                                 { 1,  2,  3,  2,  1}}
+                                 };
+
+   // Update momentsGrid Ghost Cells
+   momentsGrid.updateGhostCells(); 
+
+
+   // Get size of local domain and create swapGrid for filtering
+   const int *mntDims= &momentsGrid.getLocalSize()[0];  
+   const int maxRefLevel = mpiGrid.mapping.get_maximum_refinement_level();
+   FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> swapGrid = momentsGrid;  //swap array 
+
+   // Filtering Loop
+   for (int blurPass = 0; blurPass < Parameters::maxFilteringPasses; blurPass++){
+
+      // Blurring Pass
+      #pragma omp parallel for collapse(2)
+      for (int k = 0; k < mntDims[2]; k++){
+         for (int j = 0; j < mntDims[1]; j++){
+            for (int i = 0; i < mntDims[0]; i++){
+
+               //  Get refLevel level
+               int refLevel = technicalGrid.get(i, j, k)->refLevel;
+
+               //  Get refLevel level
+               // Skip pass
+               if (blurPass >= P::numPasses[refLevel] ||
+                  technicalGrid.get(i, j, k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
+                  (technicalGrid.get(i, j, k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY &&
+                  technicalGrid.get(i, j, k)->sysBoundaryLayer == 2)
+               )
+               {
+                  continue;
+               }
+
+               // Get pointers to our cells
+               std::array<Real, fsgrids::moments::N_MOMENTS> *cell;  
+               std::array<Real,fsgrids::moments::N_MOMENTS> *swap;
+            
+               // Set Cell to zero before passing filter
+               swap = swapGrid.get(i,j,k);
+               for (int e = 0; e < fsgrids::moments::N_MOMENTS; ++e) {
+                  swap->at(e)=0.0;
+               }
+
+               // Perform the blur
+               for (int c=-kernelOffset; c<=kernelOffset; c++){
+                  for (int b=-kernelOffset; b<=kernelOffset; b++){
+                     for (int a=-kernelOffset; a<=kernelOffset; a++){
+
+                        swap = swapGrid.get(i,j,k);
+                        cell = momentsGrid.get(i+a,j+b,k+c);
+
+                        for (int e = 0; e < fsgrids::moments::N_MOMENTS; ++e) {
+                           swap->at(e)+=cell->at(e) *kernel[kernelOffset+a][kernelOffset+b][kernelOffset+c]/kernelSum;
+                        } 
+                     }
+                  }
+               }//inner filtering loop
+            }
+         }
+      } //spatial loops
+
+      // Copy swapGrid back to momentsGrid
+      momentsGrid=swapGrid;
+      // Update Ghost Cells
+      momentsGrid.updateGhostCells();
+
+    }
+}
+
 void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                            const std::vector<CellID>& cells,
                            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
@@ -189,116 +304,12 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
 
   MPI_Waitall(sendRequests.size(), sendRequests.data(), MPI_STATUSES_IGNORE);
 
-
-
-  if (P::amrMaxSpatialRefLevel>0) {
-
-    /*----------------------Filtering------------------------*/
-    phiprof::start("BoxCar Filtering");
-
-    // Kernel Characteristics
-    // int stencilWidth = sizeof( kernel) / sizeof( kernel[0]); //get the stnecil width
-    // int kernelOffset= stencilWidth/3; //this is the kernel offset -int
-    int stencilWidth = 3;   // dimension size of a 3D kernel
-    int kernelOffset = 1;   // offset of 3 point stencil 3D kernel
-    Real kernelWeight= 1.0/27.0;  // 3D boxcar kernel weight
-
-
-    // Update momentsGrid Ghost Cells
-    phiprof::start("GhostUpdate");
-    momentsGrid.updateGhostCells(); //update ghost zones
-    phiprof::stop("GhostUpdate");
-
-    // Get size of local domain and create swapGrid for filtering
-    const int *mntDims= &momentsGrid.getLocalSize()[0];   //get local size for each proc.
-    FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> swapGrid = momentsGrid;  //swap array 
-    const int maxRefLevel = mpiGrid.mapping.get_maximum_refinement_level();
-
-    // Filtering Loop
-   std::vector<int>::iterator  maxNumPassesPtr;
-   int maxNumPasses;
-   maxNumPassesPtr=std::max_element(P::numPasses.begin(), P::numPasses.end());
-   if(maxNumPassesPtr != P::numPasses.end()){ 
-      maxNumPasses = *maxNumPassesPtr;
-   }else{
-      std::cerr << "Trying to dereference null pointer \t" << " in " << __FILE__ << ":" << __LINE__ << std::endl;
-      abort();
-   } 
-
-    for (int blurPass = 0; blurPass < maxNumPasses; blurPass++){
-
-      // Blurring Pass
-      phiprof::start("BlurPass");
-      #pragma omp parallel for collapse(2)
-      for (int kk = 0; kk < mntDims[2]; kk++){
-        for (int jj = 0; jj < mntDims[1]; jj++){
-          for (int ii = 0; ii < mntDims[0]; ii++){
-
-            //  Get refLevel level
-            int refLevel = technicalGrid.get(ii, jj, kk)->refLevel;
-
-            // Skip pass
-            if (blurPass >= P::numPasses.at(refLevel) ||
-                technicalGrid.get(ii, jj, kk)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
-                (technicalGrid.get(ii, jj, kk)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY && technicalGrid.get(ii, jj, kk)->sysBoundaryLayer == 2)
-              )
-            {
-              
-              continue;
-            }
-
-            // Define some Pointers
-            std::array<Real, fsgrids::moments::N_MOMENTS> *cell;  
-            std::array<Real,fsgrids::moments::N_MOMENTS> *swap;
-           
-            // Set Cell to zero before passing filter
-            swap = swapGrid.get(ii,jj,kk);
-            for (int e = 0; e < fsgrids::moments::N_MOMENTS; ++e) {
-
-              swap->at(e)=0.0;
-
-            }
-
-            // Perform the blur
-            for (int a=0; a<stencilWidth; a++){
-              for (int b=0; b<stencilWidth; b++){
-                for (int c=0; c<stencilWidth; c++){
-
-                  int xn=ii+a-kernelOffset;
-                  int yn=jj+b-kernelOffset;
-                  int zn=kk+c-kernelOffset;
-
-                  cell = momentsGrid.get(xn, yn, zn);
-                  swap = swapGrid.get(ii,jj,kk);
-
-                  for (int e = 0; e < fsgrids::moments::N_MOMENTS; ++e) {
-                    swap->at(e)+=cell->at(e) * kernelWeight;
-
-                    } 
-                  }
-                }
-              }
-            }
-          }
-        }
-
-      phiprof::stop("BlurPass");
-
-
-      // Copy swapGrid back to momentsGrid
-      momentsGrid=swapGrid;
-
-      // Update Ghost Cells
-      phiprof::start("GhostUpdate");
-      momentsGrid.updateGhostCells();
-      phiprof::stop("GhostUpdate");
-
-    }
-    
-
-    phiprof::stop("BoxCar Filtering");  
-
-  }   
+   //Filter Moments
+  if (P::amrMaxSpatialRefLevel>0) { 
+      phiprof::start("AMR Filtering-Triangle-3D");
+      filterMoments(mpiGrid,momentsGrid,technicalGrid);
+      phiprof::stop("AMR Filtering-Triangle-3D");
+   }   
 }
 
 

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -185,10 +185,7 @@ void filterMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                for (int c=-kernelOffset; c<=kernelOffset; c++){
                   for (int b=-kernelOffset; b<=kernelOffset; b++){
                      for (int a=-kernelOffset; a<=kernelOffset; a++){
-
-                        swap = swapGrid.get(i,j,k);
                         cell = momentsGrid.get(i+a,j+b,k+c);
-
                         for (int e = 0; e < fsgrids::moments::N_MOMENTS; ++e) {
                            swap->at(e)+=cell->at(e) *kernel[kernelOffset+a][kernelOffset+b][kernelOffset+c]/kernelSum;
                         } 
@@ -304,7 +301,7 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
 
   MPI_Waitall(sendRequests.size(), sendRequests.data(), MPI_STATUSES_IGNORE);
 
-   //Filter Moments
+   //Filter Moments if this is a 3D AMR run.
   if (P::amrMaxSpatialRefLevel>0) { 
       phiprof::start("AMR Filtering-Triangle-3D");
       filterMoments(mpiGrid,momentsGrid,technicalGrid);

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -107,7 +107,7 @@ void filterMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    const int stencilWidth = 5;   // dimension size of a 3D kernel
    const int kernelOffset = 2;   // offset of 5 pointstencil 3D kernel => (floor(stencilWidth/2);)
    const Real kernelSum=729.0;
-   const Real kernel[5][5][5] ={
+   const static Real kernel[5][5][5] ={
                                  {{ 1,  2,  3,  2,  1},
                                  { 2,  4,  6,  4,  2},
                                  { 3,  6,  9,  6,  3},
@@ -160,12 +160,11 @@ void filterMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                //  Get refLevel level
                int refLevel = technicalGrid.get(i, j, k)->refLevel;
 
-               //  Get refLevel level
                // Skip pass
-               if (blurPass >= P::numPasses[refLevel] ||
+               if (blurPass >= P::numPasses.at(refLevel) ||
                   technicalGrid.get(i, j, k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
                   (technicalGrid.get(i, j, k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY &&
-                  technicalGrid.get(i, j, k)->sysBoundaryLayer == 2)
+                  technicalGrid.get(i, j, k)->sysBoundaryLayer >= 2)
                )
                {
                   continue;

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -580,14 +580,22 @@ void Parameters::getParameters() {
       }else{
          //here we will default to manually constructing the number of passes
          numPasses.clear();
-         int maxPasses=P::amrMaxSpatialRefLevel;
-         for (uint refLevel=0; refLevel<P::amrMaxSpatialRefLevel+1; refLevel++){
+         auto g_sequence=[](int size){
+            int retval=1;
+            while(size!=0){
+               retval*=2;
+               size-=1;
+            }
+            return retval;
+         };
+         int maxPasses=g_sequence(P::amrMaxSpatialRefLevel-1);
+         for (uint refLevel=0; refLevel<=P::amrMaxSpatialRefLevel; refLevel++){
             numPasses[refLevel] =maxPasses;
             maxPasses/=2; 
          }
       }
-      //Overwrite 0 passes for the highest refLevel. We do not want to filter there.
       P::maxFilteringPasses = numPasses[0];
+      //Overwrite 0 passes for the highest refLevel. We do not want to filter there.
       numPasses[P::amrMaxSpatialRefLevel] = 0;
    }
 

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -556,7 +556,7 @@ void Parameters::getParameters() {
    RP::get("AMR.transShortPencils", P::amrTransShortPencils);
    RP::get("AMR.filterpasses", P::blurPassString);
 
-   // If we are in an AMR run we need to set up the filtering options.
+   // If we are in an AMR run we need to set up the filtering scheme.
    if (P::amrMaxSpatialRefLevel>0){
       bool isEmpty = blurPassString.size() == 0;
       if (!isEmpty){
@@ -580,7 +580,7 @@ void Parameters::getParameters() {
       }else{
          //here we will default to manually constructing the number of passes
          numPasses.clear();
-         int maxPasses=P::amrMaxSpatialRefLevel+1;
+         int maxPasses=P::amrMaxSpatialRefLevel;
          for (uint refLevel=0; refLevel<P::amrMaxSpatialRefLevel+1; refLevel++){
             numPasses[refLevel] =maxPasses;
             maxPasses/=2; 
@@ -589,12 +589,6 @@ void Parameters::getParameters() {
       //Overwrite 0 passes for the highest refLevel. We do not want to filter there.
       P::maxFilteringPasses = numPasses[0];
       numPasses[P::amrMaxSpatialRefLevel] = 0;
-      if (myRank == MASTER_RANK) {
-         for (const auto p:numPasses){
-            printf("Refinement Level %d-->%d Passes\n", p.first, p.second);
-         }
-         std::cout<<"Max Passes= "<<P::maxFilteringPasses<<std::endl;
-      }
    }
 
    if (geometryString == "XY4D") {

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -589,10 +589,10 @@ void Parameters::getParameters() {
             numPasses.push_back(maxPasses);
             maxPasses/=2; 
          }
-         P::maxFilteringPasses = numPasses[0];
          //Overwrite passes for the highest refLevel. We do not want to filter there.
          numPasses[P::amrMaxSpatialRefLevel] = 0;
       }
+         P::maxFilteringPasses = numPasses[0];
    }
 
    if (geometryString == "XY4D") {

--- a/parameters.h
+++ b/parameters.h
@@ -184,7 +184,7 @@ struct Parameters {
    static Realf amrBoxCenterZ;
    static bool amrTransShortPencils;        /*!< Use short or longpencils in AMR translation.*/
    static std::vector<std::string> blurPassString;
-   static std::map<int,int> numPasses;
+   static std::vector<int> numPasses;
 
    /*! \brief Add the global parameters.
     *

--- a/parameters.h
+++ b/parameters.h
@@ -175,6 +175,7 @@ struct Parameters {
                                   * refined.  The value must be larger than amrCoarsenLimit.*/
    static std::string amrVelRefCriterion; /**< Name of the velocity block refinement criterion function.*/
    static uint amrMaxSpatialRefLevel;
+   static int maxFilteringPasses;
    static uint amrBoxHalfWidthX;
    static uint amrBoxHalfWidthY;
    static uint amrBoxHalfWidthZ;
@@ -183,7 +184,7 @@ struct Parameters {
    static Realf amrBoxCenterZ;
    static bool amrTransShortPencils;        /*!< Use short or longpencils in AMR translation.*/
    static std::vector<std::string> blurPassString;
-   static std::vector<int> numPasses;
+   static std::map<int,int> numPasses;
 
    /*! \brief Add the global parameters.
     *

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -608,8 +608,8 @@ int main(int argn,char* args[]) {
       //report filtering if we are in an AMR run 
       if (P::amrMaxSpatialRefLevel>0){
          logFile<<"Filtering Report: "<<endl;
-         for (const auto p:P::numPasses){
-            logFile<<"\tRefinement Level " <<p.first<<"==> Passes "<<p.second<<endl;
+         for (uint refLevel=0 ; refLevel<= P::amrMaxSpatialRefLevel; refLevel++){
+            logFile<<"\tRefinement Level " <<refLevel<<"==> Passes "<<P::numPasses.at(refLevel)<<endl;
          }
             logFile<<endl;
       }

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -603,8 +603,19 @@ int main(int argn,char* args[]) {
    // ***********************************
 
    // Main simulation loop:
-   if (myRank == MASTER_RANK) logFile << "(MAIN): Starting main simulation loop." << endl << writeVerbose;
+   if (myRank == MASTER_RANK){
+      logFile << "(MAIN): Starting main simulation loop." << endl << writeVerbose;
+      //report filtering if we are in an AMR run 
+      if (P::amrMaxSpatialRefLevel>0){
+         logFile<<"Filtering Report: "<<endl;
+         for (const auto p:P::numPasses){
+            logFile<<"\tRefinement Level " <<p.first<<"==> Passes "<<p.second<<endl;
+         }
+            logFile<<endl;
+      }
+   } 
    
+
    phiprof::start("report-memory-consumption");
    report_process_memory_consumption();
    phiprof::stop("report-memory-consumption");


### PR DESCRIPTION
So this is the filtering update, now using the triangle 3D kernel. The default behavior for the filtering configuration is now changed .

- If the user does not select the number of passes then the filtering will be applied automatically (if 3D-AMR).  
**Example**:
```
 max_spatial_level = 2

Fitlering:
        Refinement Level 0==> Passes 2
        Refinement Level 1==> Passes 1
        Refinement Level 2==> Passes 0
```

- Otherwise the user can select the number of passes per refinement level, same as before.
- Also the filtering is reported in the ```logfile``` now instead of  ```stdout```