### PR TITLE
Move the IONOSPHERE_SORTED_SUMS flag to the testpackage flags in Makefile and not in the arch files

### DIFF
--- a/MAKE/Makefile.Freezer
+++ b/MAKE/Makefile.Freezer
@@ -31,7 +31,7 @@ CC_BRAND = gcc
 CC_BRAND_VERSION = 6.2.0
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -mavx2
 #CXXFLAGS += -ggdb -O0 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -mavx2
-testpackage: CXXFLAGS = -g -ggdb -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mno-avx -mno-fma -fno-unsafe-math-optimizations -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -g -ggdb -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mno-avx -mno-fma -fno-unsafe-math-optimizations
 
 MATHFLAGS = -ffast-math
 testpackage: MATHFLAGS =  -fno-unsafe-math-optimizations

--- a/MAKE/Makefile.carrington_gcc_openmpi
+++ b/MAKE/Makefile.carrington_gcc_openmpi
@@ -69,7 +69,7 @@ FLAGS =
 CC_BRAND = gcc
 CC_BRAND_VERSION = 9.4.0
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2 #-flto
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2 -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2
 CXXFLAGS += -Wall -Wextra -Wno-unused
 
 MATHFLAGS = -ffast-math

--- a/MAKE/Makefile.docker
+++ b/MAKE/Makefile.docker
@@ -22,7 +22,7 @@ FLAGS =
 
 #GNU flags:
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -mavx2
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mavx -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mavx
 
 MATHFLAGS = -ffast-math
 LDFLAGS = -g

--- a/MAKE/Makefile.hawk_gcc_mpt
+++ b/MAKE/Makefile.hawk_gcc_mpt
@@ -47,7 +47,7 @@ CC_BRAND_VERSION = 9.2.0_bis
 CXXFLAGS += -g -fopenmp -O3 -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -Wall -Wpedantic -mfma -march=native -mavx2
 #CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -mavx
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
-testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0
 not_parallel_tools: CC_BRAND_VERSION = 4.9.2-noavx2
 
 MATHFLAGS = -ffast-math

--- a/MAKE/Makefile.hawk_gcc_openmpi
+++ b/MAKE/Makefile.hawk_gcc_openmpi
@@ -28,7 +28,7 @@ CC_BRAND = gcc
 CC_BRAND_VERSION = 9.2.0
 CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -Wall -Wpedantic -mfma -march=native -mavx2
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
-testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0
 not_parallel_tools: CC_BRAND_VERSION = 4.9.2-noavx2
 
 MATHFLAGS = -ffast-math

--- a/MAKE/Makefile.hawk_intel_mpt
+++ b/MAKE/Makefile.hawk_intel_mpt
@@ -28,7 +28,7 @@ CC_BRAND = intel
 CC_BRAND_VERSION = 19.1.0
 # note: std was not updated to c++17
 CXXFLAGS += -traceback -g -O3 -qopenmp -std=c++14 -W -Wall -Wno-unused -march=core-avx2 -qopt-zmm-usage=high
-testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++14 -W -Wno-unused -march=core-avx2 -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++14 -W -Wno-unused -march=core-avx2
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
 not_parallel_tools: CC_BRAND_VERSION = 4.9.2-noavx2
 

--- a/MAKE/Makefile.hawk_intel_openmpi
+++ b/MAKE/Makefile.hawk_intel_openmpi
@@ -28,7 +28,7 @@ CC_BRAND = intel
 CC_BRAND_VERSION = 19.1.0
 #note: std was not updated to c++17
 CXXFLAGS += -traceback -g -O3 -qopenmp -std=c++14 -W -Wall -Wno-unused -march=core-avx2 -qopt-zmm-usage=high
-testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++14 -W -Wno-unused -march=core-avx2 -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++14 -W -Wno-unused -march=core-avx2
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
 not_parallel_tools: CC_BRAND_VERSION = 4.9.2-noavx2
 

--- a/MAKE/Makefile.kstppd
+++ b/MAKE/Makefile.kstppd
@@ -26,7 +26,7 @@ endif
 
 FLAGS =
 CXXFLAGS = -O3   -funroll-loops -std=c++17 -fopenmp -W -Wall -Wno-unused -Wno-unused-parameter -Wno-missing-braces -fabi-version=0 -mavx
-testpackage: CXXFLAGS = -g -ggdb -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mno-avx -mno-fma -fno-unsafe-math-optimizations -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -g -ggdb -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mno-avx -mno-fma -fno-unsafe-math-optimizations
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE -DPAPI_MEM
 MATHFLAGS = -ffast-math
 testpackage: MATHFLAGS =  -fno-unsafe-math-optimizations

--- a/MAKE/Makefile.lumi_gnu
+++ b/MAKE/Makefile.lumi_gnu
@@ -2,7 +2,7 @@ CMP = CC
 LNK = CC
 
 # Modules loaded
-# module swap PrgEnv-cray PrgEnv-gnu ; module swap perftools-base/21.05.0 papi 
+# module --force purge ; module load LUMI/22.08 ; module load cpeGNU ; module load papi
 
 #======== Vectorization ==========
 #Set vector backend type for vlasov solvers, sets precision and length. 

--- a/MAKE/Makefile.lumi_gnu
+++ b/MAKE/Makefile.lumi_gnu
@@ -1,8 +1,9 @@
-CMP = mpic++
-LNK = mpic++
+CMP = CC
+LNK = CC
 
 # Modules loaded
-# module load gcc openmpi jemalloc papi boost
+# module swap PrgEnv-cray PrgEnv-gnu ; module swap perftools-base/21.05.0 papi 
+
 #======== Vectorization ==========
 #Set vector backend type for vlasov solvers, sets precision and length. 
 #Options: 
@@ -23,12 +24,12 @@ FLAGS =
 #GNU flags:
 CC_BRAND = gcc
 CC_BRAND_VERSION = 9.3.0
-CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -march=native -mfma -mavx2
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -mfma
+CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mno-fma -mno-avx2
+testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++20 -mno-fma -mno-avx2 -mno-avx
 
 MATHFLAGS = -ffast-math
-LDFLAGS = -lrt
-LIB_MPI = -lgomp 
+LDFLAGS = -lrt -fopenmp -lgomp
+LIB_MPI = -lgomp
 
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
@@ -55,33 +56,32 @@ testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 #
 #======== Libraries ===========
 
-MPT_VERSION = 4.0.3
-JEMALLOC_VERSION = 5.2.1
-LIBRARY_PREFIX = /users/kempf/libraries_rhel8_openmpi/
-
+LIBRARY_PREFIX = /scratch/project_465000287/kempfyan/libraries/LUMI22.08_cpeGNU
+LIBRARY_PREFIX_HEADERS = /scratch/project_465000287/libraries
 
 #compiled libraries
-LIB_BOOST = -lboost_program_options
+INC_BOOST = -I$(LIBRARY_PREFIX)/boost/include
+LIB_BOOST = -L$(LIBRARY_PREFIX)/boost/lib -lboost_program_options -Wl,-rpath=$(LIBRARY_PREFIX)/boost/lib
 
 INC_ZOLTAN = -I$(LIBRARY_PREFIX)/zoltan/include
 LIB_ZOLTAN = -L$(LIBRARY_PREFIX)/zoltan/lib -lzoltan -Wl,-rpath=$(LIBRARY_PREFIX)/zoltan/lib
 
+INC_JEMALLOC = -I$(LIBRARY_PREFIX)/jemalloc/include
+LIB_JEMALLOC = -L$(LIBRARY_PREFIX)/jemalloc/lib -ljemalloc -Wl,-rpath=$(LIBRARY_PREFIX)/jemalloc/lib
 
-LIB_JEMALLOC = -ljemalloc
-
-LIB_PAPI = -lpapi
+#INC_PAPI = -I$(LIBRARY_PREFIX)/papi/include
+#LIB_PAPI = -L$(LIBRARY_PREFIX)/papi/lib -lpapi -Wl,-rpath=$(LIBRARY_PREFIX)/papi/lib
 
 INC_VLSV = -I$(LIBRARY_PREFIX)/vlsv
 LIB_VLSV = -L$(LIBRARY_PREFIX)/vlsv -lvlsv -Wl,-rpath=$(LIBRARY_PREFIX)/vlsv
 
-
-LIB_PROFILE = -L$(LIBRARY_PREFIX)/phiprof/lib -lphiprof -lgfortran -Wl,-rpath=$(LIBRARY_PREFIX)/phiprof/lib
-INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include
+LIB_PROFILE = -L$(LIBRARY_PREFIX)/phiprof/lib -lnophiprof -lgfortran -Wl,-rpath=$(LIBRARY_PREFIX)/phiprof/lib
+INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include 
 
 
 #header libraries
 
-INC_FSGRID = -I$(LIBRARY_PREFIX)/../libraries/fsgrid/
-INC_EIGEN = -I$(LIBRARY_PREFIX)/../libraries/eigen/
-INC_DCCRG = -I$(LIBRARY_PREFIX)/../libraries/dccrg/
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/../libraries/vectorclass/
+INC_FSGRID = -I$(LIBRARY_PREFIX_HEADERS)/fsgrid/
+INC_EIGEN = -I$(LIBRARY_PREFIX_HEADERS)/eigen/
+INC_DCCRG = -I$(LIBRARY_PREFIX_HEADERS)/dccrg/
+INC_VECTORCLASS = -I$(LIBRARY_PREFIX_HEADERS)/vectorclass/

--- a/MAKE/Makefile.marconi
+++ b/MAKE/Makefile.marconi
@@ -30,7 +30,7 @@ CC_BRAND = intel
 CC_BRAND_VERSION = 17.0.1
 # note: std was c++11
 CXXFLAGS +=  -O2 -g -DMAX_VECTOR_SIZE=512 -xMIC-AVX512 -std=c++17 -qopenmp -ansi-alias
-testpackage: CXXFLAGS = -O2 -g -DMAX_VECTOR_SIZE=512 -xMIC-AVX512 -std=c++17 -qopenmp -ansi-alias -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -O2 -g -DMAX_VECTOR_SIZE=512 -xMIC-AVX512 -std=c++17 -qopenmp -ansi-alias
 MATHFLAGS = 
 LDFLAGS += -qopenmp -lifcore -Wl,-rpath,/cineca/prod/opt/libraries/boost/1.61.0/intelmpi--2017--binary/lib,-rpath,/marconi_work/Pra14_3521/libraries/phiprof/lib,-rpath,/marconi_work/Pra14_3521/libraries/papi/lib
 CMP = mpicxx

--- a/MAKE/Makefile.puhti_gcc
+++ b/MAKE/Makefile.puhti_gcc
@@ -22,7 +22,7 @@ FLAGS =
 CC_BRAND = gcc
 CC_BRAND_VERSION = 9.1.0
 CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -march=native -mfma -mavx512f
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -mfma -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -mfma
 
 MATHFLAGS = -ffast-math
 LDFLAGS = -lrt

--- a/MAKE/Makefile.puhti_intel
+++ b/MAKE/Makefile.puhti_intel
@@ -22,7 +22,7 @@ FLAGS =
 CC_BRAND = intel
 CC_BRAND_VERSION = 19.0.4
 CXXFLAGS += -traceback -g -O3 -qopenmp -std=c++17 -W -Wall -Wno-unused -xHost -ipo -qopt-zmm-usage=high 
-testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++17 -W -Wno-unused -xHost -ipo -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++17 -W -Wno-unused -xHost -ipo
 
 MATHFLAGS = -ffast-math
 LDFLAGS = -qopenmp -lifcore -ipo

--- a/MAKE/Makefile.puhti_pgi
+++ b/MAKE/Makefile.puhti_pgi
@@ -22,7 +22,7 @@ FLAGS =
 CC_BRAND = pgi
 CC_BRAND_VERSION = 19.7
 CXXFLAGS += -g -O3 -acc -D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1 -Minfo=accel
-testpackage: CXXFLAGS = -g -O2 -acc -D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1 -Minfo=accel -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -g -O2 -acc -D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1 -Minfo=accel
 
 MATHFLAGS =
 LDFLAGS = -O3 -acc -g

--- a/MAKE/Makefile.ukko_gcc_openmpi
+++ b/MAKE/Makefile.ukko_gcc_openmpi
@@ -68,7 +68,7 @@ FLAGS =
 CC_BRAND = gcc
 CC_BRAND_VERSION = 9.4.0
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mavx -march=znver2 #-flto
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2 -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2
 
 MATHFLAGS = -ffast-math
 LDFLAGS = -lrt -lgfortran -std=c++17 -lgomp

--- a/MAKE/Makefile.vorna_gcc
+++ b/MAKE/Makefile.vorna_gcc
@@ -35,7 +35,7 @@ FLAGS =
 CC_BRAND = gcc
 CC_BRAND_VERSION = 10.2.0
 CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -mavx
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx -DIONOSPHERE_SORTED_SUMS
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx
 CXXFLAGS += -Wall -Wextra -Wno-unused
 
 MATHFLAGS = -ffast-math

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ ifneq (,$(findstring testpackage,$(MAKECMDGOALS)))
 	MATHFLAGS =
 	FP_PRECISION = DP
 	DISTRIBUTION_FP_PRECISION = DPF
+        CXXFLAGS += -DIONOSPHERE_SORTED_SUMS
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifneq (,$(findstring testpackage,$(MAKECMDGOALS)))
 	MATHFLAGS =
 	FP_PRECISION = DP
 	DISTRIBUTION_FP_PRECISION = DPF
-        CXXFLAGS += -DIONOSPHERE_SORTED_SUMS
+        COMPFLAGS += -DIONOSPHERE_SORTED_SUMS
 endif
 
 
@@ -37,9 +37,9 @@ COMPFLAGS += -DPROFILE
 
 #Add -DNDEBUG to turn debugging off. If debugging is enabled performance will degrade significantly
 COMPFLAGS += -DNDEBUG
-# CXXFLAGS += -DIONOSPHERE_SORTED_SUMS
-# CXXFLAGS += -DDEBUG_SOLVERS
-# CXXFLAGS += -DDEBUG_IONOSPHERE
+# COMPFLAGS += -DIONOSPHERE_SORTED_SUMS
+# COMPFLAGS += -DDEBUG_SOLVERS
+# COMPFLAGS += -DDEBUG_IONOSPHERE
 
 #Set order of semilag solver in velocity space acceleration
 #  ACC_SEMILAG_PLM 	2nd order	


### PR DESCRIPTION
All simple and trivial. Except I mistakenly pushed a half-baked LUMI Makefile.