### PR TITLE
LUMI Cray compilers complain 

### DIFF
--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -2858,13 +2858,13 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "ig_precipnumflux") {
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_precipnumflux", [](SBC::SphericalTriGrid& grid)->std::vector<Real> {
 
-                     std::array< Real, grid.productionNumParticleEnergies+1 > particle_energy;
+                     std::array< Real, SBC::productionNumParticleEnergies+1 > particle_energy;
                      // Precalculate effective energy bins
                      // Make sure this stays in sync with sysboundary/ionosphere.cpp
-                     for(int e=0; e<grid.productionNumParticleEnergies; e++) {
-                     particle_energy[e] = pow(10.0, -1.+e*(2.3+1.)/(grid.productionNumParticleEnergies-1));
+                     for(int e=0; e<SBC::productionNumParticleEnergies; e++) {
+                     particle_energy[e] = pow(10.0, -1.+e*(2.3+1.)/(SBC::productionNumParticleEnergies-1));
                      }
-                     particle_energy[grid.productionNumParticleEnergies] = 2*particle_energy[grid.productionNumParticleEnergies-1] - particle_energy[grid.productionNumParticleEnergies-2];
+                     particle_energy[SBC::productionNumParticleEnergies] = 2*particle_energy[SBC::productionNumParticleEnergies-1] - particle_energy[SBC::productionNumParticleEnergies-2];
 
                      Real accenergy = grid.productionMinAccEnergy;
 
@@ -2872,7 +2872,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                      for(uint i=0; i<grid.nodes.size(); i++) {
                         Real temp_keV = physicalconstants::K_B * grid.nodes[i].electronTemperature() / physicalconstants::CHARGE / 1000;
 
-                        for(int p=0; p<grid.productionNumParticleEnergies; p++) {
+                        for(int p=0; p<SBC::productionNumParticleEnergies; p++) {
                            Real energyparam = (particle_energy[p]-accenergy)/temp_keV; // = E_p / (kB T)
                            Real deltaE = (particle_energy[p+1] - particle_energy[p])* 1e3*physicalconstants::CHARGE;  // dE in J
                            retval[i] += grid.nodes[i].parameters[ionosphereParameters::RHON] * sqrt(1. / (2. * M_PI * physicalconstants::MASS_ELECTRON))
@@ -2888,13 +2888,13 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "ig_precipavgenergy") {
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_precipavgenergy", [](SBC::SphericalTriGrid& grid)->std::vector<Real> {
 
-                     std::array< Real, grid.productionNumParticleEnergies+1 > particle_energy;
+                     std::array< Real, SBC::productionNumParticleEnergies+1 > particle_energy;
                      // Precalculate effective energy bins
                      // Make sure this stays in sync with sysboundary/ionosphere.cpp
-                     for(int e=0; e<grid.productionNumParticleEnergies; e++) {
-                     particle_energy[e] = pow(10.0, -1.+e*(2.3+1.)/(grid.productionNumParticleEnergies-1));
+                     for(int e=0; e<SBC::productionNumParticleEnergies; e++) {
+                     particle_energy[e] = pow(10.0, -1.+e*(2.3+1.)/(SBC::productionNumParticleEnergies-1));
                      }
-                     particle_energy[grid.productionNumParticleEnergies] = 2*particle_energy[grid.productionNumParticleEnergies-1] - particle_energy[grid.productionNumParticleEnergies-2];
+                     particle_energy[SBC::productionNumParticleEnergies] = 2*particle_energy[SBC::productionNumParticleEnergies-1] - particle_energy[SBC::productionNumParticleEnergies-2];
 
                      Real accenergy = grid.productionMinAccEnergy;
 
@@ -2907,7 +2907,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                         // ig_precipnumflux reducer above. Share code?)
                         Real temp_keV = physicalconstants::K_B * grid.nodes[i].electronTemperature() / physicalconstants::CHARGE / 1000;
 
-                        for(int p=0; p<grid.productionNumParticleEnergies; p++) {
+                        for(int p=0; p<SBC::productionNumParticleEnergies; p++) {
                            Real energyparam = (particle_energy[p]-accenergy)/temp_keV; // = E_p / (kB T)
                            Real deltaE = (particle_energy[p+1] - particle_energy[p])* 1e3*physicalconstants::CHARGE;  // dE in J
                            numberFlux += grid.nodes[i].parameters[ionosphereParameters::RHON] * sqrt(1. / (2. * M_PI * physicalconstants::MASS_ELECTRON))

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -717,17 +717,17 @@ namespace SBC {
 
       // Energies of particles that sample the production array
       // are logspace-distributed from 10^-1 to 10^2.3 keV
-      std::array< Real, productionNumParticleEnergies+1 > particle_energy; // In KeV
-      for(int e=0; e<productionNumParticleEnergies; e++) {
+      std::array< Real, SBC::productionNumParticleEnergies+1 > particle_energy; // In KeV
+      for(int e=0; e<SBC::productionNumParticleEnergies; e++) {
          // TODO: Hardcoded constants. Make parameter?
-         particle_energy[e] = pow(10.0, -1.+e*(2.3+1.)/(productionNumParticleEnergies-1));
+         particle_energy[e] = pow(10.0, -1.+e*(2.3+1.)/(SBC::productionNumParticleEnergies-1));
       }
-      particle_energy[productionNumParticleEnergies] = 2*particle_energy[productionNumParticleEnergies-1] - particle_energy[productionNumParticleEnergies-2];
+      particle_energy[SBC::productionNumParticleEnergies] = 2*particle_energy[SBC::productionNumParticleEnergies-1] - particle_energy[SBC::productionNumParticleEnergies-2];
 
       // Precalculate scattering rates
       const Real eps_ion_keV = 0.035; // Energy required to create one ion
-      std::array< std::array< Real, numAtmosphereLevels >, productionNumParticleEnergies > scatteringRate;
-      for(int e=0;e<productionNumParticleEnergies; e++) {
+      std::array< std::array< Real, numAtmosphereLevels >, SBC::productionNumParticleEnergies > scatteringRate;
+      for(int e=0;e<SBC::productionNumParticleEnergies; e++) {
 
          Real electronRange=0.;
          Real rho_R=0.;
@@ -781,7 +781,7 @@ namespace SBC {
       }
 
       // Fill ionisation production table
-      std::array< Real, productionNumParticleEnergies > differentialFlux; // Differential flux
+      std::array< Real, SBC::productionNumParticleEnergies > differentialFlux; // Differential flux
 
       for(int e=0; e<productionNumAccEnergies; e++) {
 
@@ -792,7 +792,7 @@ namespace SBC {
             const Real productionTemperatureStep = (log10(productionMaxTemperature) - log10(productionMinTemperature)) / productionNumTemperatures;
             Real tempenergy = pow(10, productionMinTemperature + t*productionTemperatureStep); // In KeV
 
-            for(int p=0; p<productionNumParticleEnergies; p++) {
+            for(int p=0; p<SBC::productionNumParticleEnergies; p++) {
                // TODO: Kappa distribution here? Now only going for maxwellian
                Real energyparam = (particle_energy[p]-accenergy)/tempenergy; // = E_p / (kB T)
 
@@ -808,7 +808,7 @@ namespace SBC {
             }
             for(int h=0; h < numAtmosphereLevels; h++) {
                productionTable[h][e][t] = 0;
-               for(int p=0; p<productionNumParticleEnergies; p++) {
+               for(int p=0; p<SBC::productionNumParticleEnergies; p++) {
                   productionTable[h][e][t] += scatteringRate[p][h]*differentialFlux[p];
                }
             }

--- a/sysboundary/ionosphere.h
+++ b/sysboundary/ionosphere.h
@@ -37,6 +37,7 @@ using namespace std;
 
 namespace SBC {
 
+   constexpr static int productionNumParticleEnergies = 100;
    struct IonosphereSpeciesParameters {
       Real rho;
       Real V0[3];
@@ -166,7 +167,7 @@ namespace SBC {
       // TODO: Make these parameters?
       constexpr static int productionNumAccEnergies = 60;
       constexpr static int productionNumTemperatures = 60;
-      constexpr static int productionNumParticleEnergies = 100;
+      //constexpr static int productionNumParticleEnergies = 100;
       constexpr static Real productionMinAccEnergy = 0.1; // keV
       constexpr static Real productionMaxAccEnergy = 100.; // keV
       constexpr static Real productionMinTemperature = 0.1; // keV


### PR DESCRIPTION
Cray compilers on LUMI complain about ionosphere in datareduction: grid.productionNumParticleEnergies in a template argument (see below). Works on gnu toolchain, but not with cray, probably since grid is not a constexpr (even though the contained `int` is). Suggested solution: moving the constexpr to SBC namespace (or maybe elsewhere?). This anyway allows compilation on LUMI Cray as it is, now.

```
datareduction/datareducer.cpp:2861:40: error: non-type template argument is not a constant expression
                     std::array< Real, grid.productionNumParticleEnergies+1 > particle_energy;
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
datareduction/datareducer.cpp:2861:40: note: function parameter 'grid' with unknown value cannot be used in a constant expression
datareduction/datareducer.cpp:2859:128: note: declared here
         outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_precipnumflux", [](SBC::SphericalTriGrid& grid)->std::vector<Real> {
                                                                                                                               ^
                                                                                                                               ```