### PR TITLE
Cut-cell precipitation DRO

### DIFF
--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -421,6 +421,18 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          continue;
       }
+      if(lowercase == "populations_precipitationfluxcutcells" || lowercase == "populations_vg_precipitationdifferentialfluxcutcells" || lowercase == "populations_precipitationdifferentialfluxcutcells") {
+         // Per-population precipitation differential flux
+         for(unsigned int i =0; i < getObjectWrapper().particleSpecies.size(); i++) {
+            species::Species& species=getObjectWrapper().particleSpecies[i];
+            const std::string& pop = species.name;
+            outputReducer->addOperator(new DRO::VariablePrecipitationDiffFluxCutCells(i));
+	    std::stringstream conversion;
+	    conversion << (1.0e-4)*physicalconstants::CHARGE;
+	    outputReducer->addMetadata(outputReducer->size()-1,"1/(cm^2 sr s eV)","$\\mathrm{cm}^{-2}\\,\\mathrm{sr}^{-1}\\,\\mathrm{s}^{-1}\\,\\mathrm{eV}^{-1}$","$\\mathcal{F}_\\mathrm{"+pop+"}$",conversion.str());
+         }
+         continue;
+      }
       if(lowercase == "populations_heatflux" || lowercase == "populations_vg_heatflux") {
          // Per-population heat flux vector
          for(unsigned int i =0; i < getObjectWrapper().particleSpecies.size(); i++) {

--- a/datareduction/datareductionoperator.h
+++ b/datareduction/datareductionoperator.h
@@ -624,6 +624,27 @@ namespace DRO {
       std::vector<Real> channels, dataDiffFlux;
    };
 
+   // Precipitation directional differential number flux, with cut Cells for higher effective resolution
+   class VariablePrecipitationDiffFluxCutCells: public DataReductionOperatorHasParameters {
+   public:
+      VariablePrecipitationDiffFluxCutCells(cuint popID);
+      virtual ~VariablePrecipitationDiffFluxCutCells();
+      
+      virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
+      virtual std::string getName() const;
+      virtual bool reduceData(const SpatialCell* cell,char* buffer);
+      virtual bool setSpatialCell(const SpatialCell* cell);
+      virtual bool writeParameters(vlsv::Writer& vlsvWriter);
+      
+   protected:
+      uint popID;
+      std::string popName;
+      int nChannels;
+      Real emin, emax;
+      Real lossConeAngle;
+      std::vector<Real> channels, dataDiffFlux;
+   };
+
    class JPerBModifier: public DataReductionOperatorHasParameters {
    public:
       virtual bool reduceData(const SpatialCell* cell,char* buffer) {return true;}


### PR DESCRIPTION
As yet another alternative to the line-cutting precipitation DRO in PR#670, this version implements an implementation where each velocity cell is coverage-tested against the loss cone, allowing for partial coverage to contribute partially.

The concrete implementation defines the loss cone as a signed distance function, which returns the distance to the cone surface for every point in vspace. If this distance is much larger than the vspace cell's diagonal, the cell is assumed to be clearly outside. If it is negative by the same distance, it is clearly inside.
But cells that are closer to the cone boundary then their diagonal are recursively octree-subdivided, and each subcell is again tested in the same way (up to a hardcoded recursion limit of 6).