### PR TITLE
Ionosphere mini app build fix

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -194,31 +194,31 @@ jobs:
       # Note: Testpackage output is further processed in the pr_report.yml workflow
       # (to produce Checks against pull requests)
 
-  #build_ionosphereTests:
-  #  # Build IonosphereSolverTests miniApp (currently broken)
-  #  runs-on: ubuntu-latest
-  #  container: ursg/vlasiator_ci:20230220_1
-  #  needs: build_libraries
-  #  steps:
-  #  - name: Checkout source
-  #    uses: actions/checkout@v3 
-  #  - name: Download libraries
-  #    uses: actions/download-artifact@v3
-  #    with:
-  #      name: libraries
-  #  - name: Unpack libraries
-  #    run: tar --zstd -xvf libraries.tar.zstd
-  #  - uses: ursg/gcc-problem-matcher@master
-  #  - name: Compile ionosphereSolverTests
-  #    run: |
-  #      cd mini-apps/ionosphereSolverTests/
-  #      VLASIATOR_ARCH=github_actions make -j 3 main differentialFlux sigmaProfiles
-  #  - name: Upload ionosphereTest binaries
-  #    uses: actions/upload-artifact@v3
-  #    with:
-  #      name: vlasiator-tools
-  #      path: |
-  #        mini-apps/ionosphereSolverTests/main
-  #        mini-apps/ionosphereSolverTests/differentialFlux
-  #        mini-apps/ionosphereSolverTests/sigmaProfiles
+  build_ionosphereTests:
+    # Build IonosphereSolverTests miniApp (currently broken)
+    runs-on: ubuntu-latest
+    container: ursg/vlasiator_ci:20230220_1
+    needs: build_libraries
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3 
+    - name: Download libraries
+      uses: actions/download-artifact@v3
+      with:
+        name: libraries
+    - name: Unpack libraries
+      run: tar --zstd -xvf libraries.tar.zstd
+    - uses: ursg/gcc-problem-matcher@master
+    - name: Compile ionosphereSolverTests
+      run: |
+        cd mini-apps/ionosphereSolverTests/
+        VLASIATOR_ARCH=github_actions make -j 3 main differentialFlux sigmaProfiles
+    - name: Upload ionosphereTest binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: vlasiator-tools
+        path: |
+          mini-apps/ionosphereSolverTests/main
+          mini-apps/ionosphereSolverTests/differentialFlux
+          mini-apps/ionosphereSolverTests/sigmaProfiles
 

--- a/mini-apps/ionosphereSolverTests/Makefile
+++ b/mini-apps/ionosphereSolverTests/Makefile
@@ -13,7 +13,7 @@ all: main differentialFlux sigmaProfiles quadrupoleTests atmosphere.pdf
 .PHONY: clean quadrupoleTests
 
 clean: 
-	rm *.o main
+	rm *.o main differentialFlux sigmaProfiles
 
 ionosphere.o: ../../sysboundary/ionosphere.h ../../sysboundary/ionosphere.cpp ../../backgroundfield/backgroundfield.h ../../projects/project.h
 	${CMP} ${CXXFLAGS} ${FLAGS} ${MATHFLAGS} -c ../../sysboundary/ionosphere.cpp ${INC_DCCRG} ${INC_FSGRID} ${INC_ZOLTAN} ${INC_BOOST} ${INC_EIGEN} ${INC_VECTORCLASS} ${INC_PROFILE} ${INC_JEMALLOC} -Wno-comment
@@ -42,9 +42,6 @@ spatial_cell.o: ../../spatial_cell.cpp
 cpu_moments.o: ../../vlasovsolver/cpu_moments.cpp
 	${CMP} ${CXXFLAGS} ${FLAG_OPENMP} ${MATHFLAGS} ${FLAGS} -c ../../vlasovsolver/cpu_moments.cpp ${INC_DCCRG} ${INC_BOOST} ${INC_ZOLTAN} ${INC_PROFILE} ${INC_FSGRID} ${INC_JEMALLOC}
 
-mesh_data_container.o: ../../mesh_data_container.h ../../mesh_data.h
-	${CMP} ${CXXFLAGS} ${FLAGS} ${MATHFLAGS} -c ../../mesh_data_container.cpp ${INC_VLSV} ${INC_DCCRG} ${INC_ZOLTAN} ${INC_BOOST} ${INC_FSGRID} ${INC_PROFILE} ${INC_JEMALLOC}
-
 iowrite.o:  ../../parameters.h ../../iowrite.cpp ../../iowrite.h  
 	${CMP} ${CXXFLAGS} ${FLAG_OPENMP} ${MATHFLAGS} ${FLAGS} -c ../../iowrite.cpp ${INC_MPI} ${INC_DCCRG} ${INC_FSGRID} ${INC_BOOST} ${INC_EIGEN} ${INC_ZOLTAN} ${INC_PROFILE} ${INC_VLSV} ${INC_JEMALLOC}
 
@@ -69,10 +66,13 @@ fs_common.o: ../../fieldsolver/fs_limiters.h ../../fieldsolver/fs_limiters.cpp
 grid.o:  ../../grid.cpp ../../grid.h  ../../sysboundary/sysboundary.h
 	${CMP} ${CXXFLAGS} ${MATHFLAGS} ${FLAG_OPENMP} ${FLAGS} -c ../../grid.cpp ${INC_MPI} ${INC_DCCRG} ${INC_FSGRID} ${INC_BOOST} ${INC_EIGEN} ${INC_ZOLTAN} ${INC_PROFILE} ${INC_VLSV} ${INC_PAPI} ${INC_VECTORCLASS}
 
+fieldtracing.o: ../../fieldtracing/fieldtracing.cpp
+	${CMP} ${CXXFLAGS} ${FLAGS} ${MATHFLAGS} -c ../../fieldtracing/fieldtracing.cpp ${INC_DCCRG} ${INC_FSGRID} ${INC_BOOST} ${INC_ZOLTAN} ${INC_EIGEN} ${INC_PROFILE} ${INC_JEMALLOC}
+
 main.o: main.cpp
 	${CMP} ${CXXFLAGS} ${FLAGS} ${MATHFLAGS} -c ./main.cpp  ${INC_VLSV} ${INC_BOOST} ${INC_PROFILE} ${INC_JEMALLOC} ${INC_DCCRG} ${INC_ZOLTAN} ${INC_FSGRID}
 
-main: main.o ionosphere.o sysboundarycondition.o parameters.o readparameters.o object_wrapper.o particle_species.o spatial_cell.o cpu_moments.o mesh_data_container.o iowrite.o logger.o datareducer.o datareductionoperator.o common.o ioread.o fs_common.o version.o
+main: main.o ionosphere.o sysboundarycondition.o parameters.o readparameters.o object_wrapper.o particle_species.o spatial_cell.o cpu_moments.o iowrite.o logger.o datareducer.o datareductionoperator.o common.o ioread.o fs_common.o version.o fieldtracing.o
 	${LNK} ${LDFLAGS} -o main $^ $(LIBS) -lgomp
 
 differentialFlux: differentialFlux.cpp

--- a/mini-apps/ionosphereSolverTests/Makefile
+++ b/mini-apps/ionosphereSolverTests/Makefile
@@ -30,6 +30,9 @@ readparameters.o: ../../readparameters.h ../../readparameters.cpp ../../version.
 version.o: ../../version.cpp
 	 ${CMP} ${CXXFLAGS} ${FLAGS} -c ../../version.cpp
 
+../../version.cpp:
+	make -C../.. version.cpp
+
 object_wrapper.o:  ../../object_wrapper.h ../../object_wrapper.cpp
 	${CMP} ${CXXFLAGS} ${FLAGS} -c ../../object_wrapper.cpp ${INC_DCCRG} ${INC_ZOLTAN} ${INC_BOOST} ${INC_FSGRID} ${INC_PROFILE} ${INC_JEMALLOC}
 

--- a/mini-apps/ionosphereSolverTests/main.cpp
+++ b/mini-apps/ionosphereSolverTests/main.cpp
@@ -15,6 +15,7 @@ Logger logFile,diagnostic;
 int globalflags::bailingOut=0;
 bool globalflags::writeRestart=0;
 bool globalflags::balanceLoad=0;
+bool globalflags::ionosphereJustSolved = false;
 ObjectWrapper objectWrapper;
 ObjectWrapper& getObjectWrapper() {
    return objectWrapper;

--- a/mini-apps/ionosphereSolverTests/main.cpp
+++ b/mini-apps/ionosphereSolverTests/main.cpp
@@ -28,6 +28,9 @@ void deallocateRemoteCellBlocks(dccrg::Dccrg<spatial_cell::SpatialCell, dccrg::C
 void updateRemoteVelocityBlockLists(dccrg::Dccrg<spatial_cell::SpatialCell, dccrg::Cartesian_Geometry, std::tuple<>, std::tuple<> >&, unsigned int, unsigned int) {
 };
 void recalculateLocalCellsCache() {}
+SysBoundary::SysBoundary() {}
+SysBoundary::~SysBoundary() {}
+
 
 void assignConductivityTensor(std::vector<SphericalTriGrid::Node>& nodes, Real sigmaP, Real sigmaH) {
    static const char epsilon[3][3][3] = {

--- a/mini-apps/ionosphereSolverTests/main.cpp
+++ b/mini-apps/ionosphereSolverTests/main.cpp
@@ -148,7 +148,7 @@ int main(int argc, char** argv) {
       }
       cerr << "Unknown command line option \"" << argv[i] << "\"" << endl;
       cerr << endl;
-      cerr << "main [-N num] [-r <lat0> <lat1>] [-sigma (identity|random|35|53|file)] [-fac (constant|dipole|quadrupole|octopole|hexadecapole||file)] [-facfile <filename>] [-gaugeFix equator|pole|integral|none] [-np]" << endl;
+      cerr << "main [-N num] [-r <lat0> <lat1>] [-sigma (identity|random|35|53|file)] [-fac (constant|dipole|quadrupole|octopole|hexadecapole||file)] [-facfile <filename>] [-gaugeFix equator|equator40|equator60|pole|integral|none] [-np]" << endl;
       cerr << "Paramters:" << endl;
       cerr << " -N:        Number of ionosphere mesh nodes (default: 64)" << endl;
       cerr << " -r:        Refine grid between the given latitudes (can be specified multiple times)" << endl;
@@ -170,6 +170,11 @@ int main(int argc, char** argv) {
       cerr << "            file       - read FAC distribution from vlsv input file" << endl;
       cerr << " -infile:   Read FACs from this input file" << endl;
       cerr << " -gaugeFix: Solver gauge fixing method (default: pole)" << endl;
+      cerr << "            options are:" << endl;
+      cerr << "            pole      - Fix potential in a single node at the north pole" << endl;
+      cerr << "            equator   - Fix potential on all nodes +- 10 degrees of the equator" << endl;
+      cerr << "            equator40 - Fix potential on all nodes +- 40 degrees of the equator" << endl;
+      cerr << "            equator60 - Fix potential on all nodes +- 60 degrees of the equator" << endl;
       cerr << " -np:       DON'T use the matrix preconditioner (default: do)" << endl;
       cerr << " -maxIter:  Maximum number of solver iterations" << endl;
       

--- a/mini-apps/ionosphereSolverTests/main.cpp
+++ b/mini-apps/ionosphereSolverTests/main.cpp
@@ -31,7 +31,6 @@ void recalculateLocalCellsCache() {}
 SysBoundary::SysBoundary() {}
 SysBoundary::~SysBoundary() {}
 
-
 void assignConductivityTensor(std::vector<SphericalTriGrid::Node>& nodes, Real sigmaP, Real sigmaH) {
    static const char epsilon[3][3][3] = {
       {{0,0,0},{0,0,1},{0,-1,0}},
@@ -40,6 +39,33 @@ void assignConductivityTensor(std::vector<SphericalTriGrid::Node>& nodes, Real s
    };
 
    for(uint n=0; n<nodes.size(); n++) {
+      std::array<Real, 3> b = {nodes[n].x[0] / Ionosphere::innerRadius, nodes[n].x[1] / Ionosphere::innerRadius, nodes[n].x[2] / Ionosphere::innerRadius};
+      if(nodes[n].x[2] >= 0) {
+         b[0] *= -1;
+         b[1] *= -1;
+         b[2] *= -1;
+      }
+      for(int i=0; i<3; i++) {
+         for(int j=0; j<3; j++) {
+            nodes[n].parameters[ionosphereParameters::SIGMA + i*3 + j] = sigmaP * (((i==j)? 1. : 0.) - b[i]*b[j]);
+            for(int k=0; k<3; k++) {
+               nodes[n].parameters[ionosphereParameters::SIGMA + i*3 + j] -= sigmaH * epsilon[i][j][k]*b[k];
+            }
+         }
+      }
+   }
+}
+
+void assignConductivityTensorFromLoadedData(std::vector<SphericalTriGrid::Node>& nodes) {
+   static const char epsilon[3][3][3] = {
+      {{0,0,0},{0,0,1},{0,-1,0}},
+      {{0,0,-1},{0,0,0},{1,0,0}},
+      {{0,1,0},{-1,0,0},{0,0,0}}
+   };
+
+   for(uint n=0; n<nodes.size(); n++) {
+      Real sigmaH = nodes[n].parameters[ionosphereParameters::SIGMAH];
+      Real sigmaP = nodes[n].parameters[ionosphereParameters::SIGMAP];
       std::array<Real, 3> b = {nodes[n].x[0] / Ionosphere::innerRadius, nodes[n].x[1] / Ionosphere::innerRadius, nodes[n].x[2] / Ionosphere::innerRadius};
       if(nodes[n].x[2] >= 0) {
          b[0] *= -1;
@@ -215,7 +241,18 @@ int main(int argc, char** argv) {
    } else if(sigmaString == "file") {
       vlsv::ParallelReader inVlsv;
       inVlsv.open(inputFile,MPI_COMM_WORLD,masterProcessID);
-      readIonosphereNodeVariable(inVlsv, "ig_sigma", ionosphereGrid, ionosphereParameters::SIGMA);
+      // Try to read the sigma tensor directly
+      if(!readIonosphereNodeVariable(inVlsv, "ig_sigma", ionosphereGrid, ionosphereParameters::SIGMA)) {
+
+         // If that doesn't exist, reconstruct it from the sigmaH and sigmaP components
+         // (This assumes that the input file was run with the "GUMICS" conductivity model. Which is reasonable,
+         // because the others don't work very well)
+         cerr << "Reading conductivity tensor from ig_sigmah, ig_sigmap." << endl;
+         readIonosphereNodeVariable(inVlsv, "ig_sigmah", ionosphereGrid, ionosphereParameters::SIGMAH);
+         readIonosphereNodeVariable(inVlsv, "ig_sigmap", ionosphereGrid, ionosphereParameters::SIGMAP);
+         //readIonosphereNodeVariable(inVlsv, "ig_sigmaparallel", ionosphereGrid, ionosphereParameters::SIGMAPARALLEL);
+         assignConductivityTensorFromLoadedData(nodes);
+      } 
    } else if(sigmaString == "ponly") {
          Real sigmaP=3.;
          Real sigmaH=0.;


### PR DESCRIPTION
Cleaning up makefile after fieldtracing changes broke it, added the ability to load bulk files from 3D runs and solve those, updated help text.

This also adds the ionosphere miniApps to the automatic build checks, so that it doesn't break again.