### PR TITLE
Fix filtering

### DIFF
--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -161,12 +161,7 @@ void filterMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                int refLevel = technicalGrid.get(i, j, k)->refLevel;
 
                // Skip pass
-               if (blurPass >= P::numPasses.at(refLevel) ||
-                  technicalGrid.get(i, j, k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
-                  (technicalGrid.get(i, j, k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY &&
-                  technicalGrid.get(i, j, k)->sysBoundaryLayer >= 2)
-               )
-               {
+               if (blurPass >= P::numPasses.at(refLevel) || technicalGrid.get(i, j, k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY) {
                   continue;
                }
 


### PR DESCRIPTION
Fixes filtering for outer boundaries with non-zero refinement level. Specifically the issue was that the filtering stencil filtered cells with boundarylayer 1, which segfaults on non-existing cells if the outer boundary cells are on the highest refinement level. The fix is to skip all sysboundary cells when filtering.