### PR TITLE
CI Test: Sabotage testpackage configs by introducing bogus output parameters.

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -185,6 +185,10 @@ jobs:
         cat $GITHUB_STEP_SUMMARY > $GITHUB_WORKSPACE/testpackage_check_description.txt
         cd $GITHUB_WORKSPACE
         tar -czvf testpackage-output.tar.gz testpackage_check_description.txt testpackage_output_variables.txt
+        if [ -f $GITHUB_WORKSPACE/testpackage_failed ]; then
+          # Fail this step if any test failed.
+          exit 1
+        fi
     - name: Upload testpackage output
       uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/pr_report.yml
+++ b/.github/workflows/pr_report.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           tar -xzvf testpackage-output.tar.gz
           cat testpackage_output_variables.txt >> $GITHUB_OUTPUT
+          # Limit Report filesize, as github only allows 64k PR reports
+          truncate --size='<60K' testpackage_check_description.txt
       - name: Generate PR check report
         uses: ursg/checks-action@v1.6.0
         if: always()

--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -135,6 +135,8 @@ for run in ${run_tests[*]}; do
       cat $GITHUB_WORKSPACE/stderr.txt >> $GITHUB_STEP_SUMMARY
       echo -e "\`'`'`\n</details>" >> $GITHUB_STEP_SUMMARY
       FAILEDTESTS=$((FAILEDTESTS+1))
+
+      touch $GITHUB_WORKSPACE/testpackage_failed
       continue
    fi
 

--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -131,9 +131,9 @@ for run in ${run_tests[*]}; do
       echo -e "<details><summary>:red_circle: ${test_name[$run]}: Failed to run or died with an error.</summary>\n"  >> $GITHUB_STEP_SUMMARY
       echo -e "Stdout:\n \`\`\`\n" >> $GITHUB_STEP_SUMMARY
       cat $GITHUB_WORKSPACE/stdout.txt >> $GITHUB_STEP_SUMMARY
-      echo -e "\`'`'`\nStderr:\n \`\`\`\n" >> $GITHUB_STEP_SUMMARY
+      echo -e "\`\`\`\nStderr:\n \`\`\`\n" >> $GITHUB_STEP_SUMMARY
       cat $GITHUB_WORKSPACE/stderr.txt >> $GITHUB_STEP_SUMMARY
-      echo -e "\`'`'`\n</details>" >> $GITHUB_STEP_SUMMARY
+      echo -e "\`\`\`\n</details>" >> $GITHUB_STEP_SUMMARY
       FAILEDTESTS=$((FAILEDTESTS+1))
 
       touch $GITHUB_WORKSPACE/testpackage_failed

--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -119,13 +119,13 @@ for run in ${run_tests[*]}; do
 
    # Run the actual simulation
    if [[ ${single_cell[$run]} ]]; then
-      { $small_run_command $bin --run_config=${test_name[$run]}.cfg 2>&1 1>&3 3>&- | tee $GITHUB_WORKSPACE/stderr.txt; } 3>&1 1>&2 | tee $GITHUB_WORKSPACE/stdout.txt
+      { $small_run_command $bin --run_config=${test_name[$run]}.cfg 2>&1 1>&3 3>&- | tee $GITHUB_WORKSPACE/stderr.txt; exit ${PIPESTATUS[0]}; } 3>&1 1>&2 | tee $GITHUB_WORKSPACE/stdout.txt
    else
-      { $run_command $bin --run_config=${test_name[$run]}.cfg 2>&1 1>&3 3>&- | tee $GITHUB_WORKSPACE/stderr.txt; } 3>&1 1>&2 | tee $GITHUB_WORKSPACE/stdout.txt
+      { $run_command $bin --run_config=${test_name[$run]}.cfg 2>&1 1>&3 3>&- | tee $GITHUB_WORKSPACE/stderr.txt; exit ${PIPESTATUS[0]}; } 3>&1 1>&2 | tee $GITHUB_WORKSPACE/stdout.txt
    fi
 
    # Store error return value
-   RUN_ERROR=$?
+   RUN_ERROR=${PIPESTATUS[0]}
 
    if [[ $RUN_ERROR != 0 ]]; then
       echo -e "<details><summary>:red_circle: ${test_name[$run]}: Failed to run or died with an error.</summary>\n"  >> $GITHUB_STEP_SUMMARY

--- a/testpackage/tests/Flowthrough_amr/Flowthrough_amr.cfg
+++ b/testpackage/tests/Flowthrough_amr/Flowthrough_amr.cfg
@@ -52,6 +52,7 @@ system_write_distribution_yline_stride = 0
 system_write_distribution_zline_stride = 0
 
 [variables]
+output = pudding
 output = populations_vg_rho
 output = populations_vg_v
 output = fg_e

--- a/testpackage/tests/Ionosphere_small/Ionosphere_small.cfg
+++ b/testpackage/tests/Ionosphere_small/Ionosphere_small.cfg
@@ -63,6 +63,7 @@ maxSlAccelerationRotation = 22
 rebalanceInterval = 10
 
 [variables]
+output = molten_cheese
 output = populations_vg_rho
 output = populations_vg_v
 output = populations_vg_blocks

--- a/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
+++ b/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
@@ -65,6 +65,7 @@ maxSlAccelerationSubcycles = 2
 rebalanceInterval = 50
 
 [variables]
+output = Nachos
 output = populations_vg_rho
 output = fg_b
 output = fg_e


### PR DESCRIPTION
This should fail the CI run with a friendly error message and a red check mark.

(This includes the commits of #718. Merge that one, not this one!)