### PR TITLE
Dev no double phiprof calls

### DIFF
--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -666,8 +666,6 @@ void calculateCurvatureSimple(
       }
    }
    
-   phiprof::stop(timer,N_cells,"Spatial Cells");
-   
    phiprof::stop("Calculate curvature",N_cells,"Spatial Cells");
 }
 

--- a/fieldtracing/fieldtracing.cpp
+++ b/fieldtracing/fieldtracing.cpp
@@ -444,7 +444,7 @@ namespace FieldTracing {
             cerr << __FILE__ << ":" << __LINE__ << ": invalid elementIndex returned for coordinate "
             << x[0] << " " << x[1] << " " << x[2] << " projected to rx " << rx[0] << " " << rx[1] << " " << rx[2]
             << ". Last valid elementIndex: " << oldElementIndex << "." << endl;
-            phiprof::stop("ionosphere-VlasovGridCoupling");
+            phiprof::stop("fieldtracing-ionosphere-VlasovGridCoupling");
             return coupling;
          }
       }

--- a/grid.cpp
+++ b/grid.cpp
@@ -58,7 +58,6 @@
 #endif
 
 using namespace std;
-using namespace phiprof;
 
 int globalflags::AMRstencilWidth = VLASOV_STENCIL_WIDTH;
 

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -48,7 +48,6 @@
 #include "fieldtracing/fieldtracing.h"
 
 using namespace std;
-using namespace phiprof;
 using namespace vlsv;
 
 extern Logger logFile, diagnostic;

--- a/tools/check_vlasiator_cfg.sh
+++ b/tools/check_vlasiator_cfg.sh
@@ -65,7 +65,7 @@ done
 
 
 # List of prefixes to allow (excludes all but the active project's project options)
-for prefix in $project $boundaries $population_prefixes AMR bailout boundaries fieldsolver gridbuilder io loadBalance Project_common restart variables vlasovsolver
+for prefix in $project $boundaries $population_prefixes AMR bailout boundaries fieldsolver fieldtracing gridbuilder io loadBalance Project_common restart variables vlasovsolver
 do
    echo "${prefix}\."
 done > .allowed_prefixes

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -73,7 +73,6 @@ Logger logFile, diagnostic;
 static dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry> mpiGrid;
 
 using namespace std;
-using namespace phiprof;
 
 int globalflags::bailingOut = 0;
 bool globalflags::writeRestart = 0;


### PR DESCRIPTION
Found one mistake which crashed TAU, one forgotten renamed stop call, and removed three using namespace phiprof lines that were useless.