### PR TITLE
Fix sample filtering passes

### DIFF
--- a/samples/Magnetosphere3D/Magnetosphere3D.cfg
+++ b/samples/Magnetosphere3D/Magnetosphere3D.cfg
@@ -14,10 +14,6 @@ max_memory = 58 # set based on system
 
 [AMR]
 max_spatial_level = 3
-filterpasses = 0
-filterpasses = 2
-filterpasses = 4
-filterpasses = 8
 
 [io]
 diagnostic_write_interval = 10

--- a/testpackage/tests/Ionosphere_small/Ionosphere_small.cfg
+++ b/testpackage/tests/Ionosphere_small/Ionosphere_small.cfg
@@ -2,14 +2,8 @@ project = Magnetosphere
 ParticlePopulations = proton
 dynamic_timestep = 1
 
-#[AMR]
-#max_spatial_level=1
 [AMR]
 max_spatial_level=1
-filterpasses = 0
-filterpasses = 2
-#filterpasses = 4
-#filterpasses = 8
 
 [proton_properties]
 mass = 1

--- a/testpackage/tests/Magnetosphere_3D_small/Magnetosphere_3D_small.cfg
+++ b/testpackage/tests/Magnetosphere_3D_small/Magnetosphere_3D_small.cfg
@@ -91,6 +91,7 @@ precedence = 2
 
 [proton_conductingsphere]
 rho = 1.0e6
+T = 0.5e6
 
 [outflow]
 precedence = 3


### PR DESCRIPTION
Some config files still had manual AMR filtering passes set according to the boxcar filter, which is outdated.