### PR TITLE
Zoltan options

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -176,7 +176,10 @@ void initializeGrids(
    initVelocityGridGeometry(mpiGrid);
    initializeStencils(mpiGrid);
    
-   mpiGrid.set_partitioning_option("IMBALANCE_TOL", P::loadBalanceTolerance);
+   for (const auto& [key, value] : P::loadBalanceOptions) {
+      std::clog << key < ": " << value << std::endl;
+      mpiGrid.set_partitioning_option(key, value);
+   }
    phiprof::start("Initial load-balancing");
    if (myRank == MASTER_RANK) logFile << "(INIT): Starting initial load balance." << endl << writeVerbose;
    mpiGrid.balance_load(); // Direct DCCRG call, recalculate cache afterwards

--- a/grid.cpp
+++ b/grid.cpp
@@ -177,7 +177,6 @@ void initializeGrids(
    initializeStencils(mpiGrid);
    
    for (const auto& [key, value] : P::loadBalanceOptions) {
-      std::clog << key < ": " << value << std::endl;
       mpiGrid.set_partitioning_option(key, value);
    }
    phiprof::start("Initial load-balancing");

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -761,9 +761,10 @@ void Parameters::getParameters() {
       if (myRank == MASTER_RANK) {
          cerr << "WARNING the number of load balance keys and values do not match. Disregarding these options." << endl;
       }
-   }
-   for (int i = 0; i < loadBalanceKeys.size(); ++i) {
-      loadBalanceOptions[loadBalanceKeys[i]] = loadBalanceValues[i];
+   } else {
+      for (int i = 0; i < loadBalanceKeys.size(); ++i) {
+         loadBalanceOptions[loadBalanceKeys[i]] = loadBalanceValues[i];
+      }
    }
 
    // Get output variable parameters

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -756,7 +756,7 @@ void Parameters::getParameters() {
    std::vector<std::string> loadBalanceKeys;
    std::vector<std::string> loadBalanceValues;
    RP::get("loadBalance.optionKey", loadBalanceKeys);
-   RP::get("loadBalance.optionValues", loadBalanceValues);
+   RP::get("loadBalance.optionValue", loadBalanceValues);
    if (loadBalanceKeys.size() != loadBalanceValues.size()) {
       if (myRank == MASTER_RANK) {
          cerr << "WARNING the number of load balance keys and values do not match. Disregarding these options." << endl;

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -128,7 +128,7 @@ bool P::isRestart = false;
 int P::writeAsFloat = false;
 int P::writeRestartAsFloat = false;
 string P::loadBalanceAlgorithm = string("");
-string P::loadBalanceTolerance = string("");
+std::map<std::string, std::string> P::loadBalanceOptions;
 uint P::rebalanceInterval = numeric_limits<uint>::max();
 
 vector<string> P::outputVariableList;
@@ -324,6 +324,9 @@ bool P::addParameters() {
    RP::add("loadBalance.algorithm", "Load balancing algorithm to be used", string("RCB"));
    RP::add("loadBalance.tolerance", "Load imbalance tolerance", string("1.05"));
    RP::add("loadBalance.rebalanceInterval", "Load rebalance interval (steps)", 10);
+
+   RP::addComposing("loadBalance.optionKey", "Zoltan option key. Has to be matched by loadBalance.optionValue.");
+   RP::addComposing("loadBalance.optionValue", "Zoltan option value. Has to be matched by loadBalance.optionKey.");
 
    // Output variable parameters
    // NOTE Do not remove the : before the list of variable names as this is parsed by tools/check_vlasiator_cfg.sh
@@ -746,8 +749,22 @@ void Parameters::getParameters() {
 
    // Get load balance parameters
    RP::get("loadBalance.algorithm", P::loadBalanceAlgorithm);
-   RP::get("loadBalance.tolerance", P::loadBalanceTolerance);
+   loadBalanceOptions["IMBALANCE_TOL"] = "";
+   RP::get("loadBalance.tolerance", loadBalanceOptions["IMBALANCE_TOL"]);
    RP::get("loadBalance.rebalanceInterval", P::rebalanceInterval);
+
+   std::vector<std::string> loadBalanceKeys;
+   std::vector<std::string> loadBalanceValues;
+   RP::get("loadBalance.optionKey", loadBalanceKeys);
+   RP::get("loadBalance.optionValues", loadBalanceValues);
+   if (loadBalanceKeys.size() != loadBalanceValues.size()) {
+      if (myRank == MASTER_RANK) {
+         cerr << "WARNING the number of load balance keys and values do not match. Disregarding these options." << endl;
+      }
+   }
+   for (int i = 0; i < loadBalanceKeys.size(); ++i) {
+      loadBalanceOptions[loadBalanceKeys[i]] = loadBalanceValues[i];
+   }
 
    // Get output variable parameters
    RP::get("variables.output", P::outputVariableList);

--- a/parameters.h
+++ b/parameters.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <map>
 
 #include "definitions.h"
 
@@ -146,7 +147,7 @@ struct Parameters {
                                    in the Lorentz force and in the field solver.*/
 
    static std::string loadBalanceAlgorithm; /*!< Algorithm to be used for load balance.*/
-   static std::string loadBalanceTolerance; /*!< Load imbalance tolerance. */
+   static std::map<std::string, std::string> loadBalanceOptions;  // Other Load balancing options
    static uint rebalanceInterval;           /*!< Load rebalance interval (steps). */
    static bool prepareForRebalance; /**< If true, propagators should measure their time consumption in preparation
                                      * for mesh repartitioning.*/


### PR DESCRIPTION
Add support for arbitrary Zoltan options using key-value pairs in the config file.
- `loadBalance.optionKey`: Option key
- `loadBalance.optionValue`: Option value

If the amount of keys and values do not match, all of them are discarded.