### PR TITLE
Lineprec dro

### DIFF
--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -410,7 +410,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          continue;
       }
       if(lowercase == "populations_precipitationflux" || lowercase == "populations_vg_precipitationdifferentialflux" || lowercase == "populations_precipitationdifferentialflux") {
-         // Per-population precipitation differential flux
+         // Per-population precipitation differential flux (within loss cone)
          for(unsigned int i =0; i < getObjectWrapper().particleSpecies.size(); i++) {
             species::Species& species=getObjectWrapper().particleSpecies[i];
             const std::string& pop = species.name;
@@ -418,6 +418,18 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
 	    std::stringstream conversion;
 	    conversion << (1.0e-4)*physicalconstants::CHARGE;
 	    outputReducer->addMetadata(outputReducer->size()-1,"1/(cm^2 sr s eV)","$\\mathrm{cm}^{-2}\\,\\mathrm{sr}^{-1}\\,\\mathrm{s}^{-1}\\,\\mathrm{eV}^{-1}$","$\\mathcal{F}_\\mathrm{"+pop+"}$",conversion.str());
+         }
+         continue;
+      }
+      if(lowercase == "populations_precipitationlineflux" || lowercase == "populations_vg_precipitationlinedifferentialflux" || lowercase == "populations_precipitationlinedifferentialflux") {
+         // Per-population precipitation differential flux (along line)
+         for(unsigned int i =0; i < getObjectWrapper().particleSpecies.size(); i++) {
+            species::Species& species=getObjectWrapper().particleSpecies[i];
+            const std::string& pop = species.name;
+            outputReducer->addOperator(new DRO::VariablePrecipitationLineDiffFlux(i));
+            std::stringstream conversion;
+            conversion << (1.0e-4)*physicalconstants::CHARGE;
+            outputReducer->addMetadata(outputReducer->size()-1,"1/(cm^2 sr s eV)","$\\mathrm{cm}^{-2}\\,\\mathrm{sr}^{-1}\\,\\mathrm{s}^{-1}\\,\\mathrm{eV}^{-1}$","$\\mathcal{F}_\\mathrm{"+pop+"}$",conversion.str());
          }
          continue;
       }

--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -1717,7 +1717,7 @@ namespace DRO {
                yGateCrit = (BnormV[1] - (VY - 0.5*BlockParams::DVY)) * (BnormV[1] - (VY + 0.5*BlockParams::DVY)) <= 0;
                zGateCrit = (BnormV[2] - (VZ - 0.5*BlockParams::DVZ)) * (BnormV[2] - (VZ + 0.5*BlockParams::DVZ)) <= 0;
                bool xyzGateCrit = xGateCrit && yGateCrit && zGateCrit;  // gate function: 1 if the line goes through the v-cell, else 0.
-               countAndGate = (Real) xyzGateCrit;
+               Real countAndGate = (Real) xyzGateCrit;
                const Real energy = 0.5 * getObjectWrapper().particleSpecies[popID].mass * normV*normV; // in SI
 
                // Find the correct energy bin number to update

--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -1713,9 +1713,12 @@ namespace DRO {
 
                // We will use a gate function based on criteria that Vi-0.5*DVi <= BnormV[i] <= Vi+0.5*DVi (for i=x,y,z or 0,1,2)
                bool xGateCrit, yGateCrit, zGateCrit;
-               xGateCrit = (BnormV[0] - (VX - 0.5*BlockParams::DVX)) * (BnormV[0] - (VX + 0.5*BlockParams::DVX)) <= 0;
-               yGateCrit = (BnormV[1] - (VY - 0.5*BlockParams::DVY)) * (BnormV[1] - (VY + 0.5*BlockParams::DVY)) <= 0;
-               zGateCrit = (BnormV[2] - (VZ - 0.5*BlockParams::DVZ)) * (BnormV[2] - (VZ + 0.5*BlockParams::DVZ)) <= 0;
+	       const Real _DVX= parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVX];
+               const Real _DVY= parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVY];
+               const Real _DVZ= parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVZ];
+               xGateCrit = (BnormV[0] - (VX - 0.5*_DVX)) * (BnormV[0] - (VX + 0.5*_DVX)) <= 0;
+               yGateCrit = (BnormV[1] - (VY - 0.5*_DVY)) * (BnormV[1] - (VY + 0.5*_DVY)) <= 0;
+               zGateCrit = (BnormV[2] - (VZ - 0.5*_DVZ)) * (BnormV[2] - (VZ + 0.5*_DVZ)) <= 0;
                bool xyzGateCrit = xGateCrit && yGateCrit && zGateCrit;  // gate function: 1 if the line goes through the v-cell, else 0.
                Real countAndGate = (Real) xyzGateCrit;
                const Real energy = 0.5 * getObjectWrapper().particleSpecies[popID].mass * normV*normV; // in SI

--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -1491,7 +1491,7 @@ namespace DRO {
       return true;
    }
 
-   /*! \brief Precipitation directional differential number flux
+   /*! \brief Precipitation directional differential number flux (within loss cone)
     * Evaluation of the precipitating differential flux (per population).
     * In a selected number (default: 16) of logarithmically spaced energy bins, the average of
     *      V*V/mass
@@ -1536,7 +1536,6 @@ namespace DRO {
 
       // Unit B-field direction
       creal normB = sqrt(B[0]*B[0] + B[1]*B[1] + B[2]*B[2]);
-      std::array<Real,3> b_unit;
       for (uint i=0; i<3; i++){
          B[i] /= normB;
       }
@@ -1624,6 +1623,146 @@ namespace DRO {
          if( vlsvWriter.writeParameter(popName+"_PrecipitationCentreEnergy"+std::to_string(i), &channelev) == false ) { return false; }
       }
       if( vlsvWriter.writeParameter(popName+"_LossConeAngle", &lossConeAngle) == false ) { return false; }
+      return true;
+   }
+
+   /*! \brief Precipitation directional differential number flux (along line)
+    * Evaluation of the precipitating differential flux (per population) targeted at low energies.
+    * In a selected number (default: 16) of logarithmically spaced energy bins, the average of
+    *      V*V/mass
+    * is calculated along (or antiparallel to) the magnetic field direction.
+    * The differential flux is converted in part. / cm^2 / s / sr / eV (unit used by observers).
+    * Parameters that can be set in cfg file under [{species}_precipitation]: nChannels, emin [eV], emax [eV]
+    * The energy channels are saved in bulk files as PrecipitationCentreEnergyLine{channel_number}.
+    */
+   VariablePrecipitationLineDiffFlux::VariablePrecipitationLineDiffFlux(cuint _popID): DataReductionOperatorHasParameters(),popID(_popID) {
+      popName = getObjectWrapper().particleSpecies[popID].name;
+      emin = getObjectWrapper().particleSpecies[popID].precipitationEmin;    // already converted to SI
+      emax = getObjectWrapper().particleSpecies[popID].precipitationEmax;    // already converted to SI
+      nChannels = getObjectWrapper().particleSpecies[popID].precipitationNChannels; // number of energy channels, logarithmically spaced between emin and emax
+      for (int i=0; i<nChannels; i++){
+         channels.push_back(emin * pow(emax/emin,(Real)i/(nChannels-1)));
+      }
+   }
+   VariablePrecipitationLineDiffFlux::~VariablePrecipitationLineDiffFlux() { }
+   
+   std::string VariablePrecipitationLineDiffFlux::getName() const {return popName + "/vg_precipitationlinedifferentialflux";}
+   
+   bool VariablePrecipitationLineDiffFlux::getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const {
+      dataType = "float";
+      dataSize =  sizeof(Real);
+      vectorSize = nChannels; //Number of energy channels
+      return true;
+   }
+   
+   bool VariablePrecipitationLineDiffFlux::reduceData(const SpatialCell* cell,char* buffer) {
+
+      dataLineDiffFlux.assign(nChannels,0.0);
+
+      std::vector<Real> sumWeights(nChannels,0.0);
+
+      std::array<Real,3> B;
+      B[0] = cell->parameters[CellParams::PERBXVOL] +  cell->parameters[CellParams::BGBXVOL];
+      B[1] = cell->parameters[CellParams::PERBYVOL] +  cell->parameters[CellParams::BGBYVOL];
+      B[2] = cell->parameters[CellParams::PERBZVOL] +  cell->parameters[CellParams::BGBZVOL];
+
+      // Unit B-field direction
+      creal normB = sqrt(B[0]*B[0] + B[1]*B[1] + B[2]*B[2]);
+      for (uint i=0; i<3; i++){
+         B[i] /= normB;
+      }
+
+      // If southern hemisphere, precipitation is along -B
+      if (cell->parameters[CellParams::ZCRD] + 0.5*cell->parameters[CellParams::DZ] < 0.0){
+         for (uint i=0; i<3; i++){
+            B[i] = -B[i];
+         }
+      }
+
+      # pragma omp parallel
+      {
+         std::vector<Real> thread_line_sum(nChannels,0.0);
+         std::vector<Real> thread_count(nChannels,0.0);
+         
+         const Real* parameters  = cell->get_block_parameters(popID);
+         const Realf* block_data = cell->get_data(popID);
+         
+         # pragma omp for
+         for (vmesh::LocalID n=0; n<cell->get_number_of_velocity_blocks(popID); n++) {
+            for (uint k = 0; k < WID; ++k) for (uint j = 0; j < WID; ++j) for (uint i = 0; i < WID; ++i) {
+               const Real VX 
+                  =          parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::VXCRD] 
+                  + (i + 0.5)*parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVX];
+               const Real VY 
+                  =          parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::VYCRD] 
+                  + (j + 0.5)*parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVY];
+               const Real VZ 
+                  =          parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::VZCRD] 
+                  + (k + 0.5)*parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVZ];
+
+               const Real DV3 
+                  = parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVX]
+                  * parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVY] 
+                  * parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVZ];
+
+               const Real normV = sqrt(VX*VX + VY*VY + VZ*VZ);
+               std::array<Real,3> BnormV;
+               BnormV[0] = B[0] * normV;
+               BnormV[1] = B[1] * normV;
+               BnormV[2] = B[2] * normV;
+
+               // We will use a gate function based on criteria that Vi-0.5*DVi <= BnormV[i] <= Vi+0.5*DVi (for i=x,y,z or 0,1,2)
+               bool xGateCrit, yGateCrit, zGateCrit;
+               xGateCrit = (BnormV[0] - (VX - 0.5*BlockParams::DVX)) * (BnormV[0] - (VX + 0.5*BlockParams::DVX)) <= 0;
+               yGateCrit = (BnormV[1] - (VY - 0.5*BlockParams::DVY)) * (BnormV[1] - (VY + 0.5*BlockParams::DVY)) <= 0;
+               zGateCrit = (BnormV[2] - (VZ - 0.5*BlockParams::DVZ)) * (BnormV[2] - (VZ + 0.5*BlockParams::DVZ)) <= 0;
+               bool xyzGateCrit = xGateCrit && yGateCrit && zGateCrit;  // gate function: 1 if the line goes through the v-cell, else 0.
+               countAndGate = (Real) xyzGateCrit;
+               const Real energy = 0.5 * getObjectWrapper().particleSpecies[popID].mass * normV*normV; // in SI
+
+               // Find the correct energy bin number to update
+               int binNumber = round((log(energy) - log(emin)) / log(emax/emin) * (nChannels-1));
+               binNumber = max(binNumber,0); // anything < emin goes to the lowest channel
+               binNumber = min(binNumber,nChannels-1); // anything > emax goes to the highest channel
+
+               thread_line_sum[binNumber] += block_data[n * SIZE_VELBLOCK + cellIndex(i,j,k)] * countAndGate * normV*normV * DV3;
+               thread_count[binNumber] += countAndGate * DV3;
+            }
+         }
+
+         // Accumulate contributions coming from this velocity block to the 
+         // spatial cell velocity moments. If multithreading / OpenMP is used, 
+         // these updates need to be atomic:
+         # pragma omp critical
+         {
+            for (int i=0; i<nChannels; i++) {
+               dataLineDiffFlux[i] += thread_line_sum[i];
+               sumWeights[i] += thread_count[i];
+            }
+         }
+      }
+
+      // Averaging within each bin and conversion to unit of part. cm-2 s-1 sr-1 ev-1
+      for (int i=0; i<nChannels; i++) {
+         if (sumWeights[i] != 0) {
+            dataLineDiffFlux[i] *= 1.0 / (getObjectWrapper().particleSpecies[popID].mass * sumWeights[i]) * physicalconstants::CHARGE * 1.0e-4;
+         }
+      }
+
+      const char* ptr = reinterpret_cast<const char*>(dataLineDiffFlux.data());
+      for (uint i = 0; i < nChannels*sizeof(Real); ++i) buffer[i] = ptr[i];
+      return true;
+   }
+   
+   bool VariablePrecipitationLineDiffFlux::setSpatialCell(const SpatialCell* cell) {
+      return true;
+   }
+
+   bool VariablePrecipitationLineDiffFlux::writeParameters(vlsv::Writer& vlsvWriter) {
+      for (int i=0; i<nChannels; i++) {
+         const Real channelev = channels[i]/physicalconstants::CHARGE; // in eV
+         if( vlsvWriter.writeParameter(popName+"_PrecipitationCentreEnergyLine"+std::to_string(i), &channelev) == false ) { return false; }
+      }
       return true;
    }
 

--- a/datareduction/datareductionoperator.h
+++ b/datareduction/datareductionoperator.h
@@ -603,7 +603,7 @@ namespace DRO {
       Real E2limit;
    };
    
-   // Precipitation directional differential number flux
+   // Precipitation directional differential number flux (within loss cone)
    class VariablePrecipitationDiffFlux: public DataReductionOperatorHasParameters {
    public:
       VariablePrecipitationDiffFlux(cuint popID);
@@ -622,6 +622,26 @@ namespace DRO {
       Real emin, emax;
       Real lossConeAngle;
       std::vector<Real> channels, dataDiffFlux;
+   };
+
+   // Precipitation directional differential number flux (along line)
+   class VariablePrecipitationLineDiffFlux: public DataReductionOperatorHasParameters {
+   public:
+      VariablePrecipitationLineDiffFlux(cuint popID);
+      virtual ~VariablePrecipitationLineDiffFlux();
+      
+      virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
+      virtual std::string getName() const;
+      virtual bool reduceData(const SpatialCell* cell,char* buffer);
+      virtual bool setSpatialCell(const SpatialCell* cell);
+      virtual bool writeParameters(vlsv::Writer& vlsvWriter);
+      
+   protected:
+      uint popID;
+      std::string popName;
+      int nChannels;
+      Real emin, emax;
+      std::vector<Real> channels, dataLineDiffFlux;
    };
 
    // Heat flux vector


### PR DESCRIPTION
Created a new DRO for precipitating particle differential number flux calculation, designed to better capture low energies.
The DRO (hereinafter referred to as 'line DRO') is extremely similar to the original one ('loss-cone DRO') in its implementation, the main difference being the choice of the gate function to select relevant v-space cells for the flux calculation.

In the line DRO approach, we consider all cells which are traversed by the magnetic field direction (or opposite in the southern hemisphere), i.e., all cells which are intersected by the line along which precipitation takes place. This means that we overcome the issue found with the loss-cone DRO, in which at low energies there were no cell centres inside the loss cone due to the v-space resolution being too coarse for such low energies/velocities.

The only caveat to keep in mind is that, if a given energy bin is such that its width corresponds to a delta V lower than the diagonal size of velocity cells, this can still lead to zero flux locally in this energy bin. The way to overcome this is to carefully set the DRO parameters (emin, emax, nChannels) based on the v-space resolution.

The code has been tested using a restart from EGI, and precipitating fluxes from the line DRO are in excellent agreement with those from the loss-cone DRO (see figure). The test package has not been run on the new code at this stage.

![spectrum_comparison](https://user-images.githubusercontent.com/35216514/200805459-273dd9dd-00fe-407e-b072-0a7c268591bc.png)
