### PR TITLE
Warnings reduction after dAMR merge.

### DIFF
--- a/common.h
+++ b/common.h
@@ -378,7 +378,7 @@ namespace fsgrids {
    };
    
    struct technical {
-      int sysBoundaryFlag;  /*!< System boundary flags. */
+      uint sysBoundaryFlag;  /*!< System boundary flags. */
       int sysBoundaryLayer; /*!< System boundary layer index. */
       Real maxFsDt;         /*!< maximum timestep allowed in ordinary space by fieldsolver for this cell**/
       int fsGridRank;       /*!< Rank in the fsGrids cartesian coordinator */

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -669,7 +669,7 @@ void calculateScaledDeltasSimple(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geome
    phiprof::start(timer);
    
    #pragma omp parallel for
-   for (int i = 0; i < cells.size(); ++i) {
+   for (uint i = 0; i < cells.size(); ++i) {
    //for (CellID id : cells) {
       CellID id = cells[i];
       SpatialCell* cell = mpiGrid[id];

--- a/grid.cpp
+++ b/grid.cpp
@@ -233,14 +233,14 @@ void initializeGrids(
 
       if (P::forceRefinement) {
          phiprof::start("Restart refinement");
-         for (int i = 0; i < P::amrMaxSpatialRefLevel; ++i) {
+         for (uint i = 0; i < P::amrMaxSpatialRefLevel; ++i) {
             adaptRefinement(mpiGrid, technicalGrid, sysBoundaries, project, true);
             balanceLoad(mpiGrid, sysBoundaries);
          }
          phiprof::stop("Restart refinement");
       } else if (P::refineOnRestart) {
          phiprof::start("Restart refinement");
-         for (int i = 0; i < P::amrMaxSpatialRefLevel; ++i) {
+         for (uint i = 0; i < P::amrMaxSpatialRefLevel; ++i) {
             adaptRefinement(mpiGrid, technicalGrid, sysBoundaries, project);
             balanceLoad(mpiGrid, sysBoundaries);
          }

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -1111,7 +1111,7 @@ bool writeVelocitySpace(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
       // Loop over AMR levels
       uint startindex=1;
       uint endindex=1;
-      for (int AMR = 0; AMR <= P::amrMaxSpatialRefLevel; AMR++) {
+      for (uint AMR = 0; AMR <= P::amrMaxSpatialRefLevel; AMR++) {
          int AMRm = 1u << AMR;
          uint cellsthislevel = (AMRm * P::xcells_ini) * (AMRm*P::ycells_ini) * (AMRm * P::zcells_ini);
          startindex = endindex;

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -628,7 +628,7 @@ void Parameters::getParameters() {
       bool isEmpty = blurPassString.size() == 0;
       if (!isEmpty){
          //sanity check=> user should define a pass for every level
-         if (static_cast<int>(blurPassString.size()) != P::amrMaxSpatialRefLevel + 1) {
+         if (blurPassString.size() != P::amrMaxSpatialRefLevel + 1) {
             cerr << "Filter Passes=" << blurPassString.size() << "\t" << "AMR Levels=" << P::amrMaxSpatialRefLevel + 1 << endl;
             cerr << "FilterPasses do not match AMR levels. \t" << " in " << __FILE__ << ":" << __LINE__ << endl;
             MPI_Abort(MPI_COMM_WORLD, 1);
@@ -652,7 +652,7 @@ void Parameters::getParameters() {
             return retval;
          };
          int maxPasses=g_sequence(P::amrMaxSpatialRefLevel-1);
-         for (int refLevel=0; refLevel<=P::amrMaxSpatialRefLevel; refLevel++){
+         for (uint refLevel=0; refLevel<=P::amrMaxSpatialRefLevel; refLevel++){
             numPasses.push_back(maxPasses);
             maxPasses/=2; 
          }

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -585,7 +585,7 @@ namespace projects {
       // L1 refinement.
       if (P::amrMaxSpatialRefLevel > 0) {
          //#pragma omp parallel for
-         for (int i = 0; i < cells.size(); ++i) {
+         for (uint i = 0; i < cells.size(); ++i) {
             CellID id = cells[i];
             std::array<double,3> xyz = mpiGrid.get_center(id);
                      
@@ -606,13 +606,13 @@ namespace projects {
          if (cells.size() > 0) {
             std::cout << "Rank " << myRank << " refined " << cells.size() << " cells to level 1" << std::endl;
          }
-         #endif NDEBUG
+         #endif //NDEBUG
       }
       
       // L2 refinement.
       if (P::amrMaxSpatialRefLevel > 1) {
          //#pragma omp parallel for
-         for (int i = 0; i < cells.size(); ++i) {
+         for (uint i = 0; i < cells.size(); ++i) {
             CellID id = cells[i];
             std::array<double,3> xyz = mpiGrid.get_center(id);
                      
@@ -632,14 +632,14 @@ namespace projects {
          if (cells.size() > 0) {
             std::cout << "Rank " << myRank << " refined " << cells.size() << " cells to level 2" << std::endl;
          }
-         #endif NDEBUG
+         #endif //NDEBUG
 
       }
       
       // L3 refinement.
       if (P::amrMaxSpatialRefLevel > 2) {
          //#pragma omp parallel for
-         for (int i = 0; i < cells.size(); ++i) {
+         for (uint i = 0; i < cells.size(); ++i) {
             CellID id = cells[i];
             std::array<double,3> xyz = mpiGrid.get_center(id);
                      
@@ -659,13 +659,13 @@ namespace projects {
          if (cells.size() > 0) {
             std::cout << "Rank " << myRank << " refined " << cells.size() << " cells to level 3" << std::endl;
          }
-         #endif NDEBUG
+         #endif //NDEBUG
       }
 
       // L4 refinement.
       if (P::amrMaxSpatialRefLevel > 3) {
          //#pragma omp parallel for
-         for (int i = 0; i < cells.size(); ++i) {
+         for (uint i = 0; i < cells.size(); ++i) {
             CellID id = cells[i];
             std::array<double,3> xyz = mpiGrid.get_center(id);
                      
@@ -687,7 +687,7 @@ namespace projects {
          if (cells.size() > 0) {
             std::cout << "Rank " << myRank << " refined " << cells.size() << " cells to level 4" << std::endl;
          }
-         #endif NDEBUG
+         #endif //NDEBUG
       }
 
       return true;
@@ -706,7 +706,7 @@ namespace projects {
       Real r_max2 {pow(P::refineRadius, 2)};
 
       //#pragma omp parallel for
-      for (int j = 0; j < cells.size(); ++j) {
+      for (uint j = 0; j < cells.size(); ++j) {
          CellID id {cells[j]};
          std::array<double,3> xyz {mpiGrid.get_center(id)};
          SpatialCell* cell {mpiGrid[id]};

--- a/sysboundary/setbyuser.cpp
+++ b/sysboundary/setbyuser.cpp
@@ -288,7 +288,7 @@ namespace SBC {
          std::array<bool, 6> isThisCellOnAFace;
          determineFace(isThisCellOnAFace, mpiGrid, id);
 
-         int max = 6;
+         uint max = 6;
          for (uint i=0; i < max; i++) {
             if (facesToProcess[i] && isThisCellOnAFace[i]) {
                copyCellData(&templateCells[i], cell ,false,popID,true); // copy also vdf, _V

--- a/sysboundary/setbyuser.cpp
+++ b/sysboundary/setbyuser.cpp
@@ -288,7 +288,7 @@ namespace SBC {
          std::array<bool, 6> isThisCellOnAFace;
          determineFace(isThisCellOnAFace, mpiGrid, id);
 
-         for (uint i=6; i < max; i++) {
+         for (uint i=0; i < 6; i++) {
             if (facesToProcess[i] && isThisCellOnAFace[i]) {
                copyCellData(&templateCells[i], cell ,false,popID,true); // copy also vdf, _V
                copyCellData(&templateCells[i], cell ,true,popID,false); // don't copy vdf again but copy _R now

--- a/sysboundary/setbyuser.cpp
+++ b/sysboundary/setbyuser.cpp
@@ -288,12 +288,11 @@ namespace SBC {
          std::array<bool, 6> isThisCellOnAFace;
          determineFace(isThisCellOnAFace, mpiGrid, id);
 
-         uint max = 6;
-         for (uint i=0; i < max; i++) {
+         for (uint i=6; i < max; i++) {
             if (facesToProcess[i] && isThisCellOnAFace[i]) {
                copyCellData(&templateCells[i], cell ,false,popID,true); // copy also vdf, _V
                copyCellData(&templateCells[i], cell ,true,popID,false); // don't copy vdf again but copy _R now
-               max = i; // This effectively sets the precedence of faces through the order of faces.
+               break; // This effectively sets the precedence of faces through the order of faces.
             }
          }
       }

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -616,7 +616,7 @@ int main(int argn,char* args[]) {
       //report filtering if we are in an AMR run 
       if (P::amrMaxSpatialRefLevel>0){
          logFile<<"Filtering Report: "<<endl;
-         for (int refLevel=0 ; refLevel<= P::amrMaxSpatialRefLevel; refLevel++){
+         for (uint refLevel=0 ; refLevel<= P::amrMaxSpatialRefLevel; refLevel++){
             logFile<<"\tRefinement Level " <<refLevel<<"==> Passes "<<P::numPasses.at(refLevel)<<endl;
          }
             logFile<<endl;


### PR DESCRIPTION
The dynamic AMR merge (PR #497) introduced a couple of new compiler warnings, mostly signed/unsigned comparisons.

This PR cleans them up again.