### PR TITLE
Fix setCell comments

### DIFF
--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -512,7 +512,7 @@ namespace projects {
    }
 
    /*
-     Refine cells of mpiGrid. Each project that wants refinement shoudl implement this function. 
+     Refine cells of mpiGrid. Each project that wants refinement should implement this function. 
      Base class function prints a warning and does nothing.
     */
    bool Project::refineSpatialCells( dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid ) const {

--- a/projects/project.h
+++ b/projects/project.h
@@ -77,7 +77,6 @@ namespace projects {
 
       /*!\brief Set the perturbed fields and distribution of a cell according to the default simulation settings.
        * This is used for the NOT_SYSBOUNDARY cells and some other system boundary conditions (e.g. Outflow).
-       * NOTE: This function is called inside parallel region so it must be declared as const.
        * \param cell Pointer to the cell to set.
        */
       void setCell(spatial_cell::SpatialCell* cell);


### PR DESCRIPTION
The `setCell` method does not (and should not) be declared as `const`.