### PR TITLE
Add github action to report automatic testpackage runs to PR checks

### DIFF
--- a/.github/workflows/pr_report.yml
+++ b/.github/workflows/pr_report.yml
@@ -1,0 +1,45 @@
+name: Report
+on:
+  workflow_run:
+    workflows: [Github-CI]
+    types: [completed]
+
+permissions:
+  checks: write
+
+jobs:
+  testpackage_report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: download testpackage output
+        # Note we are downloading an artifact from a
+        # *different* workflow here.
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: testpackage-output
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+      - name: unpack and process pr output
+        id: unpack
+        run: |
+          tar -xzvf testpackage-output.tar.gz
+          cat testpackage_output_variables.txt >> $GITHUB_OUTPUT
+      - name: Generate PR check report
+        uses: LouisBrunner/checks-action@v1.6.0
+        if: always()
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{github.event.workflow_run.head_sha}}
+          name: Testpackage result
+          conclusion: ${{ steps.unpack.outputs.conclusion }}
+          output: |
+            {"title": "Testpackage result", "summary":"${{ steps.unpack.outputs.summary }}"}
+          output_text_description_file: testpackage_check_description.txt
+
+     ## No need to bother with JUnit reports if the check runs work
+     #- name: Build test report
+     #  uses: mikepenz/action-junit-report@v3
+     #  with:
+     #    report_paths: 'testpackage_output_junit*.xml'
+     #    detailed_summary: true
+     #    include_passed: true

--- a/.github/workflows/pr_report.yml
+++ b/.github/workflows/pr_report.yml
@@ -14,7 +14,7 @@ jobs:
       - name: download testpackage output
         # Note we are downloading an artifact from a
         # *different* workflow here.
-        uses: dawidd6/action-download-artifact@v2
+        uses: ursg/action-download-artifact@v2
         with:
           name: testpackage-output
           workflow: ${{ github.event.workflow.id }}
@@ -25,7 +25,7 @@ jobs:
           tar -xzvf testpackage-output.tar.gz
           cat testpackage_output_variables.txt >> $GITHUB_OUTPUT
       - name: Generate PR check report
-        uses: LouisBrunner/checks-action@v1.6.0
+        uses: ursg/checks-action@v1.6.0
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is an out-of-order PR directly onto master, bypassing the regular dev staging.

For security reasons, Github Actions wants this workflow file in the master branch of the repository, and will not otherwise run it. So to get the testpackage result as a nice good/neutral/bad checkmark on pull requests, this file needs to go into master.

(The alternative would be to wait until our next merge-dev-to-master-and-release, which might also be soon)