### PR TITLE
Failure of the testpackage in CI should set red check marks.

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -185,6 +185,10 @@ jobs:
         cat $GITHUB_STEP_SUMMARY > $GITHUB_WORKSPACE/testpackage_check_description.txt
         cd $GITHUB_WORKSPACE
         tar -czvf testpackage-output.tar.gz testpackage_check_description.txt testpackage_output_variables.txt
+        if [ -f $GITHUB_WORKSPACE/testpackage_failed ]; then
+          # Fail this step if any test failed.
+          exit 1
+        fi
     - name: Upload testpackage output
       uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/pr_report.yml
+++ b/.github/workflows/pr_report.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           tar -xzvf testpackage-output.tar.gz
           cat testpackage_output_variables.txt >> $GITHUB_OUTPUT
+          # Limit Report filesize, as github only allows 64k PR reports
+          truncate --size='<60K' testpackage_check_description.txt
       - name: Generate PR check report
         uses: ursg/checks-action@v1.6.0
         if: always()

--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -135,6 +135,8 @@ for run in ${run_tests[*]}; do
       cat $GITHUB_WORKSPACE/stderr.txt >> $GITHUB_STEP_SUMMARY
       echo -e "\`'`'`\n</details>" >> $GITHUB_STEP_SUMMARY
       FAILEDTESTS=$((FAILEDTESTS+1))
+
+      touch $GITHUB_WORKSPACE/testpackage_failed
       continue
    fi
 

--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -131,9 +131,9 @@ for run in ${run_tests[*]}; do
       echo -e "<details><summary>:red_circle: ${test_name[$run]}: Failed to run or died with an error.</summary>\n"  >> $GITHUB_STEP_SUMMARY
       echo -e "Stdout:\n \`\`\`\n" >> $GITHUB_STEP_SUMMARY
       cat $GITHUB_WORKSPACE/stdout.txt >> $GITHUB_STEP_SUMMARY
-      echo -e "\`'`'`\nStderr:\n \`\`\`\n" >> $GITHUB_STEP_SUMMARY
+      echo -e "\`\`\`\nStderr:\n \`\`\`\n" >> $GITHUB_STEP_SUMMARY
       cat $GITHUB_WORKSPACE/stderr.txt >> $GITHUB_STEP_SUMMARY
-      echo -e "\`'`'`\n</details>" >> $GITHUB_STEP_SUMMARY
+      echo -e "\`\`\`\n</details>" >> $GITHUB_STEP_SUMMARY
       FAILEDTESTS=$((FAILEDTESTS+1))
 
       touch $GITHUB_WORKSPACE/testpackage_failed

--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -119,13 +119,13 @@ for run in ${run_tests[*]}; do
 
    # Run the actual simulation
    if [[ ${single_cell[$run]} ]]; then
-      { $small_run_command $bin --run_config=${test_name[$run]}.cfg 2>&1 1>&3 3>&- | tee $GITHUB_WORKSPACE/stderr.txt; } 3>&1 1>&2 | tee $GITHUB_WORKSPACE/stdout.txt
+      { $small_run_command $bin --run_config=${test_name[$run]}.cfg 2>&1 1>&3 3>&- | tee $GITHUB_WORKSPACE/stderr.txt; exit ${PIPESTATUS[0]}; } 3>&1 1>&2 | tee $GITHUB_WORKSPACE/stdout.txt
    else
-      { $run_command $bin --run_config=${test_name[$run]}.cfg 2>&1 1>&3 3>&- | tee $GITHUB_WORKSPACE/stderr.txt; } 3>&1 1>&2 | tee $GITHUB_WORKSPACE/stdout.txt
+      { $run_command $bin --run_config=${test_name[$run]}.cfg 2>&1 1>&3 3>&- | tee $GITHUB_WORKSPACE/stderr.txt; exit ${PIPESTATUS[0]}; } 3>&1 1>&2 | tee $GITHUB_WORKSPACE/stdout.txt
    fi
 
    # Store error return value
-   RUN_ERROR=$?
+   RUN_ERROR=${PIPESTATUS[0]}
 
    if [[ $RUN_ERROR != 0 ]]; then
       echo -e "<details><summary>:red_circle: ${test_name[$run]}: Failed to run or died with an error.</summary>\n"  >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This modifies the main CI workflow to fail the testpackage step if any test fails.

Also, the report step limits the uploaded report size to 60kb.