### PR TITLE
Define -DIONOSPHERE_SORTED_SUMS flag to solve the ionosphere with sorted threaded sums.

### DIFF
--- a/MAKE/Makefile.Freezer
+++ b/MAKE/Makefile.Freezer
@@ -31,7 +31,7 @@ CC_BRAND = gcc
 CC_BRAND_VERSION = 6.2.0
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -mavx2
 #CXXFLAGS += -ggdb -O0 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -mavx2
-testpackage: CXXFLAGS = -g -ggdb -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mno-avx -mno-fma -fno-unsafe-math-optimizations
+testpackage: CXXFLAGS = -g -ggdb -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mno-avx -mno-fma -fno-unsafe-math-optimizations -DIONOSPHERE_SORTED_SUMS
 
 MATHFLAGS = -ffast-math
 testpackage: MATHFLAGS =  -fno-unsafe-math-optimizations

--- a/MAKE/Makefile.carrington_gcc_openmpi
+++ b/MAKE/Makefile.carrington_gcc_openmpi
@@ -69,7 +69,7 @@ FLAGS =
 CC_BRAND = gcc
 CC_BRAND_VERSION = 9.4.0
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2 #-flto
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2 -DIONOSPHERE_SORTED_SUMS
 CXXFLAGS += -Wall -Wextra -Wno-unused
 
 MATHFLAGS = -ffast-math

--- a/MAKE/Makefile.docker
+++ b/MAKE/Makefile.docker
@@ -22,7 +22,7 @@ FLAGS =
 
 #GNU flags:
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -mavx2
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mavx
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mavx -DIONOSPHERE_SORTED_SUMS
 
 MATHFLAGS = -ffast-math
 LDFLAGS = -g

--- a/MAKE/Makefile.hawk_gcc_mpt
+++ b/MAKE/Makefile.hawk_gcc_mpt
@@ -47,7 +47,7 @@ CC_BRAND_VERSION = 9.2.0_bis
 CXXFLAGS += -g -fopenmp -O3 -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -Wall -Wpedantic -mfma -march=native -mavx2
 #CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -mavx
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
-testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 
+testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -DIONOSPHERE_SORTED_SUMS
 not_parallel_tools: CC_BRAND_VERSION = 4.9.2-noavx2
 
 MATHFLAGS = -ffast-math

--- a/MAKE/Makefile.hawk_gcc_openmpi
+++ b/MAKE/Makefile.hawk_gcc_openmpi
@@ -28,7 +28,7 @@ CC_BRAND = gcc
 CC_BRAND_VERSION = 9.2.0
 CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -Wall -Wpedantic -mfma -march=native -mavx2
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
-testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 
+testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -DIONOSPHERE_SORTED_SUMS
 not_parallel_tools: CC_BRAND_VERSION = 4.9.2-noavx2
 
 MATHFLAGS = -ffast-math

--- a/MAKE/Makefile.hawk_intel_mpt
+++ b/MAKE/Makefile.hawk_intel_mpt
@@ -28,7 +28,7 @@ CC_BRAND = intel
 CC_BRAND_VERSION = 19.1.0
 # note: std was not updated to c++17
 CXXFLAGS += -traceback -g -O3 -qopenmp -std=c++14 -W -Wall -Wno-unused -march=core-avx2 -qopt-zmm-usage=high
-testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++14 -W -Wno-unused -march=core-avx2
+testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++14 -W -Wno-unused -march=core-avx2 -DIONOSPHERE_SORTED_SUMS
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
 not_parallel_tools: CC_BRAND_VERSION = 4.9.2-noavx2
 

--- a/MAKE/Makefile.hawk_intel_openmpi
+++ b/MAKE/Makefile.hawk_intel_openmpi
@@ -28,7 +28,7 @@ CC_BRAND = intel
 CC_BRAND_VERSION = 19.1.0
 #note: std was not updated to c++17
 CXXFLAGS += -traceback -g -O3 -qopenmp -std=c++14 -W -Wall -Wno-unused -march=core-avx2 -qopt-zmm-usage=high
-testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++14 -W -Wno-unused -march=core-avx2
+testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++14 -W -Wno-unused -march=core-avx2 -DIONOSPHERE_SORTED_SUMS
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
 not_parallel_tools: CC_BRAND_VERSION = 4.9.2-noavx2
 

--- a/MAKE/Makefile.kstppd
+++ b/MAKE/Makefile.kstppd
@@ -26,7 +26,7 @@ endif
 
 FLAGS =
 CXXFLAGS = -O3   -funroll-loops -std=c++17 -fopenmp -W -Wall -Wno-unused -Wno-unused-parameter -Wno-missing-braces -fabi-version=0 -mavx
-testpackage: CXXFLAGS = -g -ggdb -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mno-avx -mno-fma -fno-unsafe-math-optimizations
+testpackage: CXXFLAGS = -g -ggdb -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mno-avx -mno-fma -fno-unsafe-math-optimizations -DIONOSPHERE_SORTED_SUMS
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE -DPAPI_MEM
 MATHFLAGS = -ffast-math
 testpackage: MATHFLAGS =  -fno-unsafe-math-optimizations

--- a/MAKE/Makefile.mahti_gcc
+++ b/MAKE/Makefile.mahti_gcc
@@ -24,7 +24,7 @@ FLAGS =
 CC_BRAND = gcc
 CC_BRAND_VERSION = 9.3.0
 CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -march=native -mfma -mavx2
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -mfma
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -mfma -DIONOSPHERE_SORTED_SUMS
 
 MATHFLAGS = -ffast-math
 LDFLAGS = -lrt

--- a/MAKE/Makefile.marconi
+++ b/MAKE/Makefile.marconi
@@ -30,7 +30,7 @@ CC_BRAND = intel
 CC_BRAND_VERSION = 17.0.1
 # note: std was c++11
 CXXFLAGS +=  -O2 -g -DMAX_VECTOR_SIZE=512 -xMIC-AVX512 -std=c++17 -qopenmp -ansi-alias
-testpackage: CXXFLAGS = -O2 -g -DMAX_VECTOR_SIZE=512 -xMIC-AVX512 -std=c++17 -qopenmp -ansi-alias
+testpackage: CXXFLAGS = -O2 -g -DMAX_VECTOR_SIZE=512 -xMIC-AVX512 -std=c++17 -qopenmp -ansi-alias -DIONOSPHERE_SORTED_SUMS
 MATHFLAGS = 
 LDFLAGS += -qopenmp -lifcore -Wl,-rpath,/cineca/prod/opt/libraries/boost/1.61.0/intelmpi--2017--binary/lib,-rpath,/marconi_work/Pra14_3521/libraries/phiprof/lib,-rpath,/marconi_work/Pra14_3521/libraries/papi/lib
 CMP = mpicxx

--- a/MAKE/Makefile.puhti_gcc
+++ b/MAKE/Makefile.puhti_gcc
@@ -22,7 +22,7 @@ FLAGS =
 CC_BRAND = gcc
 CC_BRAND_VERSION = 9.1.0
 CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -march=native -mfma -mavx512f
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -mfma
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -mfma -DIONOSPHERE_SORTED_SUMS
 
 MATHFLAGS = -ffast-math
 LDFLAGS = -lrt

--- a/MAKE/Makefile.puhti_intel
+++ b/MAKE/Makefile.puhti_intel
@@ -22,7 +22,7 @@ FLAGS =
 CC_BRAND = intel
 CC_BRAND_VERSION = 19.0.4
 CXXFLAGS += -traceback -g -O3 -qopenmp -std=c++17 -W -Wall -Wno-unused -xHost -ipo -qopt-zmm-usage=high 
-testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++17 -W -Wno-unused -xHost -ipo
+testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++17 -W -Wno-unused -xHost -ipo -DIONOSPHERE_SORTED_SUMS
 
 MATHFLAGS = -ffast-math
 LDFLAGS = -qopenmp -lifcore -ipo

--- a/MAKE/Makefile.puhti_pgi
+++ b/MAKE/Makefile.puhti_pgi
@@ -22,7 +22,7 @@ FLAGS =
 CC_BRAND = pgi
 CC_BRAND_VERSION = 19.7
 CXXFLAGS += -g -O3 -acc -D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1 -Minfo=accel
-testpackage: CXXFLAGS = -g -O2 -acc -D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1 -Minfo=accel
+testpackage: CXXFLAGS = -g -O2 -acc -D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1 -Minfo=accel -DIONOSPHERE_SORTED_SUMS
 
 MATHFLAGS =
 LDFLAGS = -O3 -acc -g

--- a/MAKE/Makefile.ukko_gcc_openmpi
+++ b/MAKE/Makefile.ukko_gcc_openmpi
@@ -68,7 +68,7 @@ FLAGS =
 CC_BRAND = gcc
 CC_BRAND_VERSION = 9.4.0
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mavx -march=znver2 #-flto
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2 -DIONOSPHERE_SORTED_SUMS
 
 MATHFLAGS = -ffast-math
 LDFLAGS = -lrt -lgfortran -std=c++17 -lgomp

--- a/MAKE/Makefile.vorna_gcc
+++ b/MAKE/Makefile.vorna_gcc
@@ -35,7 +35,7 @@ FLAGS =
 CC_BRAND = gcc
 CC_BRAND_VERSION = 10.2.0
 CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -mavx
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx -DIONOSPHERE_SORTED_SUMS
 CXXFLAGS += -Wall -Wextra -Wno-unused
 
 MATHFLAGS = -ffast-math

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ COMPFLAGS += -DPROFILE
 
 #Add -DNDEBUG to turn debugging off. If debugging is enabled performance will degrade significantly
 COMPFLAGS += -DNDEBUG
+# CXXFLAGS += -DIONOSPHERE_SORTED_SUMS
 # CXXFLAGS += -DDEBUG_SOLVERS
 # CXXFLAGS += -DDEBUG_IONOSPHERE
 

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -2478,7 +2478,11 @@ namespace SBC {
          sourcenorm = 0;
       }
       // Calculate sourcenorm and initial residual estimate
+#ifdef IONOSPHERE_SORTED_SUMS
       #pragma omp for
+#else
+      #pragma omp for reduction(+:sourcenorm)
+#endif
       for(uint n=0; n<nodes.size(); n++) {
          Node& N=nodes[n];
          // Set gauge-pinned nodes to their fixed potential
@@ -2555,8 +2559,10 @@ namespace SBC {
 #ifdef IONOSPHERE_SORTED_SUMS
          thread_set_pos.clear();
          thread_set_neg.clear();
-#endif
          #pragma omp for
+#else
+         #pragma omp for reduction(+:bknum)
+#endif
          for(uint n=0; n<nodes.size(); n++) {
             Node& N=nodes[n];
             const iSolverReal incr = N.parameters[ionosphereParameters::ZPARAM] * N.parameters[ionosphereParameters::RRESIDUAL];
@@ -2631,9 +2637,10 @@ namespace SBC {
 #ifdef IONOSPHERE_SORTED_SUMS
          thread_set_neg.clear();
          thread_set_pos.clear();
-#endif
-
          #pragma omp for
+#else
+         #pragma omp for reduction(+:akden)
+#endif
          for(uint n=0; n<nodes.size(); n++) {
             Node& N=nodes[n];
             iSolverReal zparam = Atimes(n, ionosphereParameters::PPARAM, false);
@@ -2723,8 +2730,10 @@ namespace SBC {
          }
 #ifdef IONOSPHERE_SORTED_SUMS
          thread_set_pos.clear();
-#endif
          #pragma omp for
+#else
+         #pragma omp for reduction(+:residualnorm)
+#endif
          for(uint n=0; n<nodes.size(); n++) {
             Node& N=nodes[n];
             // Calculate residual of the new solution. The faster way to do this would be


### PR DESCRIPTION
This is added to all testpackage flag sets in the Makefiles.

I was able to compile both without and with the flag but it is not run-tested.

@alhom it would be great as part of the setup performance testing if you could run a pair without and with this flag (maybe both testpackage actually?) and some ionosphere solving. The goal is to get a massively better performance of the ionosphere solver with "palatable" diffs (e.g. potential values reported in the logfile will differ at the 1e-5 or 1e-6 level unless I botched something).