### PR TITLE
Fix conductingsphere temperature value in Magnetosphere_polar_small test

### DIFF
--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -242,13 +242,13 @@ namespace projects {
          }
          if(sP.ionosphereT == 0) {
             if(myRank == MASTER_RANK) {
-               cerr << "Warning: " << pop << "_ionosphere.T is zero (default), now setting to the same value as " << pop << "_Magnetosphere.T, that is " << sP.T << ". Set/change " << pop << "_ionosphere.T if this is not the expected behavior." << endl;
+               cerr << "Warning: " << pop << "_(iono/conducting)sphere.T is zero (default), now setting to the same value as " << pop << "_Magnetosphere.T, that is " << sP.T << ". Set/change " << pop << "_(iono/conducting)sphere.T if this is not the expected behavior." << endl;
             }
             sP.ionosphereT = sP.T;
          }
          if(sP.ionosphereRho == 0) {
             if(myRank == MASTER_RANK) {
-               cerr << "Warning: " << pop << "_ionosphere.rho is zero (default), now setting to the same value as " << pop << "_Magnetosphere.rho, that is " << sP.rho << ". Set/change " << pop << "_ionosphere.rho if this is not the expected behavior." << endl;
+               cerr << "Warning: " << pop << "_(iono/conducting)sphere.rho is zero (default), now setting to the same value as " << pop << "_Magnetosphere.rho, that is " << sP.rho << ". Set/change " << pop << "_(iono/conducting)sphere.rho if this is not the expected behavior." << endl;
             }
             sP.ionosphereRho = sP.rho;
          }

--- a/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
+++ b/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
@@ -99,6 +99,7 @@ precedence = 2
 
 [proton_conductingsphere]
 rho = 1.0e6
+T=100000.0
 VX0 = 0.0
 VY0 = 0.0
 VZ0 = 0.0

--- a/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
+++ b/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
@@ -99,7 +99,7 @@ precedence = 2
 
 [proton_conductingsphere]
 rho = 1.0e6
-T=100000.0
+T = 0.5e6
 VX0 = 0.0
 VY0 = 0.0
 VZ0 = 0.0


### PR DESCRIPTION
Also, make the warning for a zero-valued ionosphere temperature a little more up-to-date w.r.t. parameter names.