### PR TITLE
Project init

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -331,8 +331,8 @@ void initializeGrids(
    
    phiprof::stop("Fetch Neighbour data");
    
-   phiprof::start("setProjectBField");
-   project.setProjectBField(perBGrid, BgBGrid, technicalGrid);
+   phiprof::start("setInitialBField");
+   project.setInitialBField(perBGrid, BgBGrid, technicalGrid);
    perBGrid.updateGhostCells();
    BgBGrid.updateGhostCells();
    EGrid.updateGhostCells();
@@ -341,7 +341,7 @@ void initializeGrids(
    volGrid.updateGhostCells();
    getFieldsFromFsGrid(volGrid, BgBGrid, EGradPeGrid, technicalGrid, mpiGrid, cells);
 
-   phiprof::stop("setProjectBField");
+   phiprof::stop("setInitialBField");
 
    if (P::isRestart == false) {
       // Apply boundary conditions so that we get correct initial moments

--- a/projects/Alfven/Alfven.cpp
+++ b/projects/Alfven/Alfven.cpp
@@ -162,7 +162,7 @@ namespace projects {
       
    }
 
-   void Alfven::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Alfven::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                  FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                  FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);

--- a/projects/Alfven/Alfven.cpp
+++ b/projects/Alfven/Alfven.cpp
@@ -36,18 +36,6 @@ using namespace std;
 namespace projects {
    Alfven::Alfven(): Project() { }
    Alfven::~Alfven() { }
-   
-   bool Alfven::initialize(void) {
-      bool success = Project::initialize();
-
-      Real norm = sqrt(this->Bx_guiding*this->Bx_guiding + this->By_guiding*this->By_guiding + this->Bz_guiding*this->Bz_guiding);
-      this->Bx_guiding /= norm;
-      this->By_guiding /= norm;
-      this->By_guiding /= norm;
-      this->ALPHA = atan(this->By_guiding/this->Bx_guiding);
-      
-      return success;
-   } 
 
    void Alfven::addParameters() {
       typedef Readparameters RP;
@@ -96,6 +84,18 @@ namespace projects {
 
          speciesParams.push_back(sP);
       }
+   }
+
+   void Alfven::initialize() {
+      Real norm = sqrt(this->Bx_guiding * this->Bx_guiding +
+                       this->By_guiding * this->By_guiding +
+                       this->Bz_guiding * this->Bz_guiding);
+      this->Bx_guiding /= norm;
+      this->By_guiding /= norm;
+      this->By_guiding /= norm;
+      this->ALPHA = atan(this->By_guiding / this->Bx_guiding);
+
+      initialized = true;
    }
 
    /*Real calcPhaseSpaceDensity(creal& z,creal& x,creal& y,creal& dz,creal& dx,creal& dy,

--- a/projects/Alfven/Alfven.cpp
+++ b/projects/Alfven/Alfven.cpp
@@ -161,49 +161,49 @@ namespace projects {
       cuint nPts = pow(this->nSpaceSamples, 3.0);
       
    }
-   
-   void Alfven::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+
+   void Alfven::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                 FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                 FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);
-      
+
       if (!P::isRestart) {
          auto localSize = perBGrid.getLocalSize().data();
-         
+
 #pragma omp parallel for collapse(3)
          for (int x = 0; x < localSize[0]; ++x) {
             for (int y = 0; y < localSize[1]; ++y) {
                for (int z = 0; z < localSize[2]; ++z) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  
+
                   Real dBxavg, dByavg, dBzavg;
                   dBxavg = dByavg = dBzavg = 0.0;
                   Real d_x = perBGrid.DX / (this->nSpaceSamples - 1);
                   Real d_y = perBGrid.DY / (this->nSpaceSamples - 1);
-                  
-                  for (uint i=0; i<this->nSpaceSamples; ++i) {
-                     for (uint j=0; j<this->nSpaceSamples; ++j) {
-                        for (uint k=0; k<this->nSpaceSamples; ++k) {
-                           Real ksi = ((xyz[0] + i * d_x)  * cos(this->ALPHA) + (xyz[1] + j * d_y) * sin(this->ALPHA)) / this->WAVELENGTH;
+
+                  for (uint i = 0; i < this->nSpaceSamples; ++i) {
+                     for (uint j = 0; j < this->nSpaceSamples; ++j) {
+                        for (uint k = 0; k < this->nSpaceSamples; ++k) {
+                           Real ksi = ((xyz[0] + i * d_x) * cos(this->ALPHA) + (xyz[1] + j * d_y) * sin(this->ALPHA)) /
+                                      this->WAVELENGTH;
                            dBxavg += sin(2.0 * M_PI * ksi);
                            dByavg += sin(2.0 * M_PI * ksi);
                            dBzavg += cos(2.0 * M_PI * ksi);
                         }
                      }
                   }
-                  
+
                   cuint nPts = pow(this->nSpaceSamples, 3.0);
-                  cell->at(fsgrids::bfield::PERBX) = this->B0 * cos(this->ALPHA) - this->A_MAG * this->B0 * sin(this->ALPHA) * dBxavg / nPts;
-                  cell->at(fsgrids::bfield::PERBY) = this->B0 * sin(this->ALPHA) + this->A_MAG * this->B0 * cos(this->ALPHA) * dByavg / nPts;
+                  cell->at(fsgrids::bfield::PERBX) =
+                      this->B0 * cos(this->ALPHA) - this->A_MAG * this->B0 * sin(this->ALPHA) * dBxavg / nPts;
+                  cell->at(fsgrids::bfield::PERBY) =
+                      this->B0 * sin(this->ALPHA) + this->A_MAG * this->B0 * cos(this->ALPHA) * dByavg / nPts;
                   cell->at(fsgrids::bfield::PERBZ) = this->B0 * this->A_MAG * dBzavg / nPts;
-                  
                }
             }
          }
       }
    }
-   
+
 } // namespace projects

--- a/projects/Alfven/Alfven.h
+++ b/projects/Alfven/Alfven.h
@@ -38,11 +38,11 @@ namespace projects {
    class Alfven: public Project {
     public:
       Alfven();
-      virtual ~Alfven();
-      
-      virtual bool initialize(void);
+      ~Alfven() override;
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/Alfven/Alfven.h
+++ b/projects/Alfven/Alfven.h
@@ -43,7 +43,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/Alfven/Alfven.h
+++ b/projects/Alfven/Alfven.h
@@ -40,16 +40,14 @@ namespace projects {
       Alfven();
       ~Alfven() override;
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
-      
-    protected:
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
+   protected:
       Real getDistribValue(
                            creal& x,creal& y, creal& z,
                            creal& vx, creal& vy, creal& vz,

--- a/projects/Diffusion/Diffusion.cpp
+++ b/projects/Diffusion/Diffusion.cpp
@@ -38,11 +38,7 @@ using namespace spatial_cell;
 namespace projects {
    Diffusion::Diffusion(): Project() { }
    Diffusion::~Diffusion() { }
-   
-   bool Diffusion::initialize(void) {
-      return Project::initialize();
-   }
-   
+
    void Diffusion::addParameters() {
       typedef Readparameters RP;
       RP::add("Diffusion.B0", "Background field value (T)", 1.0e-9);
@@ -81,6 +77,8 @@ namespace projects {
         speciesParams.push_back(sP);
       }
    }
+
+   void Diffusion::initialize() { initialized = true; }
 
    Real Diffusion::getDistribValue(
       creal& x,creal& y,creal& z,

--- a/projects/Diffusion/Diffusion.cpp
+++ b/projects/Diffusion/Diffusion.cpp
@@ -119,7 +119,7 @@ namespace projects {
    
    void Diffusion::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void Diffusion::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Diffusion::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                     FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                     FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;

--- a/projects/Diffusion/Diffusion.cpp
+++ b/projects/Diffusion/Diffusion.cpp
@@ -119,13 +119,11 @@ namespace projects {
    
    void Diffusion::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void Diffusion::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+   void Diffusion::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                    FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                    FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;
-      bgField.initialize(0,0,this->B0); //bg bx, by,bz
+      bgField.initialize(0, 0, this->B0); // bg bx,by,bz
       setBackgroundField(bgField, BgBGrid);
    }
 } // namespace projects

--- a/projects/Diffusion/Diffusion.h
+++ b/projects/Diffusion/Diffusion.h
@@ -42,17 +42,14 @@ namespace projects {
       Diffusion();
       ~Diffusion() override;
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      /*! set background field, should set it for all cells */
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
-      
-    protected:
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
+   protected:
       Real getDistribValue(
                            creal& x,creal& y, creal& z,
                            creal& vx, creal& vy, creal& vz,

--- a/projects/Diffusion/Diffusion.h
+++ b/projects/Diffusion/Diffusion.h
@@ -45,7 +45,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/Diffusion/Diffusion.h
+++ b/projects/Diffusion/Diffusion.h
@@ -40,11 +40,11 @@ namespace projects {
    class Diffusion: public Project {
     public:
       Diffusion();
-      virtual ~Diffusion();
-      
-      virtual bool initialize(void);
+      ~Diffusion() override;
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       /*! set background field, should set it for all cells */
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,

--- a/projects/Dispersion/Dispersion.cpp
+++ b/projects/Dispersion/Dispersion.cpp
@@ -230,7 +230,7 @@ namespace projects {
       this->rndVel[2]=getRandomNumber();
    }
 
-   void Dispersion::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Dispersion::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                      FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                      FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;

--- a/projects/Dispersion/Dispersion.cpp
+++ b/projects/Dispersion/Dispersion.cpp
@@ -229,36 +229,33 @@ namespace projects {
       this->rndVel[1]=getRandomNumber();
       this->rndVel[2]=getRandomNumber();
    }
-   
-   void Dispersion::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+
+   void Dispersion::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                     FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                     FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;
       bgField.initialize(this->B0 * cos(this->angleXY) * cos(this->angleXZ),
-                         this->B0 * sin(this->angleXY) * cos(this->angleXZ),
-                         this->B0 * sin(this->angleXZ));
-                         
+                         this->B0 * sin(this->angleXY) * cos(this->angleXZ), this->B0 * sin(this->angleXZ));
+
       setBackgroundField(bgField, BgBGrid);
-      
-      if(!P::isRestart) {
+
+      if (!P::isRestart) {
          const auto localSize = BgBGrid.getLocalSize().data();
-         
+
 #pragma omp parallel for collapse(3)
          for (int x = 0; x < localSize[0]; ++x) {
             for (int y = 0; y < localSize[1]; ++y) {
                for (int z = 0; z < localSize[2]; ++z) {
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
                   const int64_t cellid = perBGrid.GlobalIDForCoords(x, y, z);
-                  
+
                   setRandomSeed(cellid);
-                  
+
                   Real rndBuffer[3];
-                  rndBuffer[0]=getRandomNumber();
-                  rndBuffer[1]=getRandomNumber();
-                  rndBuffer[2]=getRandomNumber();
-                  
+                  rndBuffer[0] = getRandomNumber();
+                  rndBuffer[1] = getRandomNumber();
+                  rndBuffer[2] = getRandomNumber();
+
                   cell->at(fsgrids::bfield::PERBX) = this->magXPertAbsAmp * (0.5 - rndBuffer[0]);
                   cell->at(fsgrids::bfield::PERBY) = this->magYPertAbsAmp * (0.5 - rndBuffer[1]);
                   cell->at(fsgrids::bfield::PERBZ) = this->magZPertAbsAmp * (0.5 - rndBuffer[2]);

--- a/projects/Dispersion/Dispersion.cpp
+++ b/projects/Dispersion/Dispersion.cpp
@@ -41,9 +41,7 @@ using namespace spatial_cell;
 namespace projects {
    Dispersion::Dispersion(): Project() { }
    Dispersion::~Dispersion() { }
-   
-   bool Dispersion::initialize(void) {return Project::initialize();}
-   
+
    void Dispersion::addParameters() {
       typedef Readparameters RP;
       RP::add("Dispersion.B0", "Guide magnetic field strength (T)", 1.0e-9);
@@ -98,7 +96,9 @@ namespace projects {
          speciesParams.push_back(sP);
       }
    }
-   
+
+   void Dispersion::initialize() { initialized = true; }
+
    void Dispersion::hook(
       cuint& stage,
       const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,

--- a/projects/Dispersion/Dispersion.h
+++ b/projects/Dispersion/Dispersion.h
@@ -46,11 +46,11 @@ namespace projects {
    class Dispersion: public Project {
     public:
       Dispersion();
-      virtual ~Dispersion();
-      
-      virtual bool initialize(void);
+      ~Dispersion() override;
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/Dispersion/Dispersion.h
+++ b/projects/Dispersion/Dispersion.h
@@ -51,7 +51,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(
+      void setInitialBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
          FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid

--- a/projects/Dispersion/Dispersion.h
+++ b/projects/Dispersion/Dispersion.h
@@ -48,14 +48,14 @@ namespace projects {
       Dispersion();
       ~Dispersion() override;
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
+      void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
          FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
+      ) override;
       virtual void hook(
          cuint& stage,
          const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,

--- a/projects/Distributions/Distributions.cpp
+++ b/projects/Distributions/Distributions.cpp
@@ -40,9 +40,6 @@ namespace projects {
    Distributions::Distributions(): TriAxisSearch() { }
    Distributions::~Distributions() { }
 
-
-   bool Distributions::initialize(void) {return Project::initialize();}
-
    void Distributions::addParameters(){
       typedef Readparameters RP;
       RP::add("Distributions.rho1", "Number density, first peak (m^-3)", 0.0);
@@ -144,6 +141,8 @@ namespace projects {
       
       return value;
    }
+
+   void Distributions::initialize() { initialized = true; }
 
    Real Distributions::calcPhaseSpaceDensity(creal& x, creal& y, creal& z, creal& dx, creal& dy, creal& dz, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,const uint popID) const {   
       return getDistribValue(x+0.5*dx, y+0.5*dy,z+0.5*dz,vx+0.5*dvx, vy+0.5*dvy, vz+0.5*dvz, popID);

--- a/projects/Distributions/Distributions.cpp
+++ b/projects/Distributions/Distributions.cpp
@@ -155,7 +155,7 @@ namespace projects {
       }
    }
 
-   void Distributions::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Distributions::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                         FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;

--- a/projects/Distributions/Distributions.cpp
+++ b/projects/Distributions/Distributions.cpp
@@ -155,21 +155,17 @@ namespace projects {
       }
    }
 
-   void Distributions::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+   void Distributions::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                        FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                        FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;
-      bgField.initialize(this->Bx,
-                         this->By,
-                         this->Bz);
-      
+      bgField.initialize(this->Bx, this->By, this->Bz);
+
       setBackgroundField(bgField, BgBGrid);
-      
-      if(!P::isRestart) {
+
+      if (!P::isRestart) {
          const auto localSize = BgBGrid.getLocalSize().data();
-         
+
 #pragma omp parallel for collapse(3)
          for (int x = 0; x < localSize[0]; ++x) {
             for (int y = 0; y < localSize[1]; ++y) {
@@ -177,13 +173,13 @@ namespace projects {
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
                   const int64_t cellid = perBGrid.GlobalIDForCoords(x, y, z);
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
-                  
+
                   setRandomSeed(cellid);
-                  
+
                   if (this->lambda != 0.0) {
-                     cell->at(fsgrids::bfield::PERBX) = this->dBx*cos(2.0 * M_PI * xyz[0] / this->lambda);
-                     cell->at(fsgrids::bfield::PERBY) = this->dBy*sin(2.0 * M_PI * xyz[0] / this->lambda);
-                     cell->at(fsgrids::bfield::PERBZ) = this->dBz*cos(2.0 * M_PI * xyz[0] / this->lambda);
+                     cell->at(fsgrids::bfield::PERBX) = this->dBx * cos(2.0 * M_PI * xyz[0] / this->lambda);
+                     cell->at(fsgrids::bfield::PERBY) = this->dBy * sin(2.0 * M_PI * xyz[0] / this->lambda);
+                     cell->at(fsgrids::bfield::PERBZ) = this->dBz * cos(2.0 * M_PI * xyz[0] / this->lambda);
                   }
 
                   cell->at(fsgrids::bfield::PERBX) += this->magXPertAbsAmp * (0.5 - getRandomNumber());
@@ -194,7 +190,7 @@ namespace projects {
          }
       }
    }
-   
+
    vector<std::array<Real, 3>> Distributions::getV0(
       creal x,
       creal y,

--- a/projects/Distributions/Distributions.h
+++ b/projects/Distributions/Distributions.h
@@ -33,15 +33,14 @@ namespace projects {
       Distributions();
       ~Distributions() override;
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
-    protected:
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
+   protected:
       Real getDistribValue(
                            creal& x,creal& y, creal& z,
                            creal& vx, creal& vy, creal& vz,

--- a/projects/Distributions/Distributions.h
+++ b/projects/Distributions/Distributions.h
@@ -36,7 +36,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/Distributions/Distributions.h
+++ b/projects/Distributions/Distributions.h
@@ -31,11 +31,11 @@ namespace projects {
    class Distributions: public TriAxisSearch {
     public:
       Distributions();
-      virtual ~Distributions();
-      
-      virtual bool initialize(void);
+      ~Distributions() override;
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/Firehose/Firehose.cpp
+++ b/projects/Firehose/Firehose.cpp
@@ -37,8 +37,6 @@ using namespace std;
 namespace projects {
    Firehose::Firehose(): Project() { }
    Firehose::~Firehose() { }
-   
-   bool Firehose::initialize(void) {return Project::initialize();}
 
    void Firehose::addParameters(){
       typedef Readparameters RP;
@@ -104,6 +102,8 @@ namespace projects {
          speciesParams.push_back(sP);
       }
    }
+
+   void Firehose::initialize() { initialized = true; }
 
    Real Firehose::profile(creal top, creal bottom, creal x) const {
       return top * (1.0 + this->amp*cos(2.0*M_PI*x/this->lambda));

--- a/projects/Firehose/Firehose.cpp
+++ b/projects/Firehose/Firehose.cpp
@@ -153,7 +153,7 @@ namespace projects {
 
    void Firehose::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void Firehose::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Firehose::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                    FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                    FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;

--- a/projects/Firehose/Firehose.cpp
+++ b/projects/Firehose/Firehose.cpp
@@ -152,18 +152,14 @@ namespace projects {
    }
 
    void Firehose::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
-   
-   void Firehose::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+
+   void Firehose::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                   FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                   FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;
-      bgField.initialize(this->Bx,
-                         this->By,
-                         this->Bz);
-      
+      bgField.initialize(this->Bx, this->By, this->Bz);
+
       setBackgroundField(bgField, BgBGrid);
    }
-   
+
 } // namespace projects

--- a/projects/Firehose/Firehose.h
+++ b/projects/Firehose/Firehose.h
@@ -49,7 +49,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(
+      void setInitialBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
          FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid

--- a/projects/Firehose/Firehose.h
+++ b/projects/Firehose/Firehose.h
@@ -46,14 +46,14 @@ namespace projects {
       Firehose();
       ~Firehose() override;
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
+      void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
          FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
+      ) override;
     protected:
       Real getDistribValue(
                            creal& x,creal& y,

--- a/projects/Firehose/Firehose.h
+++ b/projects/Firehose/Firehose.h
@@ -44,11 +44,11 @@ namespace projects {
    class Firehose: public Project {
     public:
       Firehose();
-      virtual ~Firehose();
-      
-      virtual bool initialize(void);
+      ~Firehose() override;
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/Flowthrough/Flowthrough.cpp
+++ b/projects/Flowthrough/Flowthrough.cpp
@@ -214,16 +214,14 @@ namespace projects {
 
    void Flowthrough::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void Flowthrough::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+   void Flowthrough::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                      FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                      FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;
-      bgField.initialize(Bx,By,Bz); //bg bx, by,bz      
+      bgField.initialize(Bx, By, Bz); // bg bx,by,bz
       setBackgroundField(bgField, BgBGrid);
    }
-   
+
    std::vector<std::array<Real, 3> > Flowthrough::getV0(
       creal x,
       creal y,

--- a/projects/Flowthrough/Flowthrough.cpp
+++ b/projects/Flowthrough/Flowthrough.cpp
@@ -214,7 +214,7 @@ namespace projects {
 
    void Flowthrough::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void Flowthrough::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Flowthrough::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                       FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                       FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;

--- a/projects/Flowthrough/Flowthrough.cpp
+++ b/projects/Flowthrough/Flowthrough.cpp
@@ -52,10 +52,6 @@ static DensityModel densityModel;
 namespace projects {
    Flowthrough::Flowthrough(): TriAxisSearch() { }
    Flowthrough::~Flowthrough() { }
-   
-   bool Flowthrough::initialize(void) {
-      return Project::initialize();
-   }
 
    void Flowthrough::addParameters(){
       typedef Readparameters RP;
@@ -120,6 +116,8 @@ namespace projects {
          speciesParams.push_back(sP);
       }
    }
+
+   void Flowthrough::initialize() { initialized = true; }
 
    Real Flowthrough::getDistribValue(creal& x,creal& y, creal& z, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz, const uint popID) const {
 

--- a/projects/Flowthrough/Flowthrough.h
+++ b/projects/Flowthrough/Flowthrough.h
@@ -45,14 +45,14 @@ namespace projects {
       Flowthrough();
       ~Flowthrough() override;
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
+      void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
          FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
+      ) override;
 
     protected:
       Real getDistribValue(

--- a/projects/Flowthrough/Flowthrough.h
+++ b/projects/Flowthrough/Flowthrough.h
@@ -48,7 +48,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(
+      void setInitialBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
          FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid

--- a/projects/Flowthrough/Flowthrough.h
+++ b/projects/Flowthrough/Flowthrough.h
@@ -43,11 +43,11 @@ namespace projects {
    class Flowthrough: public TriAxisSearch {
     public:
       Flowthrough();
-      virtual ~Flowthrough();
-      
-      virtual bool initialize(void);
+      ~Flowthrough() override;
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/Fluctuations/Fluctuations.cpp
+++ b/projects/Fluctuations/Fluctuations.cpp
@@ -171,7 +171,7 @@ namespace projects {
       this->rndVel[2]=getRandomNumber();
    }
 
-   void Fluctuations::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Fluctuations::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                        FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                        FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;

--- a/projects/Fluctuations/Fluctuations.cpp
+++ b/projects/Fluctuations/Fluctuations.cpp
@@ -171,30 +171,26 @@ namespace projects {
       this->rndVel[2]=getRandomNumber();
    }
 
-   void Fluctuations::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+   void Fluctuations::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                       FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                       FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;
-      bgField.initialize(this->BX0,
-                         this->BY0,
-                         this->BZ0);
+      bgField.initialize(this->BX0, this->BY0, this->BZ0);
 
       setBackgroundField(bgField, BgBGrid);
-      
-      if(!P::isRestart) {
+
+      if (!P::isRestart) {
          const auto localSize = BgBGrid.getLocalSize().data();
-         
-         #pragma omp parallel for collapse(3)
+
+#pragma omp parallel for collapse(3)
          for (int x = 0; x < localSize[0]; ++x) {
             for (int y = 0; y < localSize[1]; ++y) {
                for (int z = 0; z < localSize[2]; ++z) {
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
                   const int64_t cellid = perBGrid.GlobalIDForCoords(x, y, z);
-                  
+
                   setRandomSeed(cellid);
-                  
+
                   cell->at(fsgrids::bfield::PERBX) = this->magXPertAbsAmp * (0.5 - getRandomNumber());
                   cell->at(fsgrids::bfield::PERBY) = this->magYPertAbsAmp * (0.5 - getRandomNumber());
                   cell->at(fsgrids::bfield::PERBZ) = this->magZPertAbsAmp * (0.5 - getRandomNumber());
@@ -203,7 +199,7 @@ namespace projects {
          }
       }
    }
-   
+
    std::vector<std::array<Real, 3> > Fluctuations::getV0(
       creal x,
       creal y,

--- a/projects/Fluctuations/Fluctuations.cpp
+++ b/projects/Fluctuations/Fluctuations.cpp
@@ -41,8 +41,7 @@ Real projects::Fluctuations::rndRho, projects::Fluctuations::rndVel[3];
 namespace projects {
    Fluctuations::Fluctuations(): TriAxisSearch() { }
    Fluctuations::~Fluctuations() { }
-   bool Fluctuations::initialize(void) {return Project::initialize();}
-   
+
    void Fluctuations::addParameters() {
       typedef Readparameters RP;
       RP::add("Fluctuations.BX0", "Background field value (T)", 1.0e-9);
@@ -92,7 +91,9 @@ namespace projects {
          speciesParams.push_back(sP);
       }
    }
-   
+
+   void Fluctuations::initialize() { initialized = true; }
+
    Real Fluctuations::getDistribValue(creal& vx,creal& vy, creal& vz, const uint popID) const {
       const FluctuationsSpeciesParameters& sP = speciesParams[popID];
 

--- a/projects/Fluctuations/Fluctuations.h
+++ b/projects/Fluctuations/Fluctuations.h
@@ -43,9 +43,9 @@ namespace projects {
    class Fluctuations: public TriAxisSearch {
    public:
       Fluctuations();
-      virtual ~Fluctuations();
+      ~Fluctuations() override;
       
-      virtual bool initialize(void);
+      void initialize() override;
       static void addParameters(void);
       virtual void getParameters(void);
       virtual void setProjectBField(

--- a/projects/Fluctuations/Fluctuations.h
+++ b/projects/Fluctuations/Fluctuations.h
@@ -46,13 +46,11 @@ namespace projects {
       ~Fluctuations() override;
       
       void initialize() override;
-      static void addParameters(void);
-      virtual void getParameters(void);
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
+      static void addParameters();
+      virtual void getParameters();
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
       virtual std::vector<std::array<Real, 3> > getV0(
          creal x,
          creal y,

--- a/projects/Fluctuations/Fluctuations.h
+++ b/projects/Fluctuations/Fluctuations.h
@@ -48,7 +48,7 @@ namespace projects {
       void initialize() override;
       static void addParameters();
       virtual void getParameters();
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
       virtual std::vector<std::array<Real, 3> > getV0(

--- a/projects/Harris/Harris.cpp
+++ b/projects/Harris/Harris.cpp
@@ -148,23 +148,21 @@ namespace projects {
       return V0;
    }
 
-   void Harris::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+   void Harris::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                 FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                 FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);
-      
-      if(!P::isRestart) {
+
+      if (!P::isRestart) {
          auto localSize = perBGrid.getLocalSize().data();
-         
-         #pragma omp parallel for collapse(3)
+
+#pragma omp parallel for collapse(3)
          for (int x = 0; x < localSize[0]; ++x) {
             for (int y = 0; y < localSize[1]; ++y) {
                for (int z = 0; z < localSize[2]; ++z) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  
+
                   cell->at(fsgrids::bfield::PERBX) = this->BX0 * tanh((xyz[1] + 0.5 * perBGrid.DY) / this->SCA_LAMBDA);
                   cell->at(fsgrids::bfield::PERBY) = this->BY0 * tanh((xyz[2] + 0.5 * perBGrid.DZ) / this->SCA_LAMBDA);
                   cell->at(fsgrids::bfield::PERBZ) = this->BZ0 * tanh((xyz[0] + 0.5 * perBGrid.DX) / this->SCA_LAMBDA);

--- a/projects/Harris/Harris.cpp
+++ b/projects/Harris/Harris.cpp
@@ -148,7 +148,7 @@ namespace projects {
       return V0;
    }
 
-   void Harris::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Harris::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                  FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                  FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);

--- a/projects/Harris/Harris.cpp
+++ b/projects/Harris/Harris.cpp
@@ -37,9 +37,7 @@ using namespace spatial_cell;
 namespace projects {
    Harris::Harris(): TriAxisSearch() { }
    Harris::~Harris() { }
-   
-   bool Harris::initialize(void) {return Project::initialize();}
-   
+
    void Harris::addParameters(){
       typedef Readparameters RP;
       RP::add("Harris.Scale_size", "Harris sheet scale size (m)", 150000.0);
@@ -80,7 +78,9 @@ namespace projects {
          speciesParams.push_back(sP);
       }
    }
-   
+
+   void Harris::initialize() { initialized = true; }
+
    Real Harris::getDistribValue(
       creal& x,creal& y, creal& z,
       creal& vx, creal& vy, creal& vz,

--- a/projects/Harris/Harris.h
+++ b/projects/Harris/Harris.h
@@ -44,7 +44,7 @@ namespace projects {
          virtual void getParameters();
          void initialize() override;
          virtual void calcCellParameters(spatial_cell::SpatialCell* cell,creal& t);
-         void setProjectBField(
+         void setInitialBField(
             FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
             FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
             FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid

--- a/projects/Harris/Harris.h
+++ b/projects/Harris/Harris.h
@@ -38,11 +38,11 @@ namespace projects {
    class Harris: public TriAxisSearch {
       public:
          Harris();
-         virtual ~Harris();
-         
-         virtual bool initialize(void);
+         ~Harris() override;
+
          static void addParameters(void);
          virtual void getParameters(void);
+         void initialize() override;
          virtual void calcCellParameters(spatial_cell::SpatialCell* cell,creal& t);
          virtual void setProjectBField(
             FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,

--- a/projects/Harris/Harris.h
+++ b/projects/Harris/Harris.h
@@ -40,15 +40,15 @@ namespace projects {
          Harris();
          ~Harris() override;
 
-         static void addParameters(void);
-         virtual void getParameters(void);
+         static void addParameters();
+         virtual void getParameters();
          void initialize() override;
          virtual void calcCellParameters(spatial_cell::SpatialCell* cell,creal& t);
-         virtual void setProjectBField(
+         void setProjectBField(
             FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
             FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
             FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-         );
+         ) override;
          virtual Real calcPhaseSpaceDensity(
             creal& x, creal& y, creal& z,
             creal& dx, creal& dy, creal& dz,

--- a/projects/IPShock/IPShock.cpp
+++ b/projects/IPShock/IPShock.cpp
@@ -45,11 +45,7 @@ using namespace spatial_cell;
 namespace projects {
   IPShock::IPShock(): TriAxisSearch() { }
   IPShock::~IPShock() { }
-  
-  bool IPShock::initialize() {
-    return Project::initialize();
-  }
-  
+
   void IPShock::addParameters() {
     typedef Readparameters RP;
     // Common (field / etc.) parameters
@@ -250,6 +246,7 @@ namespace projects {
     
   }
 
+  void IPShock::initialize() { initialized = true; }
 
   std::vector<std::array<Real, 3>> IPShock::getV0(creal x, creal y, creal z, const uint popID) const {
     Real mass = getObjectWrapper().particleSpecies[popID].mass;

--- a/projects/IPShock/IPShock.cpp
+++ b/projects/IPShock/IPShock.cpp
@@ -384,7 +384,7 @@ namespace projects {
     return a;
   }
 
-  void IPShock::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+  void IPShock::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                  FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                  FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
      setBackgroundFieldToZero(BgBGrid);

--- a/projects/IPShock/IPShock.cpp
+++ b/projects/IPShock/IPShock.cpp
@@ -384,65 +384,63 @@ namespace projects {
     return a;
   }
 
-  void IPShock::setProjectBField(
-     FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-     FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-     FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-  ) {
-      setBackgroundFieldToZero(BgBGrid);
-      
-      if(!P::isRestart) {
-         auto localSize = perBGrid.getLocalSize().data();
-      
-#pragma omp parallel for collapse(3)
-         for (int x = 0; x < localSize[0]; ++x) {
-            for (int y = 0; y < localSize[1]; ++y) {
-               for (int z = 0; z < localSize[2]; ++z) {
-                  const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
-                  std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  
-                  /* Maintain all values in BPERT for simplicity */
-                  Real KB = physicalconstants::K_B;
-                  Real mu0 = physicalconstants::MU_0;
-                  Real adiab = 5./3.;
-                  
-                  // Interpolate density between upstream and downstream
-                  // All other values are calculated from jump conditions
-                  Real MassDensity = 0.;
-                  Real MassDensityU = 0.;
-                  Real EffectiveVu0 = 0.;
-                  for(uint i=0; i< getObjectWrapper().particleSpecies.size(); i++) {
-                     const IPShockSpeciesParameters& sP = speciesParams[i];
-                     Real mass = getObjectWrapper().particleSpecies[i].mass;
-                     
-                     MassDensity += mass * interpolate(sP.DENSITYu,sP.DENSITYd, xyz[0]);
-                     MassDensityU += mass * sP.DENSITYu;
-                     EffectiveVu0 += sP.V0u[0] * mass * sP.DENSITYu;
-                  }
-                  EffectiveVu0 /= MassDensityU;
-                  
-                  // Solve tangential components for B and V
-                  Real VX = MassDensityU * EffectiveVu0 / MassDensity;
-                  Real BX = this->B0u[0];
-                  Real MAsq = std::pow((EffectiveVu0/this->B0u[0]), 2) * MassDensityU * mu0;
-                  Real Btang = this->B0utangential * (MAsq - 1.0)/(MAsq*VX/EffectiveVu0 -1.0);
-                  Real Vtang = VX * Btang / BX;
-                  
-                  /* Reconstruct Y and Z components using cos(phi) values and signs. Tangential variables are always positive. */
-                  Real BY = abs(Btang) * this->Bucosphi * this->Byusign;
-                  Real BZ = abs(Btang) * sqrt(1. - this->Bucosphi * this->Bucosphi) * this->Bzusign;
-                  //Real VY = Vtang * this->Vucosphi * this->Vyusign;
-                  //Real VZ = Vtang * sqrt(1. - this->Vucosphi * this->Vucosphi) * this->Vzusign;
-                  
-                  cell->at(fsgrids::bfield::PERBX) = BX;
-                  cell->at(fsgrids::bfield::PERBY) = BY;
-                  cell->at(fsgrids::bfield::PERBZ) = BZ;
-               }
-            }
-         }
-      }
-   }
+  void IPShock::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                 FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                 FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
+     setBackgroundFieldToZero(BgBGrid);
 
+     if (!P::isRestart) {
+        auto localSize = perBGrid.getLocalSize().data();
+
+#pragma omp parallel for collapse(3)
+        for (int x = 0; x < localSize[0]; ++x) {
+           for (int y = 0; y < localSize[1]; ++y) {
+              for (int z = 0; z < localSize[2]; ++z) {
+                 const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
+                 std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
+
+                 /* Maintain all values in BPERT for simplicity */
+                 Real KB = physicalconstants::K_B;
+                 Real mu0 = physicalconstants::MU_0;
+                 Real adiab = 5. / 3.;
+
+                 // Interpolate density between upstream and downstream
+                 // All other values are calculated from jump conditions
+                 Real MassDensity = 0.;
+                 Real MassDensityU = 0.;
+                 Real EffectiveVu0 = 0.;
+                 for (uint i = 0; i < getObjectWrapper().particleSpecies.size(); i++) {
+                    const IPShockSpeciesParameters& sP = speciesParams[i];
+                    Real mass = getObjectWrapper().particleSpecies[i].mass;
+
+                    MassDensity += mass * interpolate(sP.DENSITYu, sP.DENSITYd, xyz[0]);
+                    MassDensityU += mass * sP.DENSITYu;
+                    EffectiveVu0 += sP.V0u[0] * mass * sP.DENSITYu;
+                 }
+                 EffectiveVu0 /= MassDensityU;
+
+                 // Solve tangential components for B and V
+                 Real VX = MassDensityU * EffectiveVu0 / MassDensity;
+                 Real BX = this->B0u[0];
+                 Real MAsq = std::pow((EffectiveVu0 / this->B0u[0]), 2) * MassDensityU * mu0;
+                 Real Btang = this->B0utangential * (MAsq - 1.0) / (MAsq * VX / EffectiveVu0 - 1.0);
+                 Real Vtang = VX * Btang / BX;
+
+                 /* Reconstruct Y and Z components using cos(phi) values and signs. Tangential variables are always
+                  * positive. */
+                 Real BY = abs(Btang) * this->Bucosphi * this->Byusign;
+                 Real BZ = abs(Btang) * sqrt(1. - this->Bucosphi * this->Bucosphi) * this->Bzusign;
+                 // Real VY = Vtang * this->Vucosphi * this->Vyusign;
+                 // Real VZ = Vtang * sqrt(1. - this->Vucosphi * this->Vucosphi) * this->Vzusign;
+
+                 cell->at(fsgrids::bfield::PERBX) = BX;
+                 cell->at(fsgrids::bfield::PERBY) = BY;
+                 cell->at(fsgrids::bfield::PERBZ) = BZ;
+              }
+           }
+        }
+     }
+  }
 
    bool IPShock::refineSpatialCells( dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid ) const {
  

--- a/projects/IPShock/IPShock.h
+++ b/projects/IPShock/IPShock.h
@@ -62,7 +62,7 @@ namespace projects {
          virtual void getParameters();
          void initialize() override;
 
-         void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+         void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
          virtual Real calcPhaseSpaceDensity(

--- a/projects/IPShock/IPShock.h
+++ b/projects/IPShock/IPShock.h
@@ -58,15 +58,13 @@ namespace projects {
          IPShock();
          ~IPShock() override;
 
-         static void addParameters(void);
-         virtual void getParameters(void);
+         static void addParameters();
+         virtual void getParameters();
          void initialize() override;
 
-         virtual void setProjectBField(
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-         );
+         void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                               FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                               FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
          virtual Real calcPhaseSpaceDensity(
                creal& x, creal& y, creal& z,
                creal& dx, creal& dy, creal& dz,
@@ -74,8 +72,6 @@ namespace projects {
                creal& dvx, creal& dvy, creal& dvz,
                const uint popID
                ) const;
-
-
 
       protected:
          Real getDistribValue(

--- a/projects/IPShock/IPShock.h
+++ b/projects/IPShock/IPShock.h
@@ -56,11 +56,11 @@ namespace projects {
    class IPShock: public TriAxisSearch {
       public:
          IPShock();
-         virtual ~IPShock();
+         ~IPShock() override;
 
-         virtual bool initialize(void);
          static void addParameters(void);
          virtual void getParameters(void);
+         void initialize() override;
 
          virtual void setProjectBField(
             FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,

--- a/projects/KHB/KHB.cpp
+++ b/projects/KHB/KHB.cpp
@@ -152,7 +152,7 @@ namespace projects {
 
    void KHB::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void KHB::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void KHB::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                               FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                               FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);

--- a/projects/KHB/KHB.cpp
+++ b/projects/KHB/KHB.cpp
@@ -151,34 +151,35 @@ namespace projects {
    
 
    void KHB::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
-   
-   void KHB::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+
+   void KHB::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                              FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                              FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);
-      
-      if(!P::isRestart) {
+
+      if (!P::isRestart) {
          auto localSize = perBGrid.getLocalSize().data();
-         
-         #pragma omp parallel for collapse(3)
+
+#pragma omp parallel for collapse(3)
          for (int x = 0; x < localSize[0]; ++x) {
             for (int y = 0; y < localSize[1]; ++y) {
                for (int z = 0; z < localSize[2]; ++z) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  
+
                   Real Bxavg, Byavg, Bzavg;
                   Bxavg = Byavg = Bzavg = 0.0;
-                  if(this->nSpaceSamples > 1) {
+                  if (this->nSpaceSamples > 1) {
                      Real d_x = perBGrid.DX / (this->nSpaceSamples - 1);
                      Real d_z = perBGrid.DZ / (this->nSpaceSamples - 1);
-                     for (uint i=0; i<this->nSpaceSamples; ++i) {
-                        for (uint k=0; k<this->nSpaceSamples; ++k) {
-                           Bxavg += profile(this->Bx[this->BOTTOM], this->Bx[this->TOP], xyz[0]+i*d_x, xyz[2]+k*d_z);
-                           Byavg += profile(this->By[this->BOTTOM], this->By[this->TOP], xyz[0]+i*d_x, xyz[2]+k*d_z);
-                           Bzavg += profile(this->Bz[this->BOTTOM], this->Bz[this->TOP], xyz[0]+i*d_x, xyz[2]+k*d_z);
+                     for (uint i = 0; i < this->nSpaceSamples; ++i) {
+                        for (uint k = 0; k < this->nSpaceSamples; ++k) {
+                           Bxavg +=
+                               profile(this->Bx[this->BOTTOM], this->Bx[this->TOP], xyz[0] + i * d_x, xyz[2] + k * d_z);
+                           Byavg +=
+                               profile(this->By[this->BOTTOM], this->By[this->TOP], xyz[0] + i * d_x, xyz[2] + k * d_z);
+                           Bzavg +=
+                               profile(this->Bz[this->BOTTOM], this->Bz[this->TOP], xyz[0] + i * d_x, xyz[2] + k * d_z);
                         }
                      }
                      cuint nPts = pow(this->nSpaceSamples, 2.0);
@@ -186,14 +187,17 @@ namespace projects {
                      cell->at(fsgrids::bfield::PERBY) = Byavg / nPts;
                      cell->at(fsgrids::bfield::PERBZ) = Bzavg / nPts;
                   } else {
-                     cell->at(fsgrids::bfield::PERBX) = profile(this->Bx[this->BOTTOM], this->Bx[this->TOP], xyz[0]+0.5*perBGrid.DX, xyz[2]+0.5*perBGrid.DZ);
-                     cell->at(fsgrids::bfield::PERBY) = profile(this->By[this->BOTTOM], this->By[this->TOP], xyz[0]+0.5*perBGrid.DX, xyz[2]+0.5*perBGrid.DZ);
-                     cell->at(fsgrids::bfield::PERBZ) = profile(this->Bz[this->BOTTOM], this->Bz[this->TOP], xyz[0]+0.5*perBGrid.DX, xyz[2]+0.5*perBGrid.DZ);
+                     cell->at(fsgrids::bfield::PERBX) = profile(this->Bx[this->BOTTOM], this->Bx[this->TOP],
+                                                                xyz[0] + 0.5 * perBGrid.DX, xyz[2] + 0.5 * perBGrid.DZ);
+                     cell->at(fsgrids::bfield::PERBY) = profile(this->By[this->BOTTOM], this->By[this->TOP],
+                                                                xyz[0] + 0.5 * perBGrid.DX, xyz[2] + 0.5 * perBGrid.DZ);
+                     cell->at(fsgrids::bfield::PERBZ) = profile(this->Bz[this->BOTTOM], this->Bz[this->TOP],
+                                                                xyz[0] + 0.5 * perBGrid.DX, xyz[2] + 0.5 * perBGrid.DZ);
                   }
                }
             }
          }
       }
    }
-   
+
 } // namespace projects

--- a/projects/KHB/KHB.cpp
+++ b/projects/KHB/KHB.cpp
@@ -35,9 +35,7 @@ namespace projects {
    using namespace std;
    KHB::KHB(): Project() { }
    KHB::~KHB() { }
-   
-   bool KHB::initialize(void) {return Project::initialize();}
-   
+
    void KHB::addParameters() {
       typedef Readparameters RP;
       RP::add("KHB.rho1", "Number density, this->TOP state (m^-3)", 0.0);
@@ -96,8 +94,9 @@ namespace projects {
       RP::get("KHB.nSpaceSamples", this->nSpaceSamples);
       RP::get("KHB.nVelocitySamples", this->nVelocitySamples);
    }
-   
-   
+
+   void KHB::initialize() { initialized = true; }
+
    Real KHB::profile(creal top, creal bottom, creal x, creal z) const {
       if(top == bottom) {
          return top;

--- a/projects/KHB/KHB.h
+++ b/projects/KHB/KHB.h
@@ -45,7 +45,7 @@ namespace projects {
                                          creal& dvx, creal& dvy, creal& dvz,
                                          const uint popID
                                         ) const;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/KHB/KHB.h
+++ b/projects/KHB/KHB.h
@@ -34,8 +34,8 @@ namespace projects {
       KHB();
       ~KHB() override;
       
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
       virtual void calcCellParameters(spatial_cell::SpatialCell* cell,creal& t);
       virtual Real calcPhaseSpaceDensity(
@@ -45,12 +45,11 @@ namespace projects {
                                          creal& dvx, creal& dvy, creal& dvz,
                                          const uint popID
                                         ) const;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
-    protected:
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
+   protected:
       Real getDistribValue(
                            creal& x, creal& z,
                            creal& vx, creal& vy, creal& vz,

--- a/projects/KHB/KHB.h
+++ b/projects/KHB/KHB.h
@@ -32,11 +32,11 @@ namespace projects {
    class KHB: public Project {
     public:
       KHB();
-      virtual ~KHB();
+      ~KHB() override;
       
-      virtual bool initialize(void);
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void calcCellParameters(spatial_cell::SpatialCell* cell,creal& t);
       virtual Real calcPhaseSpaceDensity(
                                          creal& x, creal& y, creal& z,

--- a/projects/Larmor/Larmor.cpp
+++ b/projects/Larmor/Larmor.cpp
@@ -40,9 +40,6 @@ namespace projects {
     Larmor::Larmor(): Project() { }
     Larmor::~Larmor() { }
 
-
-   bool Larmor::initialize(void) {return Project::initialize();}
-
     void Larmor::addParameters() {
       typedef Readparameters RP;
       RP::add("Larmor.BX0", "Background field value (T)", 0.0);
@@ -83,6 +80,8 @@ namespace projects {
       RP::get("Larmor.Scale_x", this->SCA_X);
       RP::get("Larmor.Scale_y", this->SCA_Y);
     }
+
+   void Larmor::initialize() { initialized = true; }
 
     Real Larmor::getDistribValue(creal& x, creal& y, creal& z, creal& vx, creal& vy, creal& vz, const uint popID) const {
       creal kb = physicalconstants::K_B;

--- a/projects/Larmor/Larmor.cpp
+++ b/projects/Larmor/Larmor.cpp
@@ -139,7 +139,7 @@ namespace projects {
 
    void Larmor::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void Larmor::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Larmor::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                  FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                  FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;

--- a/projects/Larmor/Larmor.cpp
+++ b/projects/Larmor/Larmor.cpp
@@ -139,16 +139,12 @@ namespace projects {
 
    void Larmor::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-    void Larmor::setProjectBField(
-       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-       FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-       FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-    ) {
+   void Larmor::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                 FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                 FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;
-      bgField.initialize(this->BX0,
-                         this->BY0,
-                         this->BZ0);
-      
+      bgField.initialize(this->BX0, this->BY0, this->BZ0);
+
       setBackgroundField(bgField, BgBGrid);
    }
 } //namespace projects 

--- a/projects/Larmor/Larmor.h
+++ b/projects/Larmor/Larmor.h
@@ -38,7 +38,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/Larmor/Larmor.h
+++ b/projects/Larmor/Larmor.h
@@ -33,11 +33,11 @@ namespace projects {
    class Larmor: public Project {
     public:
       Larmor();
-      virtual ~Larmor();
-      
-      virtual bool initialize(void);
+      ~Larmor() override;
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/Larmor/Larmor.h
+++ b/projects/Larmor/Larmor.h
@@ -35,15 +35,14 @@ namespace projects {
       Larmor();
       ~Larmor() override;
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
-    protected:
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
+   protected:
       Real getDistribValue(
                            creal& x,creal& y, creal& z,
                            creal& vx, creal& vy, creal& vz,

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -297,11 +297,9 @@ namespace projects {
    void Magnetosphere::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
    /* set 0-centered dipole */
-   void Magnetosphere::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+   void Magnetosphere::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                        FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                        FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       Dipole bgFieldDipole;
       LineDipole bgFieldLineDipole;
       VectorDipole bgVectorDipole;
@@ -310,141 +308,147 @@ namespace projects {
       // from Daldorff et al (2014), see
       // https://github.com/fmihpc/vlasiator/issues/20 for a derivation of the
       // values used here.
-      switch(this->dipoleType) {
-            case 0:
-               bgFieldDipole.initialize(8e15 *this->dipoleScalingFactor, 0.0, 0.0, 0.0, 0.0 );//set dipole moment
-               setBackgroundField(bgFieldDipole, BgBGrid);
-               SBC::ionosphereGrid.setDipoleField(bgFieldDipole);
-               break;
-            case 1:
-               bgFieldLineDipole.initialize(126.2e6 *this->dipoleScalingFactor, 0.0, 0.0, 0.0 );//set dipole moment     
-               setBackgroundField(bgFieldLineDipole, BgBGrid);
-               SBC::ionosphereGrid.setDipoleField(bgFieldLineDipole);
-               break;
-            case 2:
-               bgFieldLineDipole.initialize(126.2e6 *this->dipoleScalingFactor, 0.0, 0.0, 0.0 );//set dipole moment     
-               setBackgroundField(bgFieldLineDipole, BgBGrid);
-               //Append mirror dipole
-               bgFieldLineDipole.initialize(126.2e6 *this->dipoleScalingFactor, this->dipoleMirrorLocationX, 0.0, 0.0 );
-               setBackgroundField(bgFieldLineDipole, BgBGrid, true);
-               SBC::ionosphereGrid.setDipoleField(bgFieldLineDipole);
-               break;
-            case 3:
-               bgFieldDipole.initialize(8e15 *this->dipoleScalingFactor, 0.0, 0.0, 0.0, 0.0 );//set dipole moment
-               setBackgroundField(bgFieldDipole, BgBGrid);
-               SBC::ionosphereGrid.setDipoleField(bgFieldDipole);
-               //Append mirror dipole                
-               bgFieldDipole.initialize(8e15 *this->dipoleScalingFactor, this->dipoleMirrorLocationX, 0.0, 0.0, 0.0 );//mirror
-               setBackgroundField(bgFieldDipole, BgBGrid, true);
-               break; 
-            case 4:  // Vector potential dipole, vanishes or optionally scales to static inflow value after a given x-coordinate
-               // What we in fact do is we place the regular dipole in the background field, and the
-               // corrective terms in the perturbed field. This maintains the BGB as curl-free.
-               bgFieldDipole.initialize(8e15 *this->dipoleScalingFactor, 0.0, 0.0, 0.0, 0.0 );//set dipole moment
-               setBackgroundField(bgFieldDipole, BgBGrid);
-               SBC::ionosphereGrid.setDipoleField(bgFieldDipole);
-               // Difference into perBgrid, only if not restarting
-               if (P::isRestart == false) {
-                  bgFieldDipole.initialize(-8e15 *this->dipoleScalingFactor, 0.0, 0.0, 0.0, 0.0 );
-                  setPerturbedField(bgFieldDipole, perBGrid);
-                  bgVectorDipole.initialize(8e15 *this->dipoleScalingFactor, 0.0, 0.0, 0.0, this->dipoleTiltPhi*M_PI/180., this->dipoleTiltTheta*M_PI/180., this->dipoleXFull, this->dipoleXZero, this->dipoleInflowB[0], this->dipoleInflowB[1], this->dipoleInflowB[2]);
-                  setPerturbedField(bgVectorDipole, perBGrid, true);
-               }
-               break;
-            default:
-               setBackgroundFieldToZero(BgBGrid);
+      switch (this->dipoleType) {
+      case 0:
+         bgFieldDipole.initialize(8e15 * this->dipoleScalingFactor, 0.0, 0.0, 0.0, 0.0); // set dipole moment
+         setBackgroundField(bgFieldDipole, BgBGrid);
+         SBC::ionosphereGrid.setDipoleField(bgFieldDipole);
+         break;
+      case 1:
+         bgFieldLineDipole.initialize(126.2e6 * this->dipoleScalingFactor, 0.0, 0.0, 0.0); // set dipole moment
+         setBackgroundField(bgFieldLineDipole, BgBGrid);
+         SBC::ionosphereGrid.setDipoleField(bgFieldLineDipole);
+         break;
+      case 2:
+         bgFieldLineDipole.initialize(126.2e6 * this->dipoleScalingFactor, 0.0, 0.0, 0.0); // set dipole moment
+         setBackgroundField(bgFieldLineDipole, BgBGrid);
+         // Append mirror dipole
+         bgFieldLineDipole.initialize(126.2e6 * this->dipoleScalingFactor, this->dipoleMirrorLocationX, 0.0, 0.0);
+         setBackgroundField(bgFieldLineDipole, BgBGrid, true);
+         SBC::ionosphereGrid.setDipoleField(bgFieldLineDipole);
+         break;
+      case 3:
+         bgFieldDipole.initialize(8e15 * this->dipoleScalingFactor, 0.0, 0.0, 0.0, 0.0); // set dipole moment
+         setBackgroundField(bgFieldDipole, BgBGrid);
+         SBC::ionosphereGrid.setDipoleField(bgFieldDipole);
+         // Append mirror dipole
+         bgFieldDipole.initialize(8e15 * this->dipoleScalingFactor, this->dipoleMirrorLocationX, 0.0, 0.0,
+                                  0.0); // mirror
+         setBackgroundField(bgFieldDipole, BgBGrid, true);
+         break;
+      case 4: // Vector potential dipole, vanishes or optionally scales to static inflow value after a given
+              // x-coordinate
+         // What we in fact do is we place the regular dipole in the background field, and the
+         // corrective terms in the perturbed field. This maintains the BGB as curl-free.
+         bgFieldDipole.initialize(8e15 * this->dipoleScalingFactor, 0.0, 0.0, 0.0, 0.0); // set dipole moment
+         setBackgroundField(bgFieldDipole, BgBGrid);
+         SBC::ionosphereGrid.setDipoleField(bgFieldDipole);
+         // Difference into perBgrid, only if not restarting
+         if (P::isRestart == false) {
+            bgFieldDipole.initialize(-8e15 * this->dipoleScalingFactor, 0.0, 0.0, 0.0, 0.0);
+            setPerturbedField(bgFieldDipole, perBGrid);
+            bgVectorDipole.initialize(8e15 * this->dipoleScalingFactor, 0.0, 0.0, 0.0,
+                                      this->dipoleTiltPhi * M_PI / 180., this->dipoleTiltTheta * M_PI / 180.,
+                                      this->dipoleXFull, this->dipoleXZero, this->dipoleInflowB[0],
+                                      this->dipoleInflowB[1], this->dipoleInflowB[2]);
+            setPerturbedField(bgVectorDipole, perBGrid, true);
+         }
+         break;
+      default:
+         setBackgroundFieldToZero(BgBGrid);
       }
-      
+
       const auto localSize = BgBGrid.getLocalSize().data();
-      
+
 #pragma omp parallel
       {
          bool doZeroOut;
-         //Force field to zero in the perpendicular direction for 2D (1D) simulations. Otherwise we have unphysical components.
-         doZeroOut = P::xcells_ini ==1 && this->zeroOutComponents[0]==1;
-      
-         if(doZeroOut) {
-#pragma omp for collapse(3)
-            for (int x = 0; x < localSize[0]; ++x) {
-               for (int y = 0; y < localSize[1]; ++y) {
-                  for (int z = 0; z < localSize[2]; ++z) {
-                     std::array<Real, fsgrids::bgbfield::N_BGB>* cell = BgBGrid.get(x, y, z);
-                     cell->at(fsgrids::bgbfield::BGBX)=0;
-                     cell->at(fsgrids::bgbfield::BGBXVOL)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBydx)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBzdx)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBxdy)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBxdz)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBYVOLdx)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBZVOLdx)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBXVOLdy)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBXVOLdz)=0.0;
-                  }
-               }
-            }
-         }
-            
-          doZeroOut = P::ycells_ini ==1 && this->zeroOutComponents[1]==1;
-          if(doZeroOut) {
-             /*2D simulation in x and z. Set By and derivatives along Y, and derivatives of By to zero*/
- #pragma omp for collapse(3)
-             for (int x = 0; x < localSize[0]; ++x) {
-                for (int y = 0; y < localSize[1]; ++y) {
-                   for (int z = 0; z < localSize[2]; ++z) {
-                      std::array<Real, fsgrids::bgbfield::N_BGB>* cell = BgBGrid.get(x, y, z);
-                      cell->at(fsgrids::bgbfield::BGBY)=0.0;
-                      cell->at(fsgrids::bgbfield::BGBYVOL)=0.0;
-                      cell->at(fsgrids::bgbfield::dBGBxdy)=0.0;
-                      cell->at(fsgrids::bgbfield::dBGBzdy)=0.0;
-                      cell->at(fsgrids::bgbfield::dBGBydx)=0.0;
-                      cell->at(fsgrids::bgbfield::dBGBydz)=0.0;
-                      cell->at(fsgrids::bgbfield::dBGBXVOLdy)=0.0;
-                      cell->at(fsgrids::bgbfield::dBGBZVOLdy)=0.0;
-                      cell->at(fsgrids::bgbfield::dBGBYVOLdx)=0.0;
-                      cell->at(fsgrids::bgbfield::dBGBYVOLdz)=0.0;
-                   }
-                }
-             }
-          }
+         // Force field to zero in the perpendicular direction for 2D (1D) simulations. Otherwise we have unphysical
+         // components.
+         doZeroOut = P::xcells_ini == 1 && this->zeroOutComponents[0] == 1;
 
-         doZeroOut = P::zcells_ini ==1 && this->zeroOutComponents[2]==1;
-         if(doZeroOut) {
+         if (doZeroOut) {
 #pragma omp for collapse(3)
             for (int x = 0; x < localSize[0]; ++x) {
                for (int y = 0; y < localSize[1]; ++y) {
                   for (int z = 0; z < localSize[2]; ++z) {
                      std::array<Real, fsgrids::bgbfield::N_BGB>* cell = BgBGrid.get(x, y, z);
-                     cell->at(fsgrids::bgbfield::BGBX)=0;
-                     cell->at(fsgrids::bgbfield::BGBY)=0;
-                     cell->at(fsgrids::bgbfield::BGBYVOL)=0.0;
-                     cell->at(fsgrids::bgbfield::BGBXVOL)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBxdy)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBxdz)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBydx)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBydz)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBXVOLdy)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBXVOLdz)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBYVOLdx)=0.0;
-                     cell->at(fsgrids::bgbfield::dBGBYVOLdz)=0.0;
+                     cell->at(fsgrids::bgbfield::BGBX) = 0;
+                     cell->at(fsgrids::bgbfield::BGBXVOL) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBydx) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBzdx) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBxdy) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBxdz) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBYVOLdx) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBZVOLdx) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBXVOLdy) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBXVOLdz) = 0.0;
                   }
                }
             }
          }
-         
-         // Remove dipole from inflow cells if this is requested
-         if(this->noDipoleInSW) {
+
+         doZeroOut = P::ycells_ini == 1 && this->zeroOutComponents[1] == 1;
+         if (doZeroOut) {
+            /*2D simulation in x and z. Set By and derivatives along Y, and derivatives of By to zero*/
 #pragma omp for collapse(3)
             for (int x = 0; x < localSize[0]; ++x) {
                for (int y = 0; y < localSize[1]; ++y) {
                   for (int z = 0; z < localSize[2]; ++z) {
-                     if(technicalGrid.get(x, y, z)->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN ) {
+                     std::array<Real, fsgrids::bgbfield::N_BGB>* cell = BgBGrid.get(x, y, z);
+                     cell->at(fsgrids::bgbfield::BGBY) = 0.0;
+                     cell->at(fsgrids::bgbfield::BGBYVOL) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBxdy) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBzdy) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBydx) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBydz) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBXVOLdy) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBZVOLdy) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBYVOLdx) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBYVOLdz) = 0.0;
+                  }
+               }
+            }
+         }
+
+         doZeroOut = P::zcells_ini == 1 && this->zeroOutComponents[2] == 1;
+         if (doZeroOut) {
+#pragma omp for collapse(3)
+            for (int x = 0; x < localSize[0]; ++x) {
+               for (int y = 0; y < localSize[1]; ++y) {
+                  for (int z = 0; z < localSize[2]; ++z) {
+                     std::array<Real, fsgrids::bgbfield::N_BGB>* cell = BgBGrid.get(x, y, z);
+                     cell->at(fsgrids::bgbfield::BGBX) = 0;
+                     cell->at(fsgrids::bgbfield::BGBY) = 0;
+                     cell->at(fsgrids::bgbfield::BGBYVOL) = 0.0;
+                     cell->at(fsgrids::bgbfield::BGBXVOL) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBxdy) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBxdz) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBydx) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBydz) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBXVOLdy) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBXVOLdz) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBYVOLdx) = 0.0;
+                     cell->at(fsgrids::bgbfield::dBGBYVOLdz) = 0.0;
+                  }
+               }
+            }
+         }
+
+         // Remove dipole from inflow cells if this is requested
+         if (this->noDipoleInSW) {
+#pragma omp for collapse(3)
+            for (int x = 0; x < localSize[0]; ++x) {
+               for (int y = 0; y < localSize[1]; ++y) {
+                  for (int z = 0; z < localSize[2]; ++z) {
+                     if (technicalGrid.get(x, y, z)->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN) {
                         for (int i = 0; i < fsgrids::bgbfield::N_BGB; ++i) {
-                           BgBGrid.get(x,y,z)->at(i) = 0;
+                           BgBGrid.get(x, y, z)->at(i) = 0;
                         }
-			if ( (this->dipoleType==4) && (P::isRestart == false) ) {
-			   for (int i = 0; i < fsgrids::bfield::N_BFIELD; ++i) {
-			      perBGrid.get(x,y,z)->at(i) = 0;
-			   }
+                        if ((this->dipoleType == 4) && (P::isRestart == false)) {
+                           for (int i = 0; i < fsgrids::bfield::N_BFIELD; ++i) {
+                              perBGrid.get(x, y, z)->at(i) = 0;
+                           }
                         }
                      }
                   }
@@ -453,14 +457,13 @@ namespace projects {
          }
       } // end of omp parallel region
       // Superimpose constant background field if needed
-      if(this->constBgB[0] != 0.0 || this->constBgB[1] != 0.0 || this->constBgB[2] != 0.0) {
+      if (this->constBgB[0] != 0.0 || this->constBgB[1] != 0.0 || this->constBgB[2] != 0.0) {
          ConstantField bgConstantField;
          bgConstantField.initialize(this->constBgB[0], this->constBgB[1], this->constBgB[2]);
          setBackgroundField(bgConstantField, BgBGrid, true);
       }
    }
-   
-   
+
    Real Magnetosphere::getDistribValue(
            creal& x,creal& y,creal& z,
            creal& vx,creal& vy,creal& vz,

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -297,7 +297,7 @@ namespace projects {
    void Magnetosphere::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
    /* set 0-centered dipole */
-   void Magnetosphere::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Magnetosphere::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                         FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       Dipole bgFieldDipole;

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -258,9 +258,7 @@ namespace projects {
 
    }
    
-   bool Magnetosphere::initialize() {
-      return Project::initialize();
-   }
+   void Magnetosphere::initialize() { initialized = true; }
 
    Real Magnetosphere::calcPhaseSpaceDensity(creal& x,creal& y,creal& z,creal& dx,creal& dy,creal& dz,
                                              creal& vx,creal& vy,creal& vz,creal& dvx,creal& dvy,

--- a/projects/Magnetosphere/Magnetosphere.h
+++ b/projects/Magnetosphere/Magnetosphere.h
@@ -49,7 +49,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
       virtual Real calcPhaseSpaceDensity(

--- a/projects/Magnetosphere/Magnetosphere.h
+++ b/projects/Magnetosphere/Magnetosphere.h
@@ -46,14 +46,12 @@ namespace projects {
       Magnetosphere();
       ~Magnetosphere() override;
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
       virtual Real calcPhaseSpaceDensity(
                                          creal& x, creal& y, creal& z,
                                          creal& dx, creal& dy, creal& dz,
@@ -61,7 +59,7 @@ namespace projects {
                                          creal& dvx, creal& dvy, creal& dvz,
                                          const uint popID
                                         ) const;
-      
+
     protected:
       Real getDistribValue(
                            creal& x,creal& y, creal& z,

--- a/projects/Magnetosphere/Magnetosphere.h
+++ b/projects/Magnetosphere/Magnetosphere.h
@@ -44,11 +44,11 @@ namespace projects {
    class Magnetosphere: public TriAxisSearch {
     public:
       Magnetosphere();
-      virtual ~Magnetosphere();
-      
-      virtual bool initialize(void);
+      ~Magnetosphere() override;
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/MultiPeak/MultiPeak.cpp
+++ b/projects/MultiPeak/MultiPeak.cpp
@@ -42,12 +42,7 @@ Real projects::MultiPeak::rhoRnd;
 
 namespace projects {
    MultiPeak::MultiPeak(): TriAxisSearch() { }
-   
    MultiPeak::~MultiPeak() { }
-
-   bool MultiPeak::initialize(void) {
-      return Project::initialize();
-   }
 
    void MultiPeak::addParameters(){
       typedef Readparameters RP;
@@ -125,6 +120,8 @@ namespace projects {
       if (densModelString == "uniform") densityModel = Uniform;
       else if (densModelString == "testcase") densityModel = TestCase;
    }
+
+   void MultiPeak::initialize() { initialized = true; }
 
    Real MultiPeak::getDistribValue(creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,const uint popID) const {
       const MultiPeakSpeciesParameters& sP = speciesParams[popID];

--- a/projects/MultiPeak/MultiPeak.cpp
+++ b/projects/MultiPeak/MultiPeak.cpp
@@ -214,21 +214,17 @@ namespace projects {
       rhoRnd = 0.5 - getRandomNumber();
    }
 
-   void MultiPeak::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+   void MultiPeak::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                    FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                    FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;
-      bgField.initialize(this->Bx,
-                         this->By,
-                         this->Bz);
-      
+      bgField.initialize(this->Bx, this->By, this->Bz);
+
       setBackgroundField(bgField, BgBGrid);
-      
-      if(!P::isRestart) {
+
+      if (!P::isRestart) {
          auto localSize = perBGrid.getLocalSize().data();
-         
+
 #pragma omp parallel for collapse(3)
          for (int x = 0; x < localSize[0]; ++x) {
             for (int y = 0; y < localSize[1]; ++y) {
@@ -237,13 +233,13 @@ namespace projects {
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
                   const int64_t cellid = perBGrid.GlobalIDForCoords(x, y, z);
                   setRandomSeed(cellid);
-                  
+
                   if (this->lambda != 0.0) {
-                     cell->at(fsgrids::bfield::PERBX) = this->dBx*cos(2.0 * M_PI * xyz[0] / this->lambda);
-                     cell->at(fsgrids::bfield::PERBY) = this->dBy*sin(2.0 * M_PI * xyz[0] / this->lambda);
-                     cell->at(fsgrids::bfield::PERBZ) = this->dBz*cos(2.0 * M_PI * xyz[0] / this->lambda);
+                     cell->at(fsgrids::bfield::PERBX) = this->dBx * cos(2.0 * M_PI * xyz[0] / this->lambda);
+                     cell->at(fsgrids::bfield::PERBY) = this->dBy * sin(2.0 * M_PI * xyz[0] / this->lambda);
+                     cell->at(fsgrids::bfield::PERBZ) = this->dBz * cos(2.0 * M_PI * xyz[0] / this->lambda);
                   }
-                  
+
                   cell->at(fsgrids::bfield::PERBX) += this->magXPertAbsAmp * (0.5 - getRandomNumber());
                   cell->at(fsgrids::bfield::PERBY) += this->magYPertAbsAmp * (0.5 - getRandomNumber());
                   cell->at(fsgrids::bfield::PERBZ) += this->magZPertAbsAmp * (0.5 - getRandomNumber());
@@ -252,7 +248,7 @@ namespace projects {
          }
       }
    }
-   
+
    std::vector<std::array<Real, 3> > MultiPeak::getV0(
                                                 creal x,
                                                 creal y,

--- a/projects/MultiPeak/MultiPeak.cpp
+++ b/projects/MultiPeak/MultiPeak.cpp
@@ -214,7 +214,7 @@ namespace projects {
       rhoRnd = 0.5 - getRandomNumber();
    }
 
-   void MultiPeak::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void MultiPeak::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                     FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                     FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;

--- a/projects/MultiPeak/MultiPeak.h
+++ b/projects/MultiPeak/MultiPeak.h
@@ -56,11 +56,11 @@ namespace projects {
    class MultiPeak: public TriAxisSearch {
     public:
       MultiPeak();
-      virtual ~MultiPeak();
+      ~MultiPeak() override;
       
-      virtual bool initialize(void);
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/MultiPeak/MultiPeak.h
+++ b/projects/MultiPeak/MultiPeak.h
@@ -58,15 +58,14 @@ namespace projects {
       MultiPeak();
       ~MultiPeak() override;
       
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
-    protected:
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
+   protected:
       Real getDistribValue(
                            creal& x,creal& y, creal& z,
                            creal& vx, creal& vy, creal& vz,

--- a/projects/MultiPeak/MultiPeak.h
+++ b/projects/MultiPeak/MultiPeak.h
@@ -61,7 +61,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/Riemann1/Riemann1.cpp
+++ b/projects/Riemann1/Riemann1.cpp
@@ -124,7 +124,7 @@ namespace projects {
 
    void Riemann1::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void Riemann1::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Riemann1::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                    FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                    FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);

--- a/projects/Riemann1/Riemann1.cpp
+++ b/projects/Riemann1/Riemann1.cpp
@@ -38,8 +38,6 @@ namespace projects {
    Riemann1::Riemann1(): Project() { }
    Riemann1::~Riemann1() { }
 
-   bool Riemann1::initialize(void) {return Project::initialize();}
-
    void Riemann1::addParameters(){
       typedef Readparameters RP;
       RP::add("Riemann.rho1", "Number density, left state (m^-3)", 0.0);
@@ -89,6 +87,8 @@ namespace projects {
       RP::get("Riemann.nSpaceSamples", this->nSpaceSamples);
       RP::get("Riemann.nVelocitySamples", this->nVelocitySamples);
    }
+
+   void Riemann1::initialize() { initialized = true; }
 
    Real Riemann1::getDistribValue(creal& x, creal& y, creal& z, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz, const uint popID) const {
       cint side = (x < 0.0) ? this->LEFT : this->RIGHT;

--- a/projects/Riemann1/Riemann1.cpp
+++ b/projects/Riemann1/Riemann1.cpp
@@ -123,38 +123,36 @@ namespace projects {
    }
 
    void Riemann1::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
-   
-   void Riemann1::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+
+   void Riemann1::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                   FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                   FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);
-      
-      if(!P::isRestart) {
+
+      if (!P::isRestart) {
          auto localSize = perBGrid.getLocalSize().data();
-         
-         #pragma omp parallel for collapse(3)
+
+#pragma omp parallel for collapse(3)
          for (int x = 0; x < localSize[0]; ++x) {
             for (int y = 0; y < localSize[1]; ++y) {
                for (int z = 0; z < localSize[2]; ++z) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  
+
                   Real Bxavg, Byavg, Bzavg;
                   Bxavg = Byavg = Bzavg = 0.0;
-                  if(this->nSpaceSamples > 1) {
+                  if (this->nSpaceSamples > 1) {
                      Real d_x = perBGrid.DX / (this->nSpaceSamples - 1);
                      Real d_z = perBGrid.DZ / (this->nSpaceSamples - 1);
-                     for (uint i=0; i<this->nSpaceSamples; ++i) {
-                        for (uint k=0; k<this->nSpaceSamples; ++k) {
+                     for (uint i = 0; i < this->nSpaceSamples; ++i) {
+                        for (uint k = 0; k < this->nSpaceSamples; ++k) {
                            Bxavg += ((xyz[0] + i * d_x) < 0.0) ? this->Bx[this->LEFT] : this->Bx[this->RIGHT];
                            Byavg += ((xyz[0] + i * d_x) < 0.0) ? this->By[this->LEFT] : this->By[this->RIGHT];
                            Bzavg += ((xyz[0] + i * d_x) < 0.0) ? this->Bz[this->LEFT] : this->Bz[this->RIGHT];
                         }
                      }
                      cuint nPts = pow(this->nSpaceSamples, 3.0);
-                     
+
                      cell->at(fsgrids::bfield::PERBX) = Bxavg / nPts;
                      cell->at(fsgrids::bfield::PERBY) = Byavg / nPts;
                      cell->at(fsgrids::bfield::PERBZ) = Bzavg / nPts;

--- a/projects/Riemann1/Riemann1.h
+++ b/projects/Riemann1/Riemann1.h
@@ -31,11 +31,11 @@ namespace projects {
    class Riemann1: public Project {
       public:
          Riemann1();
-         virtual ~Riemann1();
-         
-         virtual bool initialize(void);
+         ~Riemann1() override;
+
          static void addParameters(void);
          virtual void getParameters(void);
+         void initialize() override;
          virtual void setProjectBField(
             FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
             FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/Riemann1/Riemann1.h
+++ b/projects/Riemann1/Riemann1.h
@@ -36,7 +36,7 @@ namespace projects {
          static void addParameters();
          virtual void getParameters();
          void initialize() override;
-         void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+         void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/Riemann1/Riemann1.h
+++ b/projects/Riemann1/Riemann1.h
@@ -33,14 +33,13 @@ namespace projects {
          Riemann1();
          ~Riemann1() override;
 
-         static void addParameters(void);
-         virtual void getParameters(void);
+         static void addParameters();
+         virtual void getParameters();
          void initialize() override;
-         virtual void setProjectBField(
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-         );
+         void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                               FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                               FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
       protected:
          Real getDistribValue(
             creal& x,creal& y, creal& z,

--- a/projects/Shock/Shock.cpp
+++ b/projects/Shock/Shock.cpp
@@ -36,8 +36,6 @@ namespace projects {
    Shock::Shock(): Project() { }
    Shock::~Shock() { }
 
-   bool Shock::initialize(void) {return Project::initialize();}
-
    void Shock::addParameters() {
       typedef Readparameters RP;
       RP::add("Shock.BX0", "Background field value (T)", 1.0e-9);
@@ -87,6 +85,8 @@ namespace projects {
       RP::get("Shock.Scale_y", this->SCA_Y);
       RP::get("Shock.Sharp_Y", this->Sharp_Y);
    }
+
+   void Shock::initialize() { initialized = true; }
 
    Real Shock::getDistribValue(creal& x, creal& y, creal& z, creal& vx, creal& vy, creal& vz, const uint popID) const {
       creal kb = physicalconstants::K_B;

--- a/projects/Shock/Shock.cpp
+++ b/projects/Shock/Shock.cpp
@@ -143,27 +143,27 @@ namespace projects {
    }
 
    void Shock::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
-   
-   void Shock::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+
+   void Shock::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);
-      
-      if(!P::isRestart) {
+
+      if (!P::isRestart) {
          auto localSize = perBGrid.getLocalSize().data();
-         
+
 #pragma omp parallel for collapse(3)
          for (int x = 0; x < localSize[0]; ++x) {
             for (int y = 0; y < localSize[1]; ++y) {
                for (int z = 0; z < localSize[2]; ++z) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  
+
                   cell->at(fsgrids::bfield::PERBX) = 0.0;
                   cell->at(fsgrids::bfield::PERBY) = 0.0;
-                  cell->at(fsgrids::bfield::PERBZ) = this->BZ0*(3.0 + 2.0*tanh((xyz[1] - Parameters::ymax/2.0)/(this->Sharp_Y*Parameters::ymax)));
+                  cell->at(fsgrids::bfield::PERBZ) =
+                      this->BZ0 *
+                      (3.0 + 2.0 * tanh((xyz[1] - Parameters::ymax / 2.0) / (this->Sharp_Y * Parameters::ymax)));
                }
             }
          }

--- a/projects/Shock/Shock.cpp
+++ b/projects/Shock/Shock.cpp
@@ -144,7 +144,7 @@ namespace projects {
 
    void Shock::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void Shock::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Shock::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                 FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                 FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);

--- a/projects/Shock/Shock.h
+++ b/projects/Shock/Shock.h
@@ -35,7 +35,7 @@ namespace projects {
          static void addParameters();
          virtual void getParameters();
          void initialize() override;
-         void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+         void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/Shock/Shock.h
+++ b/projects/Shock/Shock.h
@@ -32,15 +32,13 @@ namespace projects {
          Shock();
          ~Shock() override;
 
-         static void addParameters(void);
-         virtual void getParameters(void);
+         static void addParameters();
+         virtual void getParameters();
          void initialize() override;
-         virtual void setProjectBField(
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-         );
-      
+         void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                               FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                               FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
       protected:
          Real getDistribValue(
             creal& x,creal& y, creal& z,

--- a/projects/Shock/Shock.h
+++ b/projects/Shock/Shock.h
@@ -30,11 +30,11 @@ namespace projects {
    class Shock: public Project {
       public:
          Shock();
-         virtual ~Shock();
-      
-         virtual bool initialize(void);
+         ~Shock() override;
+
          static void addParameters(void);
          virtual void getParameters(void);
+         void initialize() override;
          virtual void setProjectBField(
             FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
             FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/Shocktest/Shocktest.cpp
+++ b/projects/Shocktest/Shocktest.cpp
@@ -39,13 +39,9 @@ using namespace std;
 using namespace spatial_cell;
 
 namespace projects {
-
    Shocktest::Shocktest() : TriAxisSearch() {} // Constructor
    Shocktest::~Shocktest() {} // Destructor
 
-   
-   bool Shocktest::initialize(void) { return Project::initialize(); }
-   
    void Shocktest::addParameters(){
       typedef Readparameters RP;
       RP::add("Shocktest.rho1", "Number density, left state (m^-3)", 0.0);
@@ -114,7 +110,9 @@ namespace projects {
       RP::get("Shocktest.nSpaceSamples", this->nSpaceSamples);
       RP::get("Shocktest.nVelocitySamples", this->nVelocitySamples);
    }
-   
+
+   void Shocktest::initialize() { initialized = true; }
+
    Real Shocktest::getDistribValue(creal& x, creal& y, creal& z, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz, const uint popID) const {
       creal mass = physicalconstants::MASS_PROTON;
       creal kb = physicalconstants::K_B;

--- a/projects/Shocktest/Shocktest.cpp
+++ b/projects/Shocktest/Shocktest.cpp
@@ -189,7 +189,7 @@ namespace projects {
     */
    void Shocktest::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void Shocktest::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Shocktest::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                     FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                     FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);

--- a/projects/Shocktest/Shocktest.h
+++ b/projects/Shocktest/Shocktest.h
@@ -62,7 +62,7 @@ namespace projects {
                            creal& dvx, creal& dvy, creal& dvz,
                            const uint popID
                           ) const;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/Shocktest/Shocktest.h
+++ b/projects/Shocktest/Shocktest.h
@@ -36,9 +36,9 @@ namespace projects {
       Shocktest();
       ~Shocktest() override;
 
-      static void addParameters(void);
-      virtual void getParameters(void);
-      void initialize(void) override;
+      static void addParameters();
+      virtual void getParameters();
+      void initialize() override;
 
     protected:
       enum {
@@ -62,12 +62,10 @@ namespace projects {
                            creal& dvx, creal& dvy, creal& dvz,
                            const uint popID
                           ) const;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
-      
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
       virtual void calcCellParameters(spatial_cell::SpatialCell* cell,creal& t);
       virtual Real calcPhaseSpaceDensity(
                                          creal& x, creal& y, creal& z,

--- a/projects/Shocktest/Shocktest.h
+++ b/projects/Shocktest/Shocktest.h
@@ -33,13 +33,13 @@
 namespace projects {
    class Shocktest: public TriAxisSearch {
     public:
-      Shocktest(); // Constructor
-      virtual ~Shocktest(); // Destructor
-      
-      virtual bool initialize(void);
+      Shocktest();
+      ~Shocktest() override;
+
       static void addParameters(void);
       virtual void getParameters(void);
-      
+      void initialize(void) override;
+
     protected:
       enum {
          LEFT,

--- a/projects/Template/Template.cpp
+++ b/projects/Template/Template.cpp
@@ -66,7 +66,7 @@ namespace projects {
       exp(- physicalconstants::MASS_PROTON * ((vx-Vx0)*(vx-Vx0) + (vy-Vy0)*(vy-Vy0) + (vz-Vz0)*(vz-Vz0)) / (2.0 * physicalconstants::K_B * T));
    }
 
-   void Template::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void Template::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                    FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                    FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       Dipole bgField;

--- a/projects/Template/Template.cpp
+++ b/projects/Template/Template.cpp
@@ -65,17 +65,15 @@ namespace projects {
       return rho * pow(physicalconstants::MASS_PROTON / (2.0 * M_PI * physicalconstants::K_B * T), 1.5) *
       exp(- physicalconstants::MASS_PROTON * ((vx-Vx0)*(vx-Vx0) + (vy-Vy0)*(vy-Vy0) + (vz-Vz0)*(vz-Vz0)) / (2.0 * physicalconstants::K_B * T));
    }
-   
-   void Template::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+
+   void Template::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                   FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                   FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       Dipole bgField;
-      bgField.initialize(8e15, 0.0, 0.0, 0.0, 0.0); //set dipole moment and location
+      bgField.initialize(8e15, 0.0, 0.0, 0.0, 0.0); // set dipole moment and location
       setBackgroundField(bgField, BgBGrid);
    }
-   
+
    vector<std::array<Real, 3>> Template::getV0(
       creal x,
       creal y,

--- a/projects/Template/Template.cpp
+++ b/projects/Template/Template.cpp
@@ -50,9 +50,9 @@ namespace projects {
       RP::get("Template.param", this->param);
    }
    
-   bool Template::initialize() {
+   void Template::initialize() {
       this->param += 1.0;
-      return Project::initialize();
+      initialized = true;
    }
 
    Real Template::calcPhaseSpaceDensity(creal& x, creal& y, creal& z, creal& dx, creal& dy, creal& dz, creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,const uint popID) const {

--- a/projects/Template/Template.h
+++ b/projects/Template/Template.h
@@ -30,11 +30,11 @@ namespace projects {
    class Template: public TriAxisSearch {
     public:
       Template();
-      virtual ~Template();
-      
-      virtual bool initialize(void);
+      ~Template() override;
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/Template/Template.h
+++ b/projects/Template/Template.h
@@ -35,7 +35,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
       virtual Real calcPhaseSpaceDensity(

--- a/projects/Template/Template.h
+++ b/projects/Template/Template.h
@@ -32,14 +32,12 @@ namespace projects {
       Template();
       ~Template() override;
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
       virtual Real calcPhaseSpaceDensity(
                                          creal& x, creal& y, creal& z,
                                          creal& dx, creal& dy, creal& dz,

--- a/projects/VelocityBox/VelocityBox.cpp
+++ b/projects/VelocityBox/VelocityBox.cpp
@@ -98,17 +98,13 @@ namespace projects {
   
    void VelocityBox::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void VelocityBox::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+   void VelocityBox::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                      FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                      FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;
-      bgField.initialize(this->Bx,
-                         this->By,
-                         this->Bz);
-      
+      bgField.initialize(this->Bx, this->By, this->Bz);
+
       setBackgroundField(bgField, BgBGrid);
    }
-   
+
 }// namespace projects

--- a/projects/VelocityBox/VelocityBox.cpp
+++ b/projects/VelocityBox/VelocityBox.cpp
@@ -40,9 +40,6 @@ namespace projects {
    VelocityBox::VelocityBox(): Project() { }
    VelocityBox::~VelocityBox() { }
 
-
-   bool VelocityBox::initialize(void) {return Project::initialize();}
-
    void VelocityBox::addParameters(){
       typedef Readparameters RP;
       RP::add("VelocityBox.rho", "Number density in full 6 dimensions (m^-6 s^3)", 0.0);
@@ -77,16 +74,16 @@ namespace projects {
       RP::get("VelocityBox.Bz", this->Bz);
    }
 
-  Real VelocityBox::getDistribValue(creal& vx, creal& vy, creal& vz, const uint popID) const {
-     if (vx >= this->Vx[0] && vx <= this->Vx[1] &&
-         vy >= this->Vy[0] && vy <= this->Vy[1] &&
-         vz >= this->Vz[0] && vz <= this->Vz[1])
-       return this->rho;
-     else
-       return 0.0;
+   void VelocityBox::initialize() { initialized = true; }
+
+   Real VelocityBox::getDistribValue(creal& vx, creal& vy, creal& vz, const uint popID) const {
+      if (vx >= this->Vx[0] && vx <= this->Vx[1] &&
+          vy >= this->Vy[0] && vy <= this->Vy[1] &&
+          vz >= this->Vz[0] && vz <= this->Vz[1])
+         return this->rho;
+      else
+         return 0.0;
    }
-
-
 
   Real VelocityBox::calcPhaseSpaceDensity(
      creal& x, creal& y, creal& z,

--- a/projects/VelocityBox/VelocityBox.cpp
+++ b/projects/VelocityBox/VelocityBox.cpp
@@ -98,7 +98,7 @@ namespace projects {
   
    void VelocityBox::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void VelocityBox::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void VelocityBox::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                       FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                       FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;

--- a/projects/VelocityBox/VelocityBox.h
+++ b/projects/VelocityBox/VelocityBox.h
@@ -36,7 +36,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/VelocityBox/VelocityBox.h
+++ b/projects/VelocityBox/VelocityBox.h
@@ -32,10 +32,10 @@ namespace projects {
     public:
       VelocityBox();
       virtual ~VelocityBox();
-      
-      virtual bool initialize(void);
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/VelocityBox/VelocityBox.h
+++ b/projects/VelocityBox/VelocityBox.h
@@ -33,15 +33,14 @@ namespace projects {
       VelocityBox();
       virtual ~VelocityBox();
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
-    protected:
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
+   protected:
       Real getDistribValue(creal& vx, creal& vy, creal& vz, const uint popID) const;
       virtual void calcCellParameters(spatial_cell::SpatialCell* cell,creal& t);
       virtual Real calcPhaseSpaceDensity(

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -545,85 +545,61 @@ namespace projects {
    
 Project* createProject() {
    Project* rvalue = NULL;
-   if(Parameters::projectName == "") {
-      cerr << "No project specified! Please set 'project' parameter!" << endl;
-      abort();
-   }
-   if(Parameters::projectName == "Alfven") {
+
+   if (Parameters::projectName == "Alfven") {
       rvalue = new projects::Alfven;
-   }
-   if(Parameters::projectName == "Diffusion") {
+   } else if (Parameters::projectName == "Diffusion") {
       rvalue = new projects::Diffusion;
-   }
-   if(Parameters::projectName == "Dispersion") {
+   } else if (Parameters::projectName == "Dispersion") {
       rvalue = new projects::Dispersion;
-   }
-   if(Parameters::projectName == "Distributions") {
+   } else if (Parameters::projectName == "Distributions") {
       rvalue = new projects::Distributions;
-   }
-   if(Parameters::projectName == "Firehose") {
+   } else if (Parameters::projectName == "Firehose") {
       rvalue = new projects::Firehose;
-   }
-   if(Parameters::projectName == "Flowthrough") {
+   } else if (Parameters::projectName == "Flowthrough") {
       rvalue = new projects::Flowthrough;
-   }
-   if(Parameters::projectName == "Fluctuations") {
+   } else if (Parameters::projectName == "Fluctuations") {
       rvalue = new projects::Fluctuations;
-   }
-   if(Parameters::projectName == "Harris") {
+   } else if (Parameters::projectName == "Harris") {
       rvalue = new projects::Harris;
-   }
-   if(Parameters::projectName == "KHB") {
+   } else if (Parameters::projectName == "KHB") {
       rvalue = new projects::KHB;
-   }
-   if(Parameters::projectName == "Larmor") {
+   } else if (Parameters::projectName == "Larmor") {
       rvalue = new projects::Larmor;
-   }
-   if(Parameters::projectName == "Magnetosphere") {
+   } else if (Parameters::projectName == "Magnetosphere") {
       rvalue = new projects::Magnetosphere;
-   }
-   if(Parameters::projectName == "MultiPeak") {
+   } else if (Parameters::projectName == "MultiPeak") {
       rvalue = new projects::MultiPeak;
-   } 
-   if(Parameters::projectName == "VelocityBox") {
+   } else if (Parameters::projectName == "VelocityBox") {
       rvalue = new projects::VelocityBox;
-   } 
-   if(Parameters::projectName == "Riemann1") {
+   } else if (Parameters::projectName == "Riemann1") {
       rvalue = new projects::Riemann1;
-   }
-   if(Parameters::projectName == "Shock") {
+   } else if (Parameters::projectName == "Shock") {
       rvalue = new projects::Shock;
-   }
-   if(Parameters::projectName == "IPShock") {
+   } else if (Parameters::projectName == "IPShock") {
       rvalue = new projects::IPShock;
-   }
-   if(Parameters::projectName == "Template") {
+   } else if (Parameters::projectName == "Template") {
       rvalue = new projects::Template;
-   }
-   if(Parameters::projectName == "test_fp") {
+   } else if (Parameters::projectName == "test_fp") {
       rvalue = new projects::test_fp;
-   }
-   if(Parameters::projectName == "testAmr") {
+   } else if (Parameters::projectName == "testAmr") {
       rvalue = new projects::testAmr;
-   }
-   if(Parameters::projectName == "testHall") {
+   } else if (Parameters::projectName == "testHall") {
       rvalue = new projects::TestHall;
-   }
-   if(Parameters::projectName == "test_trans") {
+   } else if (Parameters::projectName == "test_trans") {
       rvalue = new projects::test_trans;
-   }
-   if(Parameters::projectName == "verificationLarmor") {
+   } else if (Parameters::projectName == "verificationLarmor") {
       rvalue = new projects::verificationLarmor;
-   }
-   if(Parameters::projectName == "Shocktest") {
+   } else if (Parameters::projectName == "Shocktest") {
       rvalue = new projects::Shocktest;
-   }
-   if (rvalue == NULL) {
+   } else if (Parameters::projectName == "") {
+      cerr << "No project specified! Please set 'project' parameter!" << endl;
+      MPI_Abort(MPI_COMM_WORLD, 1);
+   } else {
       cerr << "Unknown project name!" << endl;
-      abort();
+      MPI_Abort(MPI_COMM_WORLD, 1);
    }
 
-   getObjectWrapper().project = rvalue;
    return rvalue;
 }
 

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -101,7 +101,7 @@ namespace projects {
 
    void Project::addParameters() {
       typedef Readparameters RP;
-      // TODO add all projects' static addParameters() functions here.
+      // Add all projects' static addParameters() functions here.
       projects::Alfven::addParameters();
       projects::Diffusion::addParameters();
       projects::Dispersion::addParameters();
@@ -126,7 +126,6 @@ namespace projects {
       projects::verificationLarmor::addParameters();
       projects::Shocktest::addParameters();
       RP::add("Project_common.seed", "Seed for the RNG", 42);
-      
    }
 
    void Project::getParameters() {
@@ -136,21 +135,7 @@ namespace projects {
 
    /** Check if the project class has been initialized.
     * @return If true, the project class was successfully initialized.*/
-   bool Project::isInitialized() {return initialized;}
-
-   /*! Print a warning message to stderr and abort, one should not use the base class functions. */
-   void Project::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
-      int rank;
-      MPI_Comm_rank(MPI_COMM_WORLD,&rank);
-      if (rank == MASTER_RANK) {
-         cerr << "(Project.cpp) WARNING: Base class 'setCellBackgroundField' in " << __FILE__ << ":" << __LINE__ << " called." << endl;
-      }
-      exit(1);
-   }
+   bool Project::isInitialized() { return initialized; }
    
    void Project::hook(
       cuint& stage,

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -96,12 +96,9 @@ struct VelocityMeshParams {
 static VelocityMeshParams* velMeshParams = NULL;
 
 namespace projects {
-   Project::Project() { 
-      baseClassInitialized = false;
-   }
-   
-   Project::~Project() { }
-   
+   Project::Project() {}
+   Project::~Project() {}
+
    void Project::addParameters() {
       typedef Readparameters RP;
       // TODO add all projects' static addParameters() functions here.
@@ -135,48 +132,11 @@ namespace projects {
    void Project::getParameters() {
       typedef Readparameters RP;
       RP::get("Project_common.seed", this->seed);
-
-
-      // Note that configuration files need to be re-parsed after this.
-
-      //RP::get("ParticlePopulation.charge",popCharges);
-      //RP::get("ParticlePopulation.mass_units",popMassUnits);
-      //RP::get("ParticlePopulation.mass",popMasses);
-      //RP::get("ParticlePopulation.sparse_min_value",popSparseMinValue);
-      //RP::get("ParticlePopulation.mesh",popMeshNames);
-
-      //if (velMeshParams == NULL) velMeshParams = new VelocityMeshParams();
-      //RP::get("velocitymesh.name",velMeshParams->name);
-      //RP::get("velocitymesh.vx_min",velMeshParams->vx_min);
-      //RP::get("velocitymesh.vy_min",velMeshParams->vy_min);
-      //RP::get("velocitymesh.vz_min",velMeshParams->vz_min);
-      //RP::get("velocitymesh.vx_max",velMeshParams->vx_max);
-      //RP::get("velocitymesh.vy_max",velMeshParams->vy_max);
-      //RP::get("velocitymesh.vz_max",velMeshParams->vz_max);
-      //RP::get("velocitymesh.vx_length",velMeshParams->vx_length);
-      //RP::get("velocitymesh.vy_length",velMeshParams->vy_length);
-      //RP::get("velocitymesh.vz_length",velMeshParams->vz_length);
-      //RP::get("velocitymesh.max_refinement_level",velMeshParams->maxRefLevels);
    }
 
-   /** Initialize the Project. Velocity mesh and particle population 
-    * parameters are read from the configuration file, and corresponding internal 
-    * variables are created here.
-    * NOTE: Each project must call this function!
-    * @return If true, particle species and velocity meshes were created successfully.*/
-   bool Project::initialize() {
-      typedef Readparameters RP;
-      
-      // Basic error checking
-      bool success = true;
-
-      baseClassInitialized = success;
-      return success;
-   }
-   
-   /** Check if base class has been initialized.
-    * @return If true, base class was successfully initialized.*/
-   bool Project::initialized() {return baseClassInitialized;}
+   /** Check if the project class has been initialized.
+    * @return If true, the project class was successfully initialized.*/
+   bool Project::isInitialized() {return initialized;}
 
    /*! Print a warning message to stderr and abort, one should not use the base class functions. */
    void Project::setProjectBField(

--- a/projects/project.h
+++ b/projects/project.h
@@ -62,7 +62,7 @@ namespace projects {
        *
        * \sa setBackgroundField, setBackgroundFieldToZero
        */
-      virtual void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      virtual void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                     FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                     FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) = 0;
 

--- a/projects/project.h
+++ b/projects/project.h
@@ -54,20 +54,18 @@ namespace projects {
       ) const;
       
       bool isInitialized();
-      
+
       /** Set the background and perturbed magnetic fields for this project.
        * \param perBGrid Grid on which values of the perturbed field can be set if needed.
-       * \param BgBGrid Grid on which values for the background field can be set if needed, e.g. using the background field functions.
-       * \param technicalGrid Technical fsgrid, available if some of its data is necessary.
-       * 
+       * \param BgBGrid Grid on which values for the background field can be set if needed, e.g. using the background
+       * field functions. \param technicalGrid Technical fsgrid, available if some of its data is necessary.
+       *
        * \sa setBackgroundField, setBackgroundFieldToZero
        */
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
-      
+      virtual void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                    FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                    FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) = 0;
+
       /*! Setup data structures for subsequent setCell calls.
        * This will most likely be empty for most projects, except for some advanced
        * data juggling ones (like restart from a subset of a larger run)

--- a/projects/project.h
+++ b/projects/project.h
@@ -58,7 +58,8 @@ namespace projects {
       /** Set the background and perturbed magnetic fields for this project.
        * \param perBGrid Grid on which values of the perturbed field can be set if needed.
        * \param BgBGrid Grid on which values for the background field can be set if needed, e.g. using the background
-       * field functions. \param technicalGrid Technical fsgrid, available if some of its data is necessary.
+       * field functions.
+       * \param technicalGrid Technical fsgrid, available if some of its data is necessary.
        *
        * \sa setBackgroundField, setBackgroundFieldToZero
        */

--- a/projects/project.h
+++ b/projects/project.h
@@ -43,8 +43,8 @@ namespace projects {
       /*! Get the value that was read in. */
       virtual void getParameters();
       
-      /*! Initialize project. Can be used, e.g., to read in parameters from the input file. */
-      virtual bool initialize();
+      /*! Initialize project after reading in parameters. */
+      virtual void initialize() = 0;
       
       /*! Perform some operation at each time step in the main program loop. */
       virtual void hook(
@@ -53,7 +53,7 @@ namespace projects {
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid
       ) const;
       
-      bool initialized();
+      bool isInitialized();
       
       /** Set the background and perturbed magnetic fields for this project.
        * \param perBGrid Grid on which values of the perturbed field can be set if needed.
@@ -87,6 +87,8 @@ namespace projects {
       virtual bool refineSpatialCells( dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid ) const;
       
     protected:
+      bool initialized = false; /**< If true, the class has been initialized.*/
+
       /*! \brief Returns a list of blocks to loop through when initialising.
        * 
        * The base class version just returns all blocks, which amounts to looping through the whole velocity space.
@@ -171,8 +173,6 @@ namespace projects {
       static char rngStateBuffer[256];
       static random_data rngDataBuffer;
       #pragma omp threadprivate(rngStateBuffer,rngDataBuffer)
-
-      bool baseClassInitialized;                      /**< If true, base class has been initialized.*/
    };
    
    Project* createProject();

--- a/projects/testAmr/testAmr.cpp
+++ b/projects/testAmr/testAmr.cpp
@@ -215,7 +215,7 @@ namespace projects {
       rhoRnd = 0.5 - getRandomNumber();
    }
 
-   void testAmr::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void testAmr::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                   FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                   FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;

--- a/projects/testAmr/testAmr.cpp
+++ b/projects/testAmr/testAmr.cpp
@@ -215,38 +215,34 @@ namespace projects {
       rhoRnd = 0.5 - getRandomNumber();
    }
 
-   void testAmr::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+   void testAmr::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                  FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                  FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;
-      bgField.initialize(this->Bx,
-                         this->By,
-                         this->Bz);
-      
+      bgField.initialize(this->Bx, this->By, this->Bz);
+
       setBackgroundField(bgField, BgBGrid);
-      
-      if(!P::isRestart) {
+
+      if (!P::isRestart) {
          auto localSize = perBGrid.getLocalSize().data();
-         
-         #pragma omp parallel for collapse(3)
+
+#pragma omp parallel for collapse(3)
          for (int x = 0; x < localSize[0]; ++x) {
             for (int y = 0; y < localSize[1]; ++y) {
                for (int z = 0; z < localSize[2]; ++z) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  
+
                   const int64_t cellid = perBGrid.GlobalIDForCoords(x, y, z);
-                  
+
                   setRandomSeed(cellid);
-                  
+
                   if (this->lambda != 0.0) {
-                     cell->at(fsgrids::bfield::PERBX) = this->dBx*cos(2.0 * M_PI * xyz[0] / this->lambda);
-                     cell->at(fsgrids::bfield::PERBY) = this->dBy*sin(2.0 * M_PI * xyz[0] / this->lambda);
-                     cell->at(fsgrids::bfield::PERBZ) = this->dBz*cos(2.0 * M_PI * xyz[0] / this->lambda);
+                     cell->at(fsgrids::bfield::PERBX) = this->dBx * cos(2.0 * M_PI * xyz[0] / this->lambda);
+                     cell->at(fsgrids::bfield::PERBY) = this->dBy * sin(2.0 * M_PI * xyz[0] / this->lambda);
+                     cell->at(fsgrids::bfield::PERBZ) = this->dBz * cos(2.0 * M_PI * xyz[0] / this->lambda);
                   }
-                  
+
                   cell->at(fsgrids::bfield::PERBX) += this->magXPertAbsAmp * (0.5 - getRandomNumber());
                   cell->at(fsgrids::bfield::PERBY) += this->magYPertAbsAmp * (0.5 - getRandomNumber());
                   cell->at(fsgrids::bfield::PERBZ) += this->magZPertAbsAmp * (0.5 - getRandomNumber());
@@ -255,7 +251,7 @@ namespace projects {
          }
       }
    }
-   
+
    std::vector<std::array<Real, 3> > testAmr::getV0(
                                                 creal x,
                                                 creal y,

--- a/projects/testAmr/testAmr.cpp
+++ b/projects/testAmr/testAmr.cpp
@@ -40,12 +40,7 @@ Real projects::testAmr::rhoRnd;
 
 namespace projects {
    testAmr::testAmr(): TriAxisSearch() { }
-   
    testAmr::~testAmr() { }
-
-   bool testAmr::initialize(void) {
-      return Project::initialize();
-   }
 
    void testAmr::addParameters(){
       typedef Readparameters RP;
@@ -126,6 +121,8 @@ namespace projects {
       if (densModelString == "uniform") densityModel = Uniform;
       else if (densModelString == "testcase") densityModel = TestCase;
    }
+
+   void testAmr::initialize() { initialized = true; }
 
    Real testAmr::getDistribValue(creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,const uint popID) const {
       const testAmrSpeciesParameters& sP = speciesParams[popID];

--- a/projects/testAmr/testAmr.h
+++ b/projects/testAmr/testAmr.h
@@ -57,10 +57,10 @@ namespace projects {
     public:
       testAmr();
       virtual ~testAmr();
-      
-      virtual bool initialize(void);
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/testAmr/testAmr.h
+++ b/projects/testAmr/testAmr.h
@@ -58,15 +58,14 @@ namespace projects {
       testAmr();
       virtual ~testAmr();
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
-    protected:
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
+   protected:
       Real getDistribValue(
                            creal& x,creal& y, creal& z,
                            creal& vx, creal& vy, creal& vz,

--- a/projects/testAmr/testAmr.h
+++ b/projects/testAmr/testAmr.h
@@ -61,7 +61,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/testHall/testHall.cpp
+++ b/projects/testHall/testHall.cpp
@@ -127,31 +127,35 @@ namespace projects {
 //       cellParams[CellParams::PERBX   ] = this->BX0 * (x+0.5*Dx)*(y+0.5*Dy)*(z+0.5*Dz);
 //       cellParams[CellParams::PERBY   ] = this->BY0 * (x+0.5*Dx)*(y+0.5*Dy)*(z+0.5*Dz)*(x+0.5*Dx)*(y+0.5*Dy)*(z+0.5*Dz);
 //       cellParams[CellParams::PERBZ   ] = this->BZ0 * (x+0.5*Dx)*(y+0.5*Dy)*(z+0.5*Dz)*(x+0.5*Dx)*(y+0.5*Dy)*(z+0.5*Dz)*(x+0.5*Dx)*(y+0.5*Dy)*(z+0.5*Dz);
-   
-   void TestHall::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+
+   void TestHall::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                   FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                   FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);
-      
-      if(!P::isRestart) {
+
+      if (!P::isRestart) {
          auto localSize = perBGrid.getLocalSize().data();
-         
+
 #pragma omp parallel for collapse(3)
          for (int x = 0; x < localSize[0]; ++x) {
             for (int y = 0; y < localSize[1]; ++y) {
                for (int z = 0; z < localSize[2]; ++z) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  
-                  cell->at(fsgrids::bfield::PERBX) = this->BX0 * cos(2.0*M_PI * 1.0 * xyz[0] / (P::xmax - P::xmin)) * cos(2.0*M_PI * 1.0 * xyz[1] / (P::ymax - P::ymin)) * cos(2.0*M_PI * 1.0 * xyz[2] / (P::zmax - P::zmin));
-                  cell->at(fsgrids::bfield::PERBY) = this->BY0 * cos(2.0*M_PI * 1.0 * xyz[0] / (P::xmax - P::xmin)) * cos(2.0*M_PI * 1.0 * xyz[1] / (P::ymax - P::ymin)) * cos(2.0*M_PI * 1.0 * xyz[2] / (P::zmax - P::zmin));
-                  cell->at(fsgrids::bfield::PERBZ) = this->BZ0 * cos(2.0*M_PI * 1.0 * xyz[0] / (P::xmax - P::xmin)) * cos(2.0*M_PI * 1.0 * xyz[1] / (P::ymax - P::ymin)) * cos(2.0*M_PI * 1.0 * xyz[2] / (P::zmax - P::zmin));
+
+                  cell->at(fsgrids::bfield::PERBX) = this->BX0 * cos(2.0 * M_PI * 1.0 * xyz[0] / (P::xmax - P::xmin)) *
+                                                     cos(2.0 * M_PI * 1.0 * xyz[1] / (P::ymax - P::ymin)) *
+                                                     cos(2.0 * M_PI * 1.0 * xyz[2] / (P::zmax - P::zmin));
+                  cell->at(fsgrids::bfield::PERBY) = this->BY0 * cos(2.0 * M_PI * 1.0 * xyz[0] / (P::xmax - P::xmin)) *
+                                                     cos(2.0 * M_PI * 1.0 * xyz[1] / (P::ymax - P::ymin)) *
+                                                     cos(2.0 * M_PI * 1.0 * xyz[2] / (P::zmax - P::zmin));
+                  cell->at(fsgrids::bfield::PERBZ) = this->BZ0 * cos(2.0 * M_PI * 1.0 * xyz[0] / (P::xmax - P::xmin)) *
+                                                     cos(2.0 * M_PI * 1.0 * xyz[1] / (P::ymax - P::ymin)) *
+                                                     cos(2.0 * M_PI * 1.0 * xyz[2] / (P::zmax - P::zmin));
                }
             }
          }
       }
    }
-   
+
 } // namespace projects

--- a/projects/testHall/testHall.cpp
+++ b/projects/testHall/testHall.cpp
@@ -128,7 +128,7 @@ namespace projects {
 //       cellParams[CellParams::PERBY   ] = this->BY0 * (x+0.5*Dx)*(y+0.5*Dy)*(z+0.5*Dz)*(x+0.5*Dx)*(y+0.5*Dy)*(z+0.5*Dz);
 //       cellParams[CellParams::PERBZ   ] = this->BZ0 * (x+0.5*Dx)*(y+0.5*Dy)*(z+0.5*Dz)*(x+0.5*Dx)*(y+0.5*Dy)*(z+0.5*Dz)*(x+0.5*Dx)*(y+0.5*Dy)*(z+0.5*Dz);
 
-   void TestHall::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void TestHall::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                    FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                    FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);

--- a/projects/testHall/testHall.cpp
+++ b/projects/testHall/testHall.cpp
@@ -35,20 +35,16 @@
 using namespace std;
 
 namespace projects {
-   TestHall::TestHall(): Project() { }
-   TestHall::~TestHall() { }
-   
-   bool TestHall::initialize(void) {
-      bool success = Project::initialize();
+   TestHall::TestHall(){
       this->constBgB[0] = 0.0;
       this->constBgB[1] = 0.0;
       this->constBgB[2] = 0.0;
       this->dipoleScalingFactor = 1.0;
       this->dipoleTilt = 0.0;
       this->noDipoleInSW = 0;
-      return success;
    }
-   
+   TestHall::~TestHall() { }
+
    void TestHall::addParameters(){
       typedef Readparameters RP;
       RP::add("TestHall.BX0", "Magnetic field x (T)", 1.0e-9);
@@ -78,7 +74,9 @@ namespace projects {
       RP::get("TestHall.Temperature", this->TEMPERATURE);
       RP::get("TestHall.rho", this->DENSITY);
    }
-   
+
+   void TestHall::initialize() { initialized = true; }
+
    Real TestHall::calcPhaseSpaceDensity(
       creal& x,creal& y,creal& z,
       creal& dx,creal& dy,creal& dz,

--- a/projects/testHall/testHall.h
+++ b/projects/testHall/testHall.h
@@ -36,7 +36,7 @@ namespace projects {
          virtual void getParameters();
          void initialize() override;
          virtual void calcCellParameters(spatial_cell::SpatialCell* cell,creal& t);
-         void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+         void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
          virtual Real calcPhaseSpaceDensity(

--- a/projects/testHall/testHall.h
+++ b/projects/testHall/testHall.h
@@ -31,10 +31,10 @@ namespace projects {
       public:
          TestHall();
          virtual ~TestHall();
-         
-         virtual bool initialize(void);
+
          static void addParameters(void);
          virtual void getParameters(void);
+         void initialize() override;
          virtual void calcCellParameters(spatial_cell::SpatialCell* cell,creal& t);
          virtual void setProjectBField(
             FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,

--- a/projects/testHall/testHall.h
+++ b/projects/testHall/testHall.h
@@ -32,15 +32,13 @@ namespace projects {
          TestHall();
          virtual ~TestHall();
 
-         static void addParameters(void);
-         virtual void getParameters(void);
+         static void addParameters();
+         virtual void getParameters();
          void initialize() override;
          virtual void calcCellParameters(spatial_cell::SpatialCell* cell,creal& t);
-         virtual void setProjectBField(
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-         );
+         void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                               FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                               FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
          virtual Real calcPhaseSpaceDensity(
             creal& x, creal& y, creal& z,
             creal& dx, creal& dy, creal& dz,

--- a/projects/test_fp/test_fp.cpp
+++ b/projects/test_fp/test_fp.cpp
@@ -93,7 +93,7 @@ namespace projects {
       return result;
    }
 
-   void test_fp::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void test_fp::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                   FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                   FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);

--- a/projects/test_fp/test_fp.cpp
+++ b/projects/test_fp/test_fp.cpp
@@ -36,24 +36,10 @@ enum cases {BXCASE,BYCASE,BZCASE,BALLCASE};
 using namespace std;
 
 namespace projects {
-   test_fp::test_fp(): TriAxisSearch() { }
-   test_fp::~test_fp() { }
-
-
-   /*typedef test_fpParameters tfP;
-   Real this->B0 = NAN;
-   Real this->DENSITY = NAN;
-   Real this->TEMPERATURE = NAN;
-   Real this->ALPHA = NAN;
-   int  this->CASE = 5;
-   bool this->shear = false;
-   */
-
-   bool test_fp::initialize(void) {
-      Project::initialize();
+   test_fp::test_fp(){
       this->ALPHA *= M_PI / 4.0;
-      return true;
    }
+   test_fp::~test_fp() { }
 
    void test_fp::addParameters(void){
       typedef Readparameters RP;
@@ -82,6 +68,8 @@ namespace projects {
       RP::get("test_fp.Bdirection", this->CASE);
       RP::get("test_fp.shear", this->shear);
    }
+
+   void test_fp::initialize() { initialized = true; }
 
    Real test_fp::sign(creal value) const {
       if (abs(value) < 1e-5) return 0.0;

--- a/projects/test_fp/test_fp.cpp
+++ b/projects/test_fp/test_fp.cpp
@@ -92,80 +92,78 @@ namespace projects {
       creal result = NORM*exp(-CONST*(VX2+VY2+VZ2));
       return result;
    }
-   
-   void test_fp::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+
+   void test_fp::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                  FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                  FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       setBackgroundFieldToZero(BgBGrid);
-      
-      if(!P::isRestart) {
+
+      if (!P::isRestart) {
          auto localSize = perBGrid.getLocalSize().data();
-         
+
          creal dx = perBGrid.DX * 3.5;
          creal dy = perBGrid.DY * 3.5;
          creal dz = perBGrid.DZ * 3.5;
-         
+
          Real areaFactor = 1.0;
-         
-         #pragma omp parallel for collapse(3)
+
+#pragma omp parallel for collapse(3)
          for (int i = 0; i < localSize[0]; ++i) {
             for (int j = 0; j < localSize[1]; ++j) {
                for (int k = 0; k < localSize[2]; ++k) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(i, j, k);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(i, j, k);
-                  
+
                   creal x = xyz[0] + 0.5 * perBGrid.DX;
                   creal y = xyz[1] + 0.5 * perBGrid.DY;
                   creal z = xyz[2] + 0.5 * perBGrid.DZ;
-                  
+
                   switch (this->CASE) {
-                     case BXCASE:         
-                        cell->at(fsgrids::bfield::PERBX) = 0.1 * this->B0 * areaFactor;
-                        //areaFactor = (CellParams::DY * CellParams::DZ) / (dy * dz);
+                  case BXCASE:
+                     cell->at(fsgrids::bfield::PERBX) = 0.1 * this->B0 * areaFactor;
+                     // areaFactor = (CellParams::DY * CellParams::DZ) / (dy * dz);
+                     if (y >= -dy && y <= dy)
+                        if (z >= -dz && z <= dz)
+                           cell->at(fsgrids::bfield::PERBX) = this->B0 * areaFactor;
+                     break;
+                  case BYCASE:
+                     cell->at(fsgrids::bfield::PERBY) = 0.1 * this->B0 * areaFactor;
+                     // areaFactor = (CellParams::DX * CellParams::DZ) / (dx * dz);
+                     if (x >= -dx && x <= dx)
+                        if (z >= -dz && z <= dz)
+                           cell->at(fsgrids::bfield::PERBY) = this->B0 * areaFactor;
+                     break;
+                  case BZCASE:
+                     cell->at(fsgrids::bfield::PERBZ) = 0.1 * this->B0 * areaFactor;
+                     // areaFactor = (CellParams::DX * CellParams::DY) / (dx * dy);
+                     if (x >= -dx && x <= dx)
                         if (y >= -dy && y <= dy)
-                           if (z >= -dz && z <= dz)
-                              cell->at(fsgrids::bfield::PERBX) = this->B0 * areaFactor;
-                        break;
-                     case BYCASE:
-                        cell->at(fsgrids::bfield::PERBY) = 0.1 * this->B0 * areaFactor;
-                        //areaFactor = (CellParams::DX * CellParams::DZ) / (dx * dz);
-                        if (x >= -dx && x <= dx)
-                           if (z >= -dz && z <= dz)
-                              cell->at(fsgrids::bfield::PERBY) = this->B0 * areaFactor;
-                        break;
-                     case BZCASE:
-                        cell->at(fsgrids::bfield::PERBZ) = 0.1 * this->B0 * areaFactor;
-                        //areaFactor = (CellParams::DX * CellParams::DY) / (dx * dy);
-                        if (x >= -dx && x <= dx)
-                           if (y >= -dy && y <= dy)
-                              cell->at(fsgrids::bfield::PERBZ) = this->B0 * areaFactor;
-                        break;
-                     case BALLCASE:
-                        cell->at(fsgrids::bfield::PERBX) = 0.1 * this->B0 * areaFactor;
-                        cell->at(fsgrids::bfield::PERBY) = 0.1 * this->B0 * areaFactor;
-                        cell->at(fsgrids::bfield::PERBZ) = 0.1 * this->B0 * areaFactor;
-                        
-                        //areaFactor = (CellParams::DX * CellParams::DY) / (dx * dy);
-                        
+                           cell->at(fsgrids::bfield::PERBZ) = this->B0 * areaFactor;
+                     break;
+                  case BALLCASE:
+                     cell->at(fsgrids::bfield::PERBX) = 0.1 * this->B0 * areaFactor;
+                     cell->at(fsgrids::bfield::PERBY) = 0.1 * this->B0 * areaFactor;
+                     cell->at(fsgrids::bfield::PERBZ) = 0.1 * this->B0 * areaFactor;
+
+                     // areaFactor = (CellParams::DX * CellParams::DY) / (dx * dy);
+
+                     if (y >= -dy && y <= dy)
+                        if (z >= -dz && z <= dz)
+                           cell->at(fsgrids::bfield::PERBX) = this->B0 * areaFactor;
+                     if (x >= -dx && x <= dx)
+                        if (z >= -dz && z <= dz)
+                           cell->at(fsgrids::bfield::PERBY) = this->B0 * areaFactor;
+                     if (x >= -dx && x <= dx)
                         if (y >= -dy && y <= dy)
-                           if (z >= -dz && z <= dz)
-                              cell->at(fsgrids::bfield::PERBX) = this->B0 * areaFactor;
-                        if (x >= -dx && x <= dx)
-                           if (z >= -dz && z <= dz)
-                              cell->at(fsgrids::bfield::PERBY) = this->B0 * areaFactor;
-                        if (x >= -dx && x <= dx)
-                           if (y >= -dy && y <= dy)
-                              cell->at(fsgrids::bfield::PERBZ) = this->B0 * areaFactor;
-                        break;
+                           cell->at(fsgrids::bfield::PERBZ) = this->B0 * areaFactor;
+                     break;
                   }
                }
             }
          }
       }
    }
-   
+
    void test_fp::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {
       
       typedef Parameters P;

--- a/projects/test_fp/test_fp.h
+++ b/projects/test_fp/test_fp.h
@@ -32,11 +32,11 @@ namespace projects {
    class test_fp: public TriAxisSearch {
    public:
       test_fp();
-      virtual ~test_fp();
-      
-      virtual bool initialize(void);
+      ~test_fp() override;
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/test_fp/test_fp.h
+++ b/projects/test_fp/test_fp.h
@@ -34,15 +34,13 @@ namespace projects {
       test_fp();
       ~test_fp() override;
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
-      
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
    protected:
       Real sign(creal value) const;
       Real getDistribValue(creal& vx, creal& vy, creal& vz);

--- a/projects/test_fp/test_fp.h
+++ b/projects/test_fp/test_fp.h
@@ -37,7 +37,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/test_trans/test_trans.cpp
+++ b/projects/test_trans/test_trans.cpp
@@ -39,12 +39,6 @@ using namespace spatial_cell;
 namespace projects {
    test_trans::test_trans(): Project() { }
    test_trans::~test_trans() { }
-      
-  // Real this->cellPosition = 0;
-
-   bool test_trans::initialize(void) {
-      return Project::initialize();
-   }
 
    void test_trans::addParameters(){
       typedef Readparameters RP;
@@ -65,6 +59,7 @@ namespace projects {
       RP::get("test_trans.peakValue" ,peakValue);
    }
 
+   void test_trans::initialize() { initialized = true; }
 
    Real test_trans::calcPhaseSpaceDensity(creal& x,creal& y,creal& z,creal& dx,creal& dy,creal& dz,
                                           creal& vx,creal& vy,creal& vz,creal& dvx,creal& dvy,creal& dvz,

--- a/projects/test_trans/test_trans.cpp
+++ b/projects/test_trans/test_trans.cpp
@@ -122,14 +122,12 @@ namespace projects {
    }
 
    void test_trans::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
-   
-   void test_trans::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+
+   void test_trans::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                     FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                     FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;
-      bgField.initialize(0.0,0.0,1e-9);
+      bgField.initialize(0.0, 0.0, 1e-9);
       setBackgroundField(bgField, BgBGrid);
    }
 

--- a/projects/test_trans/test_trans.cpp
+++ b/projects/test_trans/test_trans.cpp
@@ -123,7 +123,7 @@ namespace projects {
 
    void test_trans::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void test_trans::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   void test_trans::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                      FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                      FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;

--- a/projects/test_trans/test_trans.h
+++ b/projects/test_trans/test_trans.h
@@ -34,14 +34,12 @@ namespace projects {
       test_trans();
       virtual ~test_trans();
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 
    protected:
       Real getDistribValue(creal& vx, creal& vy, creal& vz);

--- a/projects/test_trans/test_trans.h
+++ b/projects/test_trans/test_trans.h
@@ -37,7 +37,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/projects/test_trans/test_trans.h
+++ b/projects/test_trans/test_trans.h
@@ -34,9 +34,9 @@ namespace projects {
       test_trans();
       virtual ~test_trans();
 
-      virtual bool initialize(void);
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/verificationLarmor/verificationLarmor.cpp
+++ b/projects/verificationLarmor/verificationLarmor.cpp
@@ -114,7 +114,7 @@ namespace projects {
    void verificationLarmor::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
    void
-   verificationLarmor::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+   verificationLarmor::setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                         FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;

--- a/projects/verificationLarmor/verificationLarmor.cpp
+++ b/projects/verificationLarmor/verificationLarmor.cpp
@@ -38,7 +38,6 @@ using namespace spatial_cell;
 namespace projects {
    verificationLarmor::verificationLarmor(): Project() { }
    verificationLarmor::~verificationLarmor() { }
-   bool verificationLarmor::initialize(void) {return Project::initialize();}
 
    void verificationLarmor::addParameters() {
       typedef Readparameters RP;
@@ -73,6 +72,8 @@ namespace projects {
       RP::get("VerificationLarmor.Z0", this->Z0);
       RP::get("VerificationLarmor.rho", this->DENSITY);
    }
+
+   void verificationLarmor::initialize() { initialized = true; }
 
    Real verificationLarmor::calcPhaseSpaceDensity(creal& x, creal& y, creal& z, creal& dx, creal& dy, creal& dz,
            creal& vx, creal& vy, creal& vz, creal& dvx, creal& dvy, creal& dvz,const uint popID) const {

--- a/projects/verificationLarmor/verificationLarmor.cpp
+++ b/projects/verificationLarmor/verificationLarmor.cpp
@@ -113,16 +113,13 @@ namespace projects {
 
    void verificationLarmor::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) { }
 
-   void verificationLarmor::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-   ) {
+   void
+   verificationLarmor::setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                                        FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                        FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
       ConstantField bgField;
-      bgField.initialize(this->BX0,
-                         this->BY0,
-                         this->BZ0);
-      
+      bgField.initialize(this->BX0, this->BY0, this->BZ0);
+
       setBackgroundField(bgField, BgBGrid);
    }
 

--- a/projects/verificationLarmor/verificationLarmor.h
+++ b/projects/verificationLarmor/verificationLarmor.h
@@ -33,10 +33,10 @@ namespace projects {
    public:
       verificationLarmor();
       virtual ~verificationLarmor();
-      
-      virtual bool initialize(void);
+
       static void addParameters(void);
       virtual void getParameters(void);
+      void initialize() override;
       virtual void setProjectBField(
          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
          FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,

--- a/projects/verificationLarmor/verificationLarmor.h
+++ b/projects/verificationLarmor/verificationLarmor.h
@@ -34,14 +34,13 @@ namespace projects {
       verificationLarmor();
       virtual ~verificationLarmor();
 
-      static void addParameters(void);
-      virtual void getParameters(void);
+      static void addParameters();
+      virtual void getParameters();
       void initialize() override;
-      virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
+      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
+
    protected:
       Real getDistribValue(creal& vx, creal& vy, creal& vz, const uint popID) const;
       virtual void calcCellParameters(spatial_cell::SpatialCell* cell,creal& t);

--- a/projects/verificationLarmor/verificationLarmor.h
+++ b/projects/verificationLarmor/verificationLarmor.h
@@ -37,7 +37,7 @@ namespace projects {
       static void addParameters();
       virtual void getParameters();
       void initialize() override;
-      void setProjectBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+      void setInitialBField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) override;
 

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -288,8 +288,6 @@ int main(int argn,char* args[]) {
    signal(SIGFPE, fpehandler);
    #endif
 
-
-
    phiprof::start("main");
    phiprof::start("Initialization");
    phiprof::start("Read parameters");
@@ -317,9 +315,6 @@ int main(int argn,char* args[]) {
    sysBoundaries.getParameters();
    phiprof::stop("Read parameters");
 
-
-
-
    //Get version and config info here
    std::string version;
    std::string config;
@@ -328,8 +323,6 @@ int main(int argn,char* args[]) {
       version=readparameters.versionInfo();
       config=readparameters.configInfo();
    }
-
-
 
    // Init parallel logger:
    phiprof::start("open logFile & diagnostic");
@@ -363,7 +356,7 @@ int main(int argn,char* args[]) {
    if (!project->isInitialized()) {
       if (myRank == MASTER_RANK) {
          cerr << "(MAIN): Project class was not initialized!" << endl;
-         exit(1);
+         MPI_Abort(MPI_COMM_WORLD, 1);
       }
    }
    phiprof::stop("Init project");

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -359,14 +359,10 @@ int main(int argn,char* args[]) {
    
    // Init project
    phiprof::start("Init project");
-   if (project->initialize() == false) {
-      if(myRank == MASTER_RANK) cerr << "(MAIN): Project did not initialize correctly!" << endl;
-      exit(1);
-   }
-   if (project->initialized() == false) {
+   project->initialize();
+   if (!project->isInitialized()) {
       if (myRank == MASTER_RANK) {
-         cerr << "(MAIN): Project base class was not initialized!" << endl;
-         cerr << "\t Call Project::initialize() in your project's initialize()-function." << endl;
+         cerr << "(MAIN): Project class was not initialized!" << endl;
          exit(1);
       }
    }


### PR DESCRIPTION
This PR aims at clarifying the initialization step for projects. `initialize()` is required for projects because extra parameters may be read for a specific project which are then used to set the internal parameters; otherwise all the initialization should be done in the class constructors. In order to reflect the sequences, `initialize()` is moved after `addParameters()` and `setParameters()`. `initialize()` is enforced for the inherited classes by setting `virtual void initialize() = 0` in the base class. Similarly, `setProjectBField()` is enforced for the inherited classes and renamed to `setInitialBField` to reflect its purpose.