### PR TITLE
Ignore txt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.dat
-*.txt
+logfile.txt
+phiprof*.txt
+diagnostic.txt
 *.vlsv
 *.silo
 *.o

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.dat
+*.txt
 *.vlsv
 *.silo
 *.o


### PR DESCRIPTION
All text files (e.g. `log.txt`, `diagnostic.txt`, `phiprof*.txt`) shall be safely ignored by git.