### PR TITLE
Update Mahti_gcc makefile to work with new rhel8 installation.

### DIFF
--- a/MAKE/Makefile.mahti_gcc
+++ b/MAKE/Makefile.mahti_gcc
@@ -58,13 +58,14 @@ testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 MPT_VERSION = 4.0.3
 JEMALLOC_VERSION = 5.2.1
-LIBRARY_PREFIX = /users/kempf/libraries
+LIBRARY_PREFIX = /users/kempf/libraries_rhel8_openmpi/
 
 
 #compiled libraries
 LIB_BOOST = -lboost_program_options
 
-LIB_ZOLTAN = -lzoltan
+INC_ZOLTAN = -I$(LIBRARY_PREFIX)/zoltan/include
+LIB_ZOLTAN = -L$(LIBRARY_PREFIX)/zoltan/lib -lzoltan
 
 LIB_JEMALLOC = -ljemalloc
 
@@ -79,7 +80,7 @@ INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include
 
 #header libraries
 
-INC_FSGRID = -I$(LIBRARY_PREFIX)/fsgrid/
-INC_EIGEN = -I$(LIBRARY_PREFIX)/eigen/
-INC_DCCRG = -I$(LIBRARY_PREFIX)/dccrg/
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass/
+INC_FSGRID = -I$(LIBRARY_PREFIX)../libraries/fsgrid/
+INC_EIGEN = -I$(LIBRARY_PREFIX)/../libraries/eigen/
+INC_DCCRG = -I$(LIBRARY_PREFIX)/../libraries/dccrg/
+INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/../libraries/vectorclass/

--- a/MAKE/Makefile.mahti_gcc
+++ b/MAKE/Makefile.mahti_gcc
@@ -2,7 +2,7 @@ CMP = mpic++
 LNK = mpic++
 
 # Modules loaded
-# module load gcc boost jemalloc papi openmpi zoltan
+# module load gcc boost jemalloc papi openmpi
 
 #======== Vectorization ==========
 #Set vector backend type for vlasov solvers, sets precision and length. 
@@ -65,14 +65,16 @@ LIBRARY_PREFIX = /users/kempf/libraries_rhel8_openmpi/
 LIB_BOOST = -lboost_program_options
 
 INC_ZOLTAN = -I$(LIBRARY_PREFIX)/zoltan/include
-LIB_ZOLTAN = -L$(LIBRARY_PREFIX)/zoltan/lib -lzoltan
+LIB_ZOLTAN = -L$(LIBRARY_PREFIX)/zoltan/lib -lzoltan -Wl,-rpath=$(LIBRARY_PREFIX)/zoltan/lib
+
 
 LIB_JEMALLOC = -ljemalloc
 
 LIB_PAPI = -lpapi
 
-INC_VLSV = -I$(LIBRARY_PREFIX)/vlsv
-LIB_VLSV = -L$(LIBRARY_PREFIX)/vlsv -lvlsv
+INC_VLSV = -I$(LIBRARY_PREFIX)/vlsv_multiread
+LIB_VLSV = -L$(LIBRARY_PREFIX)/vlsv_multiread -lvlsv -Wl,-rpath=$(LIBRARY_PREFIX)/vlsv_multiread
+
 
 LIB_PROFILE = -L$(LIBRARY_PREFIX)/phiprof/lib -lphiprof -lgfortran -Wl,-rpath=$(LIBRARY_PREFIX)/phiprof/lib
 INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include 


### PR DESCRIPTION
This uses the newly-built libraries that Yann had already provided for this purpose, but still takes the header-only libraries from the old location.