### PR TITLE
Timer object

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -36,8 +36,9 @@ jobs:
           cp fsgrid/fsgrid.hpp $GITHUB_WORKSPACE/libraries/include
       - name: Build phiprof
         run: |
-          git clone https://github.com/fmihpc/phiprof/ 
+          git clone https://github.com/lkotipal/phiprof/ 
           cd phiprof/src
+          git checkout timer-object
           make -j 4 CCC=mpic++
           cp ../include/* $GITHUB_WORKSPACE/libraries/include
           cp ../lib/* $GITHUB_WORKSPACE/libraries/lib

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -36,9 +36,8 @@ jobs:
           cp fsgrid/fsgrid.hpp $GITHUB_WORKSPACE/libraries/include
       - name: Build phiprof
         run: |
-          git clone https://github.com/lkotipal/phiprof/ 
+          git clone https://github.com/fmihpc/phiprof/ 
           cd phiprof/src
-          git checkout timer-object
           make -j 4 CCC=mpic++
           cp ../include/* $GITHUB_WORKSPACE/libraries/include
           cp ../lib/* $GITHUB_WORKSPACE/libraries/lib

--- a/MAKE/Makefile.carrington_gcc_openmpi
+++ b/MAKE/Makefile.carrington_gcc_openmpi
@@ -100,8 +100,8 @@ JEMALLOC_VERSION = 5.2.1
 LIBRARY_PREFIX = /proj/group/spacephysics/libraries
 
 #compiled libraries mostly in modules
-LIB_PROFILE = -L/proj/lkotipal/libraries/phiprof/lib -lphiprof -Wl,-rpath=/proj/lkotipal/libraries/phiprof/lib
-INC_PROFILE = -I/proj/lkotipal/libraries/phiprof/include
+LIB_PROFILE = -L$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/phiprof/lib -lphiprof -Wl,-rpath=$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/phiprof/lib
+INC_PROFILE = -I $(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/phiprof/include
 
 LIB_VLSV = -L$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/vlsv -lvlsv -Wl,-rpath=$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/vlsv
 INC_VLSV = -I$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/vlsv

--- a/MAKE/Makefile.carrington_gcc_openmpi
+++ b/MAKE/Makefile.carrington_gcc_openmpi
@@ -100,8 +100,8 @@ JEMALLOC_VERSION = 5.2.1
 LIBRARY_PREFIX = /proj/group/spacephysics/libraries
 
 #compiled libraries mostly in modules
-LIB_PROFILE = -L/proj/lkotipal/phiprof/lib -lphiprof -Wl,-rpath=/proj/lkotipal/phiprof/lib
-INC_PROFILE = -I/proj/lkotipal/phiprof/include
+LIB_PROFILE = -L/proj/lkotipal/libraries/phiprof/lib -lphiprof -Wl,-rpath=/proj/lkotipal/libraries/phiprof/lib
+INC_PROFILE = -I/proj/lkotipal/libraries/phiprof/include
 
 LIB_VLSV = -L$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/vlsv -lvlsv -Wl,-rpath=$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/vlsv
 INC_VLSV = -I$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/vlsv

--- a/MAKE/Makefile.carrington_gcc_openmpi
+++ b/MAKE/Makefile.carrington_gcc_openmpi
@@ -100,8 +100,8 @@ JEMALLOC_VERSION = 5.2.1
 LIBRARY_PREFIX = /proj/group/spacephysics/libraries
 
 #compiled libraries mostly in modules
-LIB_PROFILE = -L$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/phiprof/lib -lphiprof -Wl,-rpath=$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/phiprof/lib
-INC_PROFILE = -I $(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/phiprof/include
+LIB_PROFILE = -L/proj/lkotipal/phiprof/lib -lphiprof -Wl,-rpath=/proj/lkotipal/phiprof/lib
+INC_PROFILE = -I/proj/lkotipal/phiprof/include
 
 LIB_VLSV = -L$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/vlsv -lvlsv -Wl,-rpath=$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/vlsv
 INC_VLSV = -I$(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAND)/$(MPT_VERSION)/carrington/vlsv

--- a/backgroundfield/backgroundfield.cpp
+++ b/backgroundfield/backgroundfield.cpp
@@ -58,13 +58,17 @@ void setBackgroundField(
       faceCoord2[2]=1;
       
       auto localSize = BgBGrid.getLocalSize();
+
+      int loopTopId {phiprof::initializeTimer("loop-top")};
+      int loopFaceId {phiprof::initializeTimer("loop-face-averages")};
+      int loopVolumeId {phiprof::initializeTimer("loop-volume-averages")};
       
       // These are threaded now that the dipole field is threadsafe
       #pragma omp parallel for collapse(3)
       for (int x = 0; x < localSize[0]; ++x) {
          for (int y = 0; y < localSize[1]; ++y) {
             for (int z = 0; z < localSize[2]; ++z) {
-               phiprof::start("loop-top");
+               phiprof::Timer loopTopTimer {loopTopId};
                std::array<double, 3> start = BgBGrid.getPhysicalCoords(x, y, z);
                double dx[3];
                dx[0] = BgBGrid.DX;
@@ -74,9 +78,9 @@ void setBackgroundField(
                end[0]=start[0]+dx[0];
                end[1]=start[1]+dx[1];
                end[2]=start[2]+dx[2];
-               phiprof::stop("loop-top");
+               loopTopTimer.stop();
                
-               phiprof::start("loop-face-averages");
+               phiprof::Timer loopFaceTimer {loopFaceId};
                //Face averages
                for(uint fComponent=0; fComponent<3; fComponent++){
                   T3DFunction valueFunction = std::bind(bgFunction, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, (coordinate)fComponent, 0, (coordinate)0);
@@ -112,9 +116,9 @@ void setBackgroundField(
                                     dx[faceCoord2[fComponent]]
                                    );
                }
-               phiprof::stop("loop-face-averages");
+               loopFaceTimer.stop();
                
-               phiprof::start("loop-volume-averages");
+               phiprof::Timer loopVolumeTimer {loopVolumeId};
                //Volume averages
                for(unsigned int fComponent=0;fComponent<3;fComponent++){
                   T3DFunction valueFunction = std::bind(bgFunction, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, (coordinate)fComponent, 0, (coordinate)0);
@@ -126,7 +130,7 @@ void setBackgroundField(
                   derivFunction = std::bind(bgFunction, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, (coordinate)fComponent, 1, (coordinate)faceCoord2[fComponent]);
                   BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBXVOLdy+1+2*fComponent) += dx[faceCoord2[fComponent]] * volumeAverage(derivFunction,accuracy,start.data(),end);
                }
-               phiprof::stop("loop-volume-averages");
+               loopVolumeTimer.stop();
             }
          }
       }

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -323,9 +323,9 @@ void calculateDerivativesSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::Timer derivatives {"Calculate face derivatives"};
+   phiprof::Timer derivativesTimer {"Calculate face derivatives"};
    
-   phiprof::Timer mpi {"MPI", {"MPI"}};
+   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
    
    switch (RKCase) {
     case RK_ORDER1:
@@ -361,9 +361,9 @@ void calculateDerivativesSimple(
       abort();
    }
    
-   mpi.stop();
+   mpiTimer.stop();
 
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
    // Calculate derivatives
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -379,9 +379,9 @@ void calculateDerivativesSimple(
       }
    }
 
-   compute.stop(N_cells, "Spatial Cells");
+   computeTimer.stop(N_cells, "Spatial Cells");
    
-   derivatives.stop(N_cells, "Spatial Cells");   
+   derivativesTimer.stop(N_cells, "Spatial Cells");   
 }
 
 /*! \brief Low-level spatial derivatives calculation.
@@ -493,14 +493,14 @@ void calculateBVOLDerivativesSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::Timer derivs {"Calculate volume derivatives"};
+   phiprof::Timer derivsTimer {"Calculate volume derivatives"};
    
-   phiprof::Timer comm {"Start comm", {"MPI"}};
+   phiprof::Timer commTimer {"Start comm", {"MPI"}};
    volGrid.updateGhostCells();
-   comm.stop(N_cells,"Spatial Cells");
+   commTimer.stop(N_cells,"Spatial Cells");
    
    // Calculate derivatives
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
    
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -514,9 +514,9 @@ void calculateBVOLDerivativesSimple(
       }
    }
 
-   compute.stop(N_cells,"Spatial Cells");
+   computeTimer.stop(N_cells,"Spatial Cells");
 
-   derivs.stop(N_cells,"Spatial Cells");
+   derivsTimer.stop(N_cells,"Spatial Cells");
 }
 
 /*! \brief Low-level curvature calculation.
@@ -640,11 +640,11 @@ void calculateCurvatureSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::Timer curvature {"Calculate curvature"};
+   phiprof::Timer curvatureTimer {"Calculate curvature"};
    
-   phiprof::Timer comm {"Start comm", {"MPI"}};
+   phiprof::Timer commTimer {"Start comm", {"MPI"}};
    volGrid.updateGhostCells();
-   comm.stop(N_cells,"Spatial Cells");
+   commTimer.stop(N_cells,"Spatial Cells");
    
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -658,7 +658,7 @@ void calculateCurvatureSimple(
       }
    }
    
-   curvature.stop(N_cells, "Spatial Cells");
+   curvatureTimer.stop(N_cells, "Spatial Cells");
 }
 
 /*! \brief Returns volumetric E of cell
@@ -811,18 +811,18 @@ void calculateScaledDeltasSimple(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geome
    const vector<CellID>& cells = getLocalCells();
    int N_cells = cells.size();
    int timer;
-   phiprof::Timer gradients {"Calculate volume gradients"};
+   phiprof::Timer gradientsTimer {"Calculate volume gradients"};
    
-   phiprof::Timer comm {"Start comm", {"MPI"}};
+   phiprof::Timer commTimer {"Start comm", {"MPI"}};
 
    // We only need nearest neighbourhood and spatial data here
    SpatialCell::set_mpi_transfer_type(Transfer::ALL_SPATIAL_DATA);
    mpiGrid.update_copies_of_remote_neighbors(NEAREST_NEIGHBORHOOD_ID);
    
-   comm.stop(N_cells,"Spatial Cells");
+   commTimer.stop(N_cells,"Spatial Cells");
    
    // Calculate derivatives
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
 
    #pragma omp parallel for
    for (uint i = 0; i < cells.size(); ++i) {
@@ -836,7 +836,7 @@ void calculateScaledDeltasSimple(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geome
       calculateScaledDeltas(cell, neighbors);
    }
 
-   compute.stop(N_cells,"Spatial Cells");
+   computeTimer.stop(N_cells,"Spatial Cells");
 
-   gradients.stop(N_cells,"Spatial Cells");
+   gradientsTimer.stop(N_cells,"Spatial Cells");
 }

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -323,9 +323,9 @@ void calculateDerivativesSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::Timer derivativesTimer {"Calculate face derivatives"};
+   phiprof::Timer derivatives {"Calculate face derivatives"};
    
-   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
+   phiprof::Timer mpi {"MPI", {"MPI"}};
    
    switch (RKCase) {
     case RK_ORDER1:
@@ -361,9 +361,9 @@ void calculateDerivativesSimple(
       abort();
    }
    
-   mpiTimer.stop();
+   mpi.stop();
 
-   phiprof::Timer computeTimer {"Compute cells"};
+   phiprof::Timer compute {"Compute cells"};
    // Calculate derivatives
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -493,14 +493,14 @@ void calculateBVOLDerivativesSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::Timer derivsTimer {"Calculate volume derivatives"};
+   phiprof::Timer derivs {"Calculate volume derivatives"};
    
-   phiprof::Timer commTimer {"Start comm", {"MPI"}};
+   phiprof::Timer comm {"Start comm", {"MPI"}};
    volGrid.updateGhostCells();
    comm.stop(N_cells,"Spatial Cells");
    
    // Calculate derivatives
-   phiprof::Timer computeTimer {"Compute cells"};
+   phiprof::Timer compute {"Compute cells"};
    
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -640,9 +640,9 @@ void calculateCurvatureSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::Timer curvatureTimer {"Calculate curvature"};
+   phiprof::Timer curvature {"Calculate curvature"};
    
-   phiprof::Timer commTimer {"Start comm", {"MPI"}};
+   phiprof::Timer comm {"Start comm", {"MPI"}};
    volGrid.updateGhostCells();
    comm.stop(N_cells,"Spatial Cells");
    
@@ -811,9 +811,9 @@ void calculateScaledDeltasSimple(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geome
    const vector<CellID>& cells = getLocalCells();
    int N_cells = cells.size();
    int timer;
-   phiprof::Timer gradientsTimer {"Calculate volume gradients"};
+   phiprof::Timer gradients {"Calculate volume gradients"};
    
-   phiprof::Timer commTimer {"Start comm", {"MPI"}};
+   phiprof::Timer comm {"Start comm", {"MPI"}};
 
    // We only need nearest neighbourhood and spatial data here
    SpatialCell::set_mpi_transfer_type(Transfer::ALL_SPATIAL_DATA);
@@ -822,7 +822,7 @@ void calculateScaledDeltasSimple(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geome
    comm.stop(N_cells,"Spatial Cells");
    
    // Calculate derivatives
-   phiprof::Timer computeTimer {"Compute cells"};
+   phiprof::Timer compute {"Compute cells"};
 
    #pragma omp parallel for
    for (uint i = 0; i < cells.size(); ++i) {

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -323,10 +323,9 @@ void calculateDerivativesSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::start("Calculate face derivatives");
+   phiprof::Timer derivatives {"Calculate face derivatives"};
    
-   timer=phiprof::initializeTimer("MPI","MPI");
-   phiprof::start(timer);
+   phiprof::Timer mpi {"MPI", {"MPI"}};
    
    switch (RKCase) {
     case RK_ORDER1:
@@ -362,11 +361,9 @@ void calculateDerivativesSimple(
       abort();
    }
    
-   phiprof::stop(timer);
+   mpi.stop();
 
-   timer=phiprof::initializeTimer("Compute cells");
-   phiprof::start(timer);
-
+   phiprof::Timer compute {"Compute cells"};
    // Calculate derivatives
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -382,9 +379,9 @@ void calculateDerivativesSimple(
       }
    }
 
-   phiprof::stop(timer,N_cells,"Spatial Cells");
+   compute.stop(N_cells, "Spatial Cells");
    
-   phiprof::stop("Calculate face derivatives",N_cells,"Spatial Cells");   
+   derivatives.stop(N_cells, "Spatial Cells");   
 }
 
 /*! \brief Low-level spatial derivatives calculation.
@@ -496,18 +493,14 @@ void calculateBVOLDerivativesSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::start("Calculate volume derivatives");
+   phiprof::Timer derivs {"Calculate volume derivatives"};
    
-   timer=phiprof::initializeTimer("Start comm","MPI");
-   phiprof::start(timer);
+   phiprof::Timer comm {"Start comm", {"MPI"}};
    volGrid.updateGhostCells();
-   
-   phiprof::stop(timer,N_cells,"Spatial Cells");
-   
+   comm.stop(N_cells,"Spatial Cells");
    
    // Calculate derivatives
-   timer=phiprof::initializeTimer("Compute cells");
-   phiprof::start(timer);
+   phiprof::Timer compute {"Compute cells"};
    
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -521,9 +514,9 @@ void calculateBVOLDerivativesSimple(
       }
    }
 
-   phiprof::stop(timer,N_cells,"Spatial Cells");
+   compute.stop(N_cells,"Spatial Cells");
 
-   phiprof::stop("Calculate volume derivatives",N_cells,"Spatial Cells");
+   derivs.stop(N_cells,"Spatial Cells");
 }
 
 /*! \brief Low-level curvature calculation.
@@ -647,12 +640,11 @@ void calculateCurvatureSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::start("Calculate curvature");
+   phiprof::Timer curvature {"Calculate curvature"};
    
-   timer=phiprof::initializeTimer("Start comm","MPI");
-   phiprof::start(timer);
+   phiprof::Timer comm {"Start comm", {"MPI"}};
    volGrid.updateGhostCells();
-   phiprof::stop(timer,N_cells,"Spatial Cells");
+   comm.stop(N_cells,"Spatial Cells");
    
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -666,7 +658,7 @@ void calculateCurvatureSimple(
       }
    }
    
-   phiprof::stop("Calculate curvature",N_cells,"Spatial Cells");
+   curvature.stop(N_cells, "Spatial Cells");
 }
 
 /*! \brief Returns volumetric E of cell
@@ -819,20 +811,18 @@ void calculateScaledDeltasSimple(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geome
    const vector<CellID>& cells = getLocalCells();
    int N_cells = cells.size();
    int timer;
-   phiprof::start("Calculate volume gradients");
+   phiprof::Timer gradients {"Calculate volume gradients"};
    
-   timer=phiprof::initializeTimer("Start comm","MPI");
-   phiprof::start(timer);
+   phiprof::Timer comm {"Start comm", {"MPI"}};
 
    // We only need nearest neighbourhood and spatial data here
    SpatialCell::set_mpi_transfer_type(Transfer::ALL_SPATIAL_DATA);
    mpiGrid.update_copies_of_remote_neighbors(NEAREST_NEIGHBORHOOD_ID);
    
-   phiprof::stop(timer,N_cells,"Spatial Cells");
+   comm.stop(N_cells,"Spatial Cells");
    
    // Calculate derivatives
-   timer=phiprof::initializeTimer("Compute cells");
-   phiprof::start(timer);
+   phiprof::Timer compute {"Compute cells"};
 
    #pragma omp parallel for
    for (uint i = 0; i < cells.size(); ++i) {
@@ -846,7 +836,7 @@ void calculateScaledDeltasSimple(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geome
       calculateScaledDeltas(cell, neighbors);
    }
 
-   phiprof::stop(timer,N_cells,"Spatial Cells");
+   compute.stop(N_cells,"Spatial Cells");
 
-   phiprof::stop("Calculate volume gradients",N_cells,"Spatial Cells");
+   gradients.stop(N_cells,"Spatial Cells");
 }

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -323,9 +323,9 @@ void calculateDerivativesSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::Timer derivatives {"Calculate face derivatives"};
+   phiprof::Timer derivativesTimer {"Calculate face derivatives"};
    
-   phiprof::Timer mpi {"MPI", {"MPI"}};
+   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
    
    switch (RKCase) {
     case RK_ORDER1:
@@ -361,9 +361,9 @@ void calculateDerivativesSimple(
       abort();
    }
    
-   mpi.stop();
+   mpiTimer.stop();
 
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
    // Calculate derivatives
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -493,14 +493,14 @@ void calculateBVOLDerivativesSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::Timer derivs {"Calculate volume derivatives"};
+   phiprof::Timer derivsTimer {"Calculate volume derivatives"};
    
-   phiprof::Timer comm {"Start comm", {"MPI"}};
+   phiprof::Timer commTimer {"Start comm", {"MPI"}};
    volGrid.updateGhostCells();
    comm.stop(N_cells,"Spatial Cells");
    
    // Calculate derivatives
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
    
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -640,9 +640,9 @@ void calculateCurvatureSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::Timer curvature {"Calculate curvature"};
+   phiprof::Timer curvatureTimer {"Calculate curvature"};
    
-   phiprof::Timer comm {"Start comm", {"MPI"}};
+   phiprof::Timer commTimer {"Start comm", {"MPI"}};
    volGrid.updateGhostCells();
    comm.stop(N_cells,"Spatial Cells");
    
@@ -811,9 +811,9 @@ void calculateScaledDeltasSimple(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geome
    const vector<CellID>& cells = getLocalCells();
    int N_cells = cells.size();
    int timer;
-   phiprof::Timer gradients {"Calculate volume gradients"};
+   phiprof::Timer gradientsTimer {"Calculate volume gradients"};
    
-   phiprof::Timer comm {"Start comm", {"MPI"}};
+   phiprof::Timer commTimer {"Start comm", {"MPI"}};
 
    // We only need nearest neighbourhood and spatial data here
    SpatialCell::set_mpi_transfer_type(Transfer::ALL_SPATIAL_DATA);
@@ -822,7 +822,7 @@ void calculateScaledDeltasSimple(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geome
    comm.stop(N_cells,"Spatial Cells");
    
    // Calculate derivatives
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
 
    #pragma omp parallel for
    for (uint i = 0; i < cells.size(); ++i) {

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -301,7 +301,7 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
 
    //Filter Moments if this is a 3D AMR run.
   if (P::amrMaxSpatialRefLevel>0) { 
-      phiprof::Timer filteringTimer {"AMR Filtering-Triangle-3D"};
+      phiprof::Timer filtering {"AMR Filtering-Triangle-3D"};
       filterMoments(mpiGrid,momentsGrid,technicalGrid);
    }   
 }

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -301,7 +301,7 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
 
    //Filter Moments if this is a 3D AMR run.
   if (P::amrMaxSpatialRefLevel>0) { 
-      phiprof::Timer filtering {"AMR Filtering-Triangle-3D"};
+      phiprof::Timer filteringTimer {"AMR Filtering-Triangle-3D"};
       filterMoments(mpiGrid,momentsGrid,technicalGrid);
    }   
 }

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -301,9 +301,8 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
 
    //Filter Moments if this is a 3D AMR run.
   if (P::amrMaxSpatialRefLevel>0) { 
-      phiprof::start("AMR Filtering-Triangle-3D");
+      phiprof::Timer filtering {"AMR Filtering-Triangle-3D"};
       filterMoments(mpiGrid,momentsGrid,technicalGrid);
-      phiprof::stop("AMR Filtering-Triangle-3D");
    }   
 }
 

--- a/fieldsolver/ldz_electric_field.cpp
+++ b/fieldsolver/ldz_electric_field.cpp
@@ -1662,9 +1662,9 @@ void calculateUpwindedElectricFieldSimple(
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
-   phiprof::Timer upwindedETimer {"Calculate upwinded electric field"};
+   phiprof::Timer upwindedE {"Calculate upwinded electric field"};
    
-   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
+   phiprof::Timer mpi {"MPI", {"MPI"}};
    // Update ghosts if necessary, unless previous terms have already updated them
    if(P::ohmHallTerm > 0) {
       EHallGrid.updateGhostCells();
@@ -1679,10 +1679,10 @@ void calculateUpwindedElectricFieldSimple(
       dMomentsGrid.updateGhostCells();
    }
    
-   mpiTimer.stop();
+   mpi.stop();
    
    // Calculate upwinded electric field on inner cells
-   phiprof::Timer computeTimer {"Compute cells"};
+   phiprof::Timer compute {"Compute cells"};
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -1727,14 +1727,14 @@ void calculateUpwindedElectricFieldSimple(
    }
    compute.stop(N_cells,"Spatial Cells");
    
-   mpiTimer.start();
+   mpi.start();
    // Exchange electric field with neighbouring processes
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
       EGrid.updateGhostCells();
    } else { 
       EDt2Grid.updateGhostCells();
    }
-   mpiTimer.stop();
+   mpi.stop();
    
    upwindedE.stop(N_cells,"Spatial Cells");
 }

--- a/fieldsolver/ldz_electric_field.cpp
+++ b/fieldsolver/ldz_electric_field.cpp
@@ -1662,9 +1662,9 @@ void calculateUpwindedElectricFieldSimple(
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
-   phiprof::Timer upwindedE {"Calculate upwinded electric field"};
+   phiprof::Timer upwindedETimer {"Calculate upwinded electric field"};
    
-   phiprof::Timer mpi {"MPI", {"MPI"}};
+   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
    // Update ghosts if necessary, unless previous terms have already updated them
    if(P::ohmHallTerm > 0) {
       EHallGrid.updateGhostCells();
@@ -1679,10 +1679,10 @@ void calculateUpwindedElectricFieldSimple(
       dMomentsGrid.updateGhostCells();
    }
    
-   mpi.stop();
+   mpiTimer.stop();
    
    // Calculate upwinded electric field on inner cells
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -1725,16 +1725,16 @@ void calculateUpwindedElectricFieldSimple(
          }
       }
    }
-   compute.stop(N_cells,"Spatial Cells");
+   computeTimer.stop(N_cells,"Spatial Cells");
    
-   mpi.start();
+   mpiTimer.start();
    // Exchange electric field with neighbouring processes
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
       EGrid.updateGhostCells();
    } else { 
       EDt2Grid.updateGhostCells();
    }
-   mpi.stop();
+   mpiTimer.stop();
    
-   upwindedE.stop(N_cells,"Spatial Cells");
+   upwindedETimer.stop(N_cells,"Spatial Cells");
 }

--- a/fieldsolver/ldz_electric_field.cpp
+++ b/fieldsolver/ldz_electric_field.cpp
@@ -1662,10 +1662,9 @@ void calculateUpwindedElectricFieldSimple(
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
-   phiprof::start("Calculate upwinded electric field");
+   phiprof::Timer upwindedE {"Calculate upwinded electric field"};
    
-   timer=phiprof::initializeTimer("MPI","MPI");
-   phiprof::start(timer);
+   phiprof::Timer mpi {"MPI", {"MPI"}};
    // Update ghosts if necessary, unless previous terms have already updated them
    if(P::ohmHallTerm > 0) {
       EHallGrid.updateGhostCells();
@@ -1680,11 +1679,10 @@ void calculateUpwindedElectricFieldSimple(
       dMomentsGrid.updateGhostCells();
    }
    
-   phiprof::stop(timer);
+   mpi.stop();
    
    // Calculate upwinded electric field on inner cells
-   timer=phiprof::initializeTimer("Compute cells");
-   phiprof::start(timer);
+   phiprof::Timer compute {"Compute cells"};
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -1727,17 +1725,16 @@ void calculateUpwindedElectricFieldSimple(
          }
       }
    }
-   phiprof::stop(timer,N_cells,"Spatial Cells");
+   compute.stop(N_cells,"Spatial Cells");
    
-   timer=phiprof::initializeTimer("MPI","MPI");
-   phiprof::start(timer);
+   mpi.start();
    // Exchange electric field with neighbouring processes
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
       EGrid.updateGhostCells();
    } else { 
       EDt2Grid.updateGhostCells();
    }
-   phiprof::stop(timer);
+   mpi.stop();
    
-   phiprof::stop("Calculate upwinded electric field",N_cells,"Spatial Cells");
+   upwindedE.stop(N_cells,"Spatial Cells");
 }

--- a/fieldsolver/ldz_electric_field.cpp
+++ b/fieldsolver/ldz_electric_field.cpp
@@ -1662,9 +1662,9 @@ void calculateUpwindedElectricFieldSimple(
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
-   phiprof::Timer upwindedE {"Calculate upwinded electric field"};
+   phiprof::Timer upwindedETimer {"Calculate upwinded electric field"};
    
-   phiprof::Timer mpi {"MPI", {"MPI"}};
+   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
    // Update ghosts if necessary, unless previous terms have already updated them
    if(P::ohmHallTerm > 0) {
       EHallGrid.updateGhostCells();
@@ -1679,10 +1679,10 @@ void calculateUpwindedElectricFieldSimple(
       dMomentsGrid.updateGhostCells();
    }
    
-   mpi.stop();
+   mpiTimer.stop();
    
    // Calculate upwinded electric field on inner cells
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -1727,14 +1727,14 @@ void calculateUpwindedElectricFieldSimple(
    }
    compute.stop(N_cells,"Spatial Cells");
    
-   mpi.start();
+   mpiTimer.start();
    // Exchange electric field with neighbouring processes
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
       EGrid.updateGhostCells();
    } else { 
       EDt2Grid.updateGhostCells();
    }
-   mpi.stop();
+   mpiTimer.stop();
    
    upwindedE.stop(N_cells,"Spatial Cells");
 }

--- a/fieldsolver/ldz_gradpe.cpp
+++ b/fieldsolver/ldz_gradpe.cpp
@@ -163,14 +163,14 @@ void calculateGradPeTermSimple(
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
-   phiprof::Timer gradPe {"Calculate GradPe term"};
+   phiprof::Timer gradPeTimer {"Calculate GradPe term"};
 
-   phiprof::Timer mpi {"MPI", {"MPI"}};
+   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
    dMomentsGrid.updateGhostCells();
-   mpi.stop();
+   mpiTimer.stop();
 
    // Calculate GradPe term
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {

--- a/fieldsolver/ldz_gradpe.cpp
+++ b/fieldsolver/ldz_gradpe.cpp
@@ -163,16 +163,14 @@ void calculateGradPeTermSimple(
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
-   phiprof::start("Calculate GradPe term");
+   phiprof::Timer gradPe {"Calculate GradPe term"};
 
-   timer=phiprof::initializeTimer("MPI","MPI");
-   phiprof::start(timer);
+   phiprof::Timer mpi {"MPI", {"MPI"}};
    dMomentsGrid.updateGhostCells();
-   phiprof::stop(timer);
+   mpi.stop();
 
    // Calculate GradPe term
-   timer=phiprof::initializeTimer("Compute cells");
-   phiprof::start(timer);
+   phiprof::Timer compute {"Compute cells"};
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -185,7 +183,7 @@ void calculateGradPeTermSimple(
          }
       }
    }
-   phiprof::stop(timer,N_cells,"Spatial Cells");
+   compute.stop(N_cells,"Spatial Cells");
    
-   phiprof::stop("Calculate GradPe term",N_cells,"Spatial Cells");
+   gradPe.stop(N_cells,"Spatial Cells");
 }

--- a/fieldsolver/ldz_gradpe.cpp
+++ b/fieldsolver/ldz_gradpe.cpp
@@ -163,14 +163,14 @@ void calculateGradPeTermSimple(
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
-   phiprof::Timer gradPe {"Calculate GradPe term"};
+   phiprof::Timer gradPeTimer {"Calculate GradPe term"};
 
-   phiprof::Timer mpi {"MPI", {"MPI"}};
+   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
    dMomentsGrid.updateGhostCells();
-   mpi.stop();
+   mpiTimer.stop();
 
    // Calculate GradPe term
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -183,7 +183,7 @@ void calculateGradPeTermSimple(
          }
       }
    }
-   compute.stop(N_cells,"Spatial Cells");
+   computeTimer.stop(N_cells,"Spatial Cells");
    
-   gradPe.stop(N_cells,"Spatial Cells");
+   gradPeTimer.stop(N_cells,"Spatial Cells");
 }

--- a/fieldsolver/ldz_gradpe.cpp
+++ b/fieldsolver/ldz_gradpe.cpp
@@ -163,14 +163,14 @@ void calculateGradPeTermSimple(
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
-   phiprof::Timer gradPeTimer {"Calculate GradPe term"};
+   phiprof::Timer gradPe {"Calculate GradPe term"};
 
-   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
+   phiprof::Timer mpi {"MPI", {"MPI"}};
    dMomentsGrid.updateGhostCells();
-   mpiTimer.stop();
+   mpi.stop();
 
    // Calculate GradPe term
-   phiprof::Timer computeTimer {"Compute cells"};
+   phiprof::Timer compute {"Compute cells"};
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -811,15 +811,15 @@ void calculateHallTermSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
 
-   phiprof::Timer hall {"Calculate Hall term"};
-   phiprof::Timer mpi {"MPI", {"MPI"}};
+   phiprof::Timer hallTimer {"Calculate Hall term"};
+   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
    dPerBGrid.updateGhostCells();
    if(P::ohmGradPeTerm == 0) {
       dMomentsGrid.updateGhostCells();
    }
-   mpi.stop();
+   mpiTimer.stop();
 
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -832,7 +832,7 @@ void calculateHallTermSimple(
          }
       }
    }
-   compute.stop();
+   computeTimer.stop();
 
-   hall.stop(N_cells, "Spatial Cells");
+   hallTimer.stop(N_cells, "Spatial Cells");
 }

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -811,15 +811,15 @@ void calculateHallTermSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
 
-   phiprof::Timer hall {"Calculate Hall term"};
-   phiprof::Timer mpi {"MPI", {"MPI"}};
+   phiprof::Timer hallTimer {"Calculate Hall term"};
+   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
    dPerBGrid.updateGhostCells();
    if(P::ohmGradPeTerm == 0) {
       dMomentsGrid.updateGhostCells();
    }
-   mpi.stop();
+   mpiTimer.stop();
 
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -832,7 +832,7 @@ void calculateHallTermSimple(
          }
       }
    }
-   compute.stop();
+   computeTimer.stop();
 
    hall.stop(N_cells, "Spatial Cells");
 }

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -811,16 +811,15 @@ void calculateHallTermSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
 
-   phiprof::start("Calculate Hall term");
-   timer=phiprof::initializeTimer("MPI","MPI");
-   phiprof::start(timer);
+   phiprof::Timer hall {"Calculate Hall term"};
+   phiprof::Timer mpi {"MPI", {"MPI"}};
    dPerBGrid.updateGhostCells();
    if(P::ohmGradPeTerm == 0) {
       dMomentsGrid.updateGhostCells();
    }
-   phiprof::stop(timer);
+   mpi.stop();
 
-   phiprof::start("Compute cells");
+   phiprof::Timer compute {"Compute cells"};
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -833,7 +832,7 @@ void calculateHallTermSimple(
          }
       }
    }
-   phiprof::stop("Compute cells");
+   compute.stop();
 
-   phiprof::stop("Calculate Hall term",N_cells,"Spatial Cells");
+   hall.stop(N_cells, "Spatial Cells");
 }

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -811,15 +811,15 @@ void calculateHallTermSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
 
-   phiprof::Timer hallTimer {"Calculate Hall term"};
-   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
+   phiprof::Timer hall {"Calculate Hall term"};
+   phiprof::Timer mpi {"MPI", {"MPI"}};
    dPerBGrid.updateGhostCells();
    if(P::ohmGradPeTerm == 0) {
       dMomentsGrid.updateGhostCells();
    }
-   mpiTimer.stop();
+   mpi.stop();
 
-   phiprof::Timer computeTimer {"Compute cells"};
+   phiprof::Timer compute {"Compute cells"};
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -832,7 +832,7 @@ void calculateHallTermSimple(
          }
       }
    }
-   computeTimer.stop();
+   compute.stop();
 
    hall.stop(N_cells, "Spatial Cells");
 }

--- a/fieldsolver/ldz_magnetic_field.cpp
+++ b/fieldsolver/ldz_magnetic_field.cpp
@@ -252,9 +252,9 @@ void propagateMagneticFieldSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::Timer propagateB {"Propagate magnetic field"};
+   phiprof::Timer propagateBTimer {"Propagate magnetic field"};
    
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
    #pragma omp parallel for collapse(3) schedule(dynamic,1)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -271,7 +271,7 @@ void propagateMagneticFieldSimple(
    //This communication is needed for boundary conditions, in practice almost all
    //of the communication is going to be redone in calculateDerivativesSimple
    //TODO: do not transfer if there are no field boundaryconditions
-   phiprof::Timer mpi {"MPI", {"MPI"}};
+   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
       // Exchange PERBX,PERBY,PERBZ with neighbours
       perBGrid.updateGhostCells();
@@ -280,10 +280,10 @@ void propagateMagneticFieldSimple(
       perBDt2Grid.updateGhostCells();
    }
    
-   mpi.stop();
+   mpiTimer.stop();
    
    // Propagate B on system boundary/process inner cells
-   phiprof::Timer sysBoundary {"Compute system boundary cells"};
+   phiprof::Timer sysBoundaryTimer {"Compute system boundary cells"};
    // L1 pass
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -305,9 +305,9 @@ void propagateMagneticFieldSimple(
          }
       }
    }
-   sysBoundary.stop();
+   sysBoundaryTimer.stop();
    
-   mpi.start();
+   mpiTimer.start();
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
       // Exchange PERBX,PERBY,PERBZ with neighbours
       perBGrid.updateGhostCells();
@@ -315,9 +315,9 @@ void propagateMagneticFieldSimple(
       // Exchange PERBX_DT2,PERBY_DT2,PERBZ_DT2 with neighbours
       perBDt2Grid.updateGhostCells();
    }
-   mpi.stop();
+   mpiTimer.stop();
 
-   sysBoundary.start();
+   sysBoundaryTimer.start();
    // L2 pass
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -336,7 +336,7 @@ void propagateMagneticFieldSimple(
    sysBoundary.stop(N_cells,"Spatial Cells");
 
    // Projection of magnetic field to normal of boundary, if necessary
-   sysBoundary.start();
+   sysBoundaryTimer.start();
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {

--- a/fieldsolver/ldz_magnetic_field.cpp
+++ b/fieldsolver/ldz_magnetic_field.cpp
@@ -252,9 +252,9 @@ void propagateMagneticFieldSimple(
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    
-   phiprof::Timer propagateB {"Propagate magnetic field"};
+   phiprof::Timer propagateBTimer {"Propagate magnetic field"};
    
-   phiprof::Timer compute {"Compute cells"};
+   phiprof::Timer computeTimer {"Compute cells"};
    #pragma omp parallel for collapse(3) schedule(dynamic,1)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -266,12 +266,12 @@ void propagateMagneticFieldSimple(
    }
    
    //phiprof::stop("propagate not sysbound",localCells.size(),"Spatial Cells");
-   compute.stop(N_cells,"Spatial Cells");
+   computeTimer.stop(N_cells,"Spatial Cells");
    
    //This communication is needed for boundary conditions, in practice almost all
    //of the communication is going to be redone in calculateDerivativesSimple
    //TODO: do not transfer if there are no field boundaryconditions
-   phiprof::Timer mpi {"MPI", {"MPI"}};
+   phiprof::Timer mpiTimer {"MPI", {"MPI"}};
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
       // Exchange PERBX,PERBY,PERBZ with neighbours
       perBGrid.updateGhostCells();
@@ -280,10 +280,10 @@ void propagateMagneticFieldSimple(
       perBDt2Grid.updateGhostCells();
    }
    
-   mpi.stop();
+   mpiTimer.stop();
    
    // Propagate B on system boundary/process inner cells
-   phiprof::Timer sysBoundary {"Compute system boundary cells"};
+   phiprof::Timer sysBoundaryTimer {"Compute system boundary cells"};
    // L1 pass
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -305,9 +305,9 @@ void propagateMagneticFieldSimple(
          }
       }
    }
-   sysBoundary.stop();
+   sysBoundaryTimer.stop();
    
-   mpi.start();
+   mpiTimer.start();
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
       // Exchange PERBX,PERBY,PERBZ with neighbours
       perBGrid.updateGhostCells();
@@ -315,9 +315,9 @@ void propagateMagneticFieldSimple(
       // Exchange PERBX_DT2,PERBY_DT2,PERBZ_DT2 with neighbours
       perBDt2Grid.updateGhostCells();
    }
-   mpi.stop();
+   mpiTimer.stop();
 
-   sysBoundary.start();
+   sysBoundaryTimer.start();
    // L2 pass
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -333,10 +333,10 @@ void propagateMagneticFieldSimple(
          }
       }
    }
-   sysBoundary.stop(N_cells,"Spatial Cells");
+   sysBoundaryTimer.stop(N_cells,"Spatial Cells");
 
    // Projection of magnetic field to normal of boundary, if necessary
-   sysBoundary.start();
+   sysBoundaryTimer.start();
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
@@ -350,7 +350,7 @@ void propagateMagneticFieldSimple(
          }
       }
    }
-   sysBoundary.stop(N_cells,"Spatial Cells");
+   sysBoundaryTimer.stop(N_cells,"Spatial Cells");
    
-   propagateB.stop(N_cells,"Spatial Cells");
+   propagateBTimer.stop(N_cells,"Spatial Cells");
 }

--- a/fieldsolver/ldz_main.cpp
+++ b/fieldsolver/ldz_main.cpp
@@ -324,7 +324,7 @@ bool propagateFields(
             RK_ORDER2_STEP2
          );
          
-         phiprof::Timer subcyclingTimer {"FS subcycle stuff"};
+         phiprof::Timer subcycling {"FS subcycle stuff"};
          subcycleT += subcycleDt; 
          subcycleCount++;
 
@@ -357,9 +357,9 @@ bool propagateFields(
             }
          }
 
-         phiprof::Timer allreduceTimer {"MPI_Allreduce"};
+         phiprof::Timer allreduce {"MPI_Allreduce"};
          technicalGrid.Allreduce(&(dtMaxLocal), &(dtMaxGlobal), 1, MPI_Type<Real>(), MPI_MIN);
-         allreduceTimer.stop();
+         allreduce.stop();
          
          //reduce dt if it is too high
          if( subcycleDt > dtMaxGlobal * P::fieldSolverMaxCFL ) {
@@ -382,7 +382,7 @@ bool propagateFields(
             }
          }
          
-         subcyclingTimer.stop();
+         subcycling.stop();
       }
       
       

--- a/fieldsolver/ldz_main.cpp
+++ b/fieldsolver/ldz_main.cpp
@@ -324,7 +324,7 @@ bool propagateFields(
             RK_ORDER2_STEP2
          );
          
-         phiprof::start("FS subcycle stuff");
+         phiprof::Timer subcycling {"FS subcycle stuff"};
          subcycleT += subcycleDt; 
          subcycleCount++;
 
@@ -334,10 +334,6 @@ bool propagateFields(
                //due to roundoff we might hit this, should add delta
                std::cerr << "subcycleT > targetT, should not happen! (values: subcycleT " << subcycleT << ", subcycleDt " << subcycleDt << ", targetT " << targetT << ")" << std::endl;
             }
-
-            // Make sure the phiprof group is closed when leaving the loop
-            phiprof::stop("FS subcycle stuff");
-
             break;
          }
 
@@ -361,9 +357,9 @@ bool propagateFields(
             }
          }
 
-         phiprof::start("MPI_Allreduce");
+         phiprof::Timer allreduce {"MPI_Allreduce"};
          technicalGrid.Allreduce(&(dtMaxLocal), &(dtMaxGlobal), 1, MPI_Type<Real>(), MPI_MIN);
-         phiprof::stop("MPI_Allreduce");
+         allreduce.stop();
          
          //reduce dt if it is too high
          if( subcycleDt > dtMaxGlobal * P::fieldSolverMaxCFL ) {
@@ -386,7 +382,7 @@ bool propagateFields(
             }
          }
          
-         phiprof::stop("FS subcycle stuff");
+         subcycling.stop();
       }
       
       

--- a/fieldsolver/ldz_main.cpp
+++ b/fieldsolver/ldz_main.cpp
@@ -324,7 +324,7 @@ bool propagateFields(
             RK_ORDER2_STEP2
          );
          
-         phiprof::Timer subcycling {"FS subcycle stuff"};
+         phiprof::Timer subcyclingTimer {"FS subcycle stuff"};
          subcycleT += subcycleDt; 
          subcycleCount++;
 
@@ -357,9 +357,9 @@ bool propagateFields(
             }
          }
 
-         phiprof::Timer allreduce {"MPI_Allreduce"};
+         phiprof::Timer allreduceTimer {"MPI_Allreduce"};
          technicalGrid.Allreduce(&(dtMaxLocal), &(dtMaxGlobal), 1, MPI_Type<Real>(), MPI_MIN);
-         allreduce.stop();
+         allreduceTimer.stop();
          
          //reduce dt if it is too high
          if( subcycleDt > dtMaxGlobal * P::fieldSolverMaxCFL ) {
@@ -382,7 +382,7 @@ bool propagateFields(
             }
          }
          
-         subcycling.stop();
+         subcyclingTimer.stop();
       }
       
       

--- a/fieldsolver/ldz_volume.cpp
+++ b/fieldsolver/ldz_volume.cpp
@@ -41,7 +41,7 @@ void calculateVolumeAveragedFields(
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
-   phiprof::start("Calculate volume averaged fields");
+   ("Calculate volume averaged fields");
    
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {

--- a/fieldsolver/ldz_volume.cpp
+++ b/fieldsolver/ldz_volume.cpp
@@ -41,7 +41,7 @@ void calculateVolumeAveragedFields(
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
    const int* gridDims = &technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
-   ("Calculate volume averaged fields");
+   phiprof::Timer timer {"Calculate volume averaged fields"};
    
    #pragma omp parallel for collapse(3)
    for (int k=0; k<gridDims[2]; k++) {
@@ -160,5 +160,5 @@ void calculateVolumeAveragedFields(
       }
    }
    
-   phiprof::stop("Calculate volume averaged fields",N_cells,"Spatial Cells");
+   timer.stop(N_cells, "Spatial Cells");
 }

--- a/fieldtracing/fieldtracing.cpp
+++ b/fieldtracing/fieldtracing.cpp
@@ -73,7 +73,7 @@ namespace FieldTracing {
          return;
       }
       
-      phiprof::Timer timer {"fieldtracing-ionosphere-fsgridCoupling"};
+      phiprof::Timer t {"fieldtracing-ionosphere-fsgridCoupling"};
       // Pick an initial stepsize
       creal stepSize = min(100e3, technicalGrid.DX / 2.);
       std::vector<Real> nodeTracingStepSize(nodes.size(), stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
@@ -302,7 +302,7 @@ namespace FieldTracing {
       
       Real stepSize = 100e3;
       std::array<Real,3> v;
-      phiprof::Timer timer {"fieldtracing-ionosphere-VlasovGridCoupling"};
+      phiprof::Timer t {"fieldtracing-ionosphere-VlasovGridCoupling"};
       
       // For tracing towards the vlasov boundary, we only require the dipole field.
       TracingFieldFunction<Real> dipoleFieldOnly = [](std::array<Real,3>& r, const bool outwards, std::array<Real,3>& b)->bool {
@@ -465,7 +465,7 @@ namespace FieldTracing {
          return;
       }
 
-      phiprof::Timer tracingTimer {"fieldtracing-ionosphere-openclosedTracing"};
+      phiprof::Timer tracing {"fieldtracing-ionosphere-openclosedTracing"};
       // Pick an initial stepsize
       const TReal stepSize = min(1000e3, technicalGrid.DX / 2.);
       std::vector<TReal> nodeTracingStepSize(nodes.size(), stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
@@ -813,7 +813,7 @@ namespace FieldTracing {
       FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
       dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid
    ) {
-      phiprof::Timer fluxTracingTimer {"fieldtracing-fullAndFluxTracing"};
+      phiprof::Timer fluxTracing {"fieldtracing-fullAndFluxTracing"};
       
       std::vector<CellID> localDccrgCells = getLocalCells();
       int localDccrgSize = localDccrgCells.size();
@@ -863,7 +863,7 @@ namespace FieldTracing {
       std::vector<signed char> storedCellFWConnection(globalDccrgSize);
       std::vector<signed char> storedCellBWConnection(globalDccrgSize);
       
-      phiprof::Timer initializationTimer {"initialization-loop"};
+      phiprof::Timer initialization {"initialization-loop"};
       for(int n=0; n<globalDccrgSize; n++) {
          const CellID id = allDccrgCells[n];
          const std::array<Real, 3> ctr = mpiGrid.get_center(id);
@@ -892,7 +892,7 @@ namespace FieldTracing {
             }
          }
       }
-      initializationTimer.stop();
+      initialization.stop();
       
       // The FW, BW and this copy of coordinates were created using mpiGrid.get_center() which is for all cells, not just local ones, so no need to reduce them now.
       const std::vector<std::array<TReal,3>> cellInitialCoordinates = cellFWTracingCoordinates;
@@ -937,7 +937,7 @@ namespace FieldTracing {
 
 
       int mpi_timer {phiprof::initializeTimer("MPI-loop")};
-      phiprof::Timer loopTimer {"loop"};
+      phiprof::Timer loop {"loop"};
       #pragma omp parallel shared(cellsToDoFullBox,cellsToDoFluxRopes)
       {
          do { // while(either leftover fraction is not achieved
@@ -985,7 +985,7 @@ namespace FieldTracing {
             } // for
             
             // Globally reduce whether any node still needs to be picked up and traced onwards
-            phiprof::Timer timer {mpi_timer};
+            phiprof::Timer t {mpi_timer};
             #pragma omp master
             {
                indicesToReduceFW.clear();
@@ -1059,7 +1059,7 @@ namespace FieldTracing {
                cellBWConnection[indicesToReduceBW[n]] = smallReducedCellBWConnection[n];
                cellBWTracingCoordinates[indicesToReduceBW[n]] = smallSumCellBWTracingCoordinates[n];
             }
-            timer.stop();
+            t.stop();
             #pragma omp single
             {
                cellsToDoFullBox = 0;
@@ -1083,7 +1083,7 @@ namespace FieldTracing {
             && cellsToDoFluxRopes <= fieldTracingParameters.fluxrope_max_incomplete_cells * globalDccrgSize
          ));
       } // pragma omp parallel
-      loopTimer.stop();
+      loop.stop();
       
       logFile << "(fieldtracing) combined flux rope + full box tracing traced in " << itCount
          << " iterations of the tracing loop with flux rope " << cellsToDoFluxRopes
@@ -1107,7 +1107,7 @@ namespace FieldTracing {
          MPI_Allreduce(cellMaxExtension.data(), reducedCellMaxExtension.data(), globalDccrgSize, MPI_FLOAT, MPI_MAX, MPI_COMM_WORLD);
       }
       
-      phiprof::Timer finalLoopTimer {"final-loop"};
+      phiprof::Timer finalLoop {"final-loop"};
       for(int n=0; n<globalDccrgSize; n++) {
          const CellID id = allDccrgCells.at(n);
          if(mpiGrid.is_local(id)) {
@@ -1163,6 +1163,6 @@ namespace FieldTracing {
             mpiGrid[id]->parameters[CellParams::CONNECTION_BW_Z] = cellBWTracingCoordinates[n][2];
          }
       }
-      finalLoopTimer.stop();
+      finalLoop.stop();
    }
 } // namespace FieldTracing

--- a/fieldtracing/fieldtracing.cpp
+++ b/fieldtracing/fieldtracing.cpp
@@ -73,7 +73,7 @@ namespace FieldTracing {
          return;
       }
       
-      phiprof::start("fieldtracing-ionosphere-fsgridCoupling");
+      phiprof::Timer t {"fieldtracing-ionosphere-fsgridCoupling"};
       // Pick an initial stepsize
       creal stepSize = min(100e3, technicalGrid.DX / 2.);
       std::vector<Real> nodeTracingStepSize(nodes.size(), stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
@@ -282,8 +282,6 @@ namespace FieldTracing {
          no.xMapped[1] = reducedxMapped[3*n+1] / reducedCouplingNum[n];
          no.xMapped[2] = reducedxMapped[3*n+2] / reducedCouplingNum[n];
       }
-      
-      phiprof::stop("fieldtracing-ionosphere-fsgridCoupling");
    }
 
    /*! Calculate mapping between ionospheric nodes and Vlasov grid cells.
@@ -304,7 +302,7 @@ namespace FieldTracing {
       
       Real stepSize = 100e3;
       std::array<Real,3> v;
-      phiprof::start("fieldtracing-ionosphere-VlasovGridCoupling");
+      phiprof::Timer t {"fieldtracing-ionosphere-VlasovGridCoupling"};
       
       // For tracing towards the vlasov boundary, we only require the dipole field.
       TracingFieldFunction<Real> dipoleFieldOnly = [](std::array<Real,3>& r, const bool outwards, std::array<Real,3>& b)->bool {
@@ -349,7 +347,6 @@ namespace FieldTracing {
             cerr << "(fieldtracing) Warning: coupling of Vlasov grid cell failed due to weird magnetic field topology." << endl;
             
             // Return a coupling that has 0 value and results in zero potential
-            phiprof::stop("fieldtracing-ionosphere-VlasovGridCoupling");
             return coupling;
          }
       }
@@ -404,7 +401,6 @@ namespace FieldTracing {
             coupling[0] = {el.corners[0], lambda1};
             coupling[1] = {el.corners[1], lambda2};
             coupling[2] = {el.corners[2], lambda3};
-            phiprof::stop("fieldtracing-ionosphere-VlasovGridCoupling");
             return coupling;
          } else if (kappa1 > 0 && kappa2 > 0 && kappa3 < 0) {
             elementIndex = SBC::ionosphereGrid.findElementNeighbour(elementIndex,0,2);
@@ -444,7 +440,6 @@ namespace FieldTracing {
             cerr << __FILE__ << ":" << __LINE__ << ": invalid elementIndex returned for coordinate "
             << x[0] << " " << x[1] << " " << x[2] << " projected to rx " << rx[0] << " " << rx[1] << " " << rx[2]
             << ". Last valid elementIndex: " << oldElementIndex << "." << endl;
-            phiprof::stop("fieldtracing-ionosphere-VlasovGridCoupling");
             return coupling;
          }
       }
@@ -453,7 +448,6 @@ namespace FieldTracing {
       // Return an empty coupling instead
       cerr << "(fieldtracing) Failed to find an ionosphere element to couple to for coordinate " <<
       x[0] << " " << x[1] << " " << x[2] << endl;
-      phiprof::stop("fieldtracing-ionosphere-VlasovGridCoupling");
       return coupling;
    }
 
@@ -470,8 +464,8 @@ namespace FieldTracing {
       if(nodes.size() == 0) {
          return;
       }
-      
-      phiprof::start("fieldtracing-ionosphere-openclosedTracing");
+
+      phiprof::Timer tracing {"fieldtracing-ionosphere-openclosedTracing"};
       // Pick an initial stepsize
       const TReal stepSize = min(1000e3, technicalGrid.DX / 2.);
       std::vector<TReal> nodeTracingStepSize(nodes.size(), stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
@@ -629,8 +623,6 @@ namespace FieldTracing {
       for(uint n=0; n<nodes.size(); n++) {
          nodes[n].openFieldLine = reducedNodeMapping.at(n);
       }
-      
-      phiprof::stop("fieldtracing-ionosphere-openclosedTracing");
    }
    
    /*!< Inside the tracing loop for full box + flux rope tracing,
@@ -821,7 +813,7 @@ namespace FieldTracing {
       FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
       dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid
    ) {
-      phiprof::start("fieldtracing-fullAndFluxTracing");
+      phiprof::Timer fluxTracing {"fieldtracing-fullAndFluxTracing"};
       
       std::vector<CellID> localDccrgCells = getLocalCells();
       int localDccrgSize = localDccrgCells.size();
@@ -871,7 +863,7 @@ namespace FieldTracing {
       std::vector<signed char> storedCellFWConnection(globalDccrgSize);
       std::vector<signed char> storedCellBWConnection(globalDccrgSize);
       
-      phiprof::start("initialization-loop");
+      phiprof::Timer initialization {"initialization-loop"};
       for(int n=0; n<globalDccrgSize; n++) {
          const CellID id = allDccrgCells[n];
          const std::array<Real, 3> ctr = mpiGrid.get_center(id);
@@ -900,7 +892,7 @@ namespace FieldTracing {
             }
          }
       }
-      phiprof::stop("initialization-loop");
+      initialization.stop();
       
       // The FW, BW and this copy of coordinates were created using mpiGrid.get_center() which is for all cells, not just local ones, so no need to reduce them now.
       const std::vector<std::array<TReal,3>> cellInitialCoordinates = cellFWTracingCoordinates;
@@ -924,7 +916,7 @@ namespace FieldTracing {
       cellBWTracingStepSize.swap(reducedCellBWTracingStepSize);
       cellCurvatureRadius.swap(reducedCellCurvatureRadius);
       
-      TracingFieldFunction<TReal> tracingFullField = [&perBGrid, &dPerBGrid, &technicalGrid](std::array<TReal,3>& r, const bool alongB, std::array<TReal,3>& b)->bool{
+      TracingFieldFunction<TReal> tracingFullField = [&perBGrid, &dPerBGrid, &technicalGrid](std::array<TReal,3>& r, const bool alongB, std::array<TReal,3>& b)->bool {
          return traceFullFieldFunction(perBGrid, dPerBGrid, technicalGrid, r, alongB, b);
       };
       int itCount = 0;
@@ -944,7 +936,8 @@ namespace FieldTracing {
       std::vector<signed char> smallReducedCellFWConnection, smallReducedCellBWConnection;
 
 
-      phiprof::start("loop");
+      int mpi_timer {phiprof::initializeTimer("MPI-loop")};
+      phiprof::Timer loop {"loop"};
       #pragma omp parallel shared(cellsToDoFullBox,cellsToDoFluxRopes)
       {
          do { // while(either leftover fraction is not achieved
@@ -992,8 +985,7 @@ namespace FieldTracing {
             } // for
             
             // Globally reduce whether any node still needs to be picked up and traced onwards
-            #pragma omp barrier
-            phiprof::start("MPI-loop");
+            phiprof::Timer t {mpi_timer};
             #pragma omp master
             {
                indicesToReduceFW.clear();
@@ -1067,7 +1059,7 @@ namespace FieldTracing {
                cellBWConnection[indicesToReduceBW[n]] = smallReducedCellBWConnection[n];
                cellBWTracingCoordinates[indicesToReduceBW[n]] = smallSumCellBWTracingCoordinates[n];
             }
-            phiprof::stop("MPI-loop");
+            t.stop();
             #pragma omp single
             {
                cellsToDoFullBox = 0;
@@ -1091,7 +1083,7 @@ namespace FieldTracing {
             && cellsToDoFluxRopes <= fieldTracingParameters.fluxrope_max_incomplete_cells * globalDccrgSize
          ));
       } // pragma omp parallel
-      phiprof::stop("loop");
+      loop.stop();
       
       logFile << "(fieldtracing) combined flux rope + full box tracing traced in " << itCount
          << " iterations of the tracing loop with flux rope " << cellsToDoFluxRopes
@@ -1115,7 +1107,7 @@ namespace FieldTracing {
          MPI_Allreduce(cellMaxExtension.data(), reducedCellMaxExtension.data(), globalDccrgSize, MPI_FLOAT, MPI_MAX, MPI_COMM_WORLD);
       }
       
-      phiprof::start("final-loop");
+      phiprof::Timer finalLoop {"final-loop"};
       for(int n=0; n<globalDccrgSize; n++) {
          const CellID id = allDccrgCells.at(n);
          if(mpiGrid.is_local(id)) {
@@ -1171,7 +1163,6 @@ namespace FieldTracing {
             mpiGrid[id]->parameters[CellParams::CONNECTION_BW_Z] = cellBWTracingCoordinates[n][2];
          }
       }
-      phiprof::stop("final-loop");
-      phiprof::stop("fieldtracing-fullAndFluxTracing");
+      finalLoop.stop();
    }
 } // namespace FieldTracing

--- a/grid.cpp
+++ b/grid.cpp
@@ -155,7 +155,7 @@ void initializeGrids(
       .set_geometry(geom_params);
 
 
-   phiprof::Timer refine {"Refine spatial cells"};
+   phiprof::Timer refineTimer {"Refine spatial cells"};
    // We need this first as well
    recalculateLocalCellsCache();
    if (!P::isRestart) {
@@ -171,7 +171,7 @@ void initializeGrids(
          mapRefinement(mpiGrid, technicalGrid);
       }
    }
-   refine.stop();
+   refineTimer.stop();
    
    // Init velocity mesh on all cells
    initVelocityGridGeometry(mpiGrid);
@@ -180,7 +180,7 @@ void initializeGrids(
    for (const auto& [key, value] : P::loadBalanceOptions) {
       mpiGrid.set_partitioning_option(key, value);
    }
-   phiprof::Timer initialLB {"Initial load-balancing"};
+   phiprof::Timer initialLBTimer {"Initial load-balancing"};
    if (myRank == MASTER_RANK) logFile << "(INIT): Starting initial load balance." << endl << writeVerbose;
    mpiGrid.balance_load(); // Direct DCCRG call, recalculate cache afterwards
    recalculateLocalCellsCache();
@@ -192,44 +192,44 @@ void initializeGrids(
       setFaceNeighborRanks( mpiGrid );
    }
    const vector<CellID>& cells = getLocalCells();
-   initialLB.stop();
+   initialLBTimer.stop();
    
    if (myRank == MASTER_RANK) {
       logFile << "(INIT): Set initial state." << endl << writeVerbose;
    }
 
-   phiprof::Timer initialState {"Set initial state"};
+   phiprof::Timer initialStateTimer {"Set initial state"};
 
-   phiprof::Timer setCoords {"Set spatial cell coordinates"};
+   phiprof::Timer setCoordsTimer {"Set spatial cell coordinates"};
    initSpatialCellCoordinates(mpiGrid);
-   setCoords.stop();
+   setCoordsTimer.stop();
    
-   phiprof::Timer initBoundary {"Initialize system boundary conditions"};
+   phiprof::Timer initBoundaryTimer {"Initialize system boundary conditions"};
    if(sysBoundaries.initSysBoundaries(project, P::t_min) == false) {
       if (myRank == MASTER_RANK) cerr << "Error in initialising the system boundaries." << endl;
       exit(1);
    }
-   initBoundary.stop();
+   initBoundaryTimer.stop();
    
    SpatialCell::set_mpi_transfer_type(Transfer::CELL_DIMENSIONS);
    mpiGrid.update_copies_of_remote_neighbors(SYSBOUNDARIES_NEIGHBORHOOD_ID);
 
    // We want this before restart refinement
-   phiprof::Timer classify {"Classify cells (sys boundary conditions)"};
+   phiprof::Timer classifyTimer {"Classify cells (sys boundary conditions)"};
    if(sysBoundaries.classifyCells(mpiGrid,technicalGrid) == false) {
       cerr << "(MAIN) ERROR: System boundary conditions were not set correctly." << endl;
       exit(1);
    }
-   classify.stop();
+   classifyTimer.stop();
    
    if (P::isRestart) {
       logFile << "Restart from "<< P::restartFileName << std::endl << writeVerbose;
-      phiprof::Timer restartRead {"Read restart"};
+      phiprof::Timer restartReadTimer {"Read restart"};
       if (readGrid(mpiGrid,perBGrid,EGrid,technicalGrid,P::restartFileName) == false) {
          logFile << "(MAIN) ERROR: restarting failed" << endl;
          exit(1);
       }
-      restartRead.stop();
+      restartReadTimer.stop();
 
       if (P::forceRefinement) {
          phiprof::Timer timer {"Restart refinement"};
@@ -247,12 +247,12 @@ void initializeGrids(
    }
 
    // Check refined cells do not touch boundary cells
-   phiprof::Timer boundaryCheck {"Check boundary refinement"};
+   phiprof::Timer boundaryCheckTimer {"Check boundary refinement"};
    if(!sysBoundaries.checkRefinement(mpiGrid)) {
       cerr << "(MAIN) WARNING: Boundary cells don't have identical refinement level " << endl;
       //exit(1);
    }
-   boundaryCheck.stop();
+   boundaryCheckTimer.stop();
 
    if (P::isRestart) {
       //initial state for sys-boundary cells, will skip those not set to be reapplied at restart
@@ -269,7 +269,7 @@ void initializeGrids(
    if (!P::isRestart) {
       //Initial state based on project, background field in all cells
       //and other initial values in non-sysboundary cells
-      phiprof::Timer applyInitial {"Apply initial state"};
+      phiprof::Timer applyInitialTimer {"Apply initial state"};
       // Go through every cell on this node and initialize the 
       //  -Background field on all cells
       //  -Perturbed fields and ion distribution function in non-sysboundary cells
@@ -278,7 +278,7 @@ void initializeGrids(
       // Allow the project to set up data structures for it's setCell calls
       project.setupBeforeSetCell(cells);
       
-      phiprof::Timer setCell {"setCell"};
+      phiprof::Timer setCellTimer {"setCell"};
       #pragma omp parallel for schedule(dynamic)
       for (size_t i=0; i<cells.size(); ++i) {
          SpatialCell* cell = mpiGrid[cells[i]];
@@ -286,16 +286,16 @@ void initializeGrids(
             project.setCell(cell);
          }
       }
-      setCell.stop();
+      setCellTimer.stop();
       
       // Initial state for sys-boundary cells
-      applyInitial.stop();
-      phiprof::Timer applyBC {"Apply system boundary conditions state"};
+      applyInitialTimer.stop();
+      phiprof::Timer applyBCTimer {"Apply system boundary conditions state"};
       if (sysBoundaries.applyInitialState(mpiGrid, technicalGrid, perBGrid, project) == false) {
          cerr << " (MAIN) ERROR: System boundary conditions initial state was not applied correctly." << endl;
          exit(1);
       }
-      applyBC.stop();
+      applyBCTimer.stop();
       
       for (size_t i=0; i<cells.size(); ++i) {
          mpiGrid[cells[i]]->parameters[CellParams::LBWEIGHTCOUNTER] = 0;
@@ -322,9 +322,9 @@ void initializeGrids(
       sysBoundaries.applySysBoundaryVlasovConditions(mpiGrid,Parameters::t);
       
       //compute moments, and set them  in RHO* and RHO_*_DT2. If restart, they are already read in
-      phiprof::Timer initMoments {"Init moments"};
+      phiprof::Timer initMomentsTimer {"Init moments"};
       calculateInitialVelocityMoments(mpiGrid);
-      initMoments.stop();
+      initMomentsTimer.stop();
       */
 
    }
@@ -333,13 +333,13 @@ void initializeGrids(
    balanceLoad(mpiGrid, sysBoundaries);
    // Function includes re-calculation of local cells cache
 
-   phiprof::Timer fetchNeighbour {"Fetch Neighbour data", {"MPI"}};
+   phiprof::Timer fetchNeighbourTimer {"Fetch Neighbour data", {"MPI"}};
    // update complete cell spatial data for full stencil (
    SpatialCell::set_mpi_transfer_type(Transfer::ALL_SPATIAL_DATA);
    mpiGrid.update_copies_of_remote_neighbors(FULL_NEIGHBORHOOD_ID);
-   fetchNeighbour.stop();
+   fetchNeighbourTimer.stop();
    
-   phiprof::Timer setB {"setProjectBField"};
+   phiprof::Timer setBTimer {"setProjectBField"};
    project.setProjectBField(perBGrid, BgBGrid, technicalGrid);
    perBGrid.updateGhostCells();
    BgBGrid.updateGhostCells();
@@ -349,7 +349,7 @@ void initializeGrids(
    volGrid.updateGhostCells();
    getFieldsFromFsGrid(volGrid, BgBGrid, EGradPeGrid, technicalGrid, mpiGrid, cells);
 
-   setB.stop();
+   setBTimer.stop();
 
    if (P::isRestart == false) {
       // Apply boundary conditions so that we get correct initial moments
@@ -365,7 +365,7 @@ void initializeGrids(
       }
    }
    
-   phiprof::Timer finishFSGrid {"Finish fsgrid setup"};
+   phiprof::Timer finishFSGridTimer {"Finish fsgrid setup"};
    feedMomentsIntoFsGrid(mpiGrid, cells, momentsGrid,technicalGrid, false);
    if(!P::isRestart) {
       // WARNING this means moments and dt2 moments are the same here at t=0, which is a feature so far.
@@ -375,7 +375,7 @@ void initializeGrids(
    }
    momentsGrid.updateGhostCells();
    momentsDt2Grid.updateGhostCells();
-   finishFSGrid.stop();
+   finishFSGridTimer.stop();
 
    // Set this so CFL doesn't break
    if(P::refineOnRestart) {
@@ -388,7 +388,7 @@ void initializeGrids(
       P::dt = P::bailout_min_dt;
    }
    
-   initialState.stop();
+   initialStateTimer.stop();
 }
 
 // initialize velocity grid of spatial cells before creating cells in dccrg.initialize
@@ -475,13 +475,13 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
    Parameters::meshRepartitioned = true;
 
    // tell other processes which velocity blocks exist in remote spatial cells
-   phiprof::Timer balanceLoad {"Balancing load", {"Load balance"}};
+   phiprof::Timer balanceLoadTimer {"Balancing load", {"Load balance"}};
 
-   phiprof::Timer dealloc {"deallocate boundary data"};
+   phiprof::Timer deallocTimer {"deallocate boundary data"};
    //deallocate blocks in remote cells to decrease memory load
    deallocateRemoteCellBlocks(mpiGrid);
 
-   dealloc.stop();
+   deallocTimer.stop();
    //set weights based on each cells LB weight counter
    const vector<CellID>& cells = getLocalCells();
    for (size_t i=0; i<cells.size(); ++i){
@@ -495,9 +495,9 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
       //reset counter
       //mpiGrid[cells[i]]->parameters[CellParams::LBWEIGHTCOUNTER] = 0.0;
    }
-   phiprof::Timer initLB {"dccrg.initialize_balance_load"};
+   phiprof::Timer initLBTimer {"dccrg.initialize_balance_load"};
    mpiGrid.initialize_balance_load(true);
-   initLB.stop();
+   initLBTimer.stop();
 
    const std::unordered_set<CellID>& incoming_cells = mpiGrid.get_cells_added_by_balance_load();
    std::vector<CellID> incoming_cells_list (incoming_cells.begin(),incoming_cells.end()); 
@@ -506,7 +506,7 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
    std::vector<CellID> outgoing_cells_list (outgoing_cells.begin(),outgoing_cells.end()); 
    
    /*transfer cells in parts to preserve memory*/
-   phiprof::Timer transfers {"Data transfers"};
+   phiprof::Timer transfersTimer {"Data transfers"};
    const uint64_t num_part_transfers=5;
    for (uint64_t transfer_part=0; transfer_part<num_part_transfers; transfer_part++) {
       //Set transfers on/off for the incoming cells in this transfer set and prepare for receive
@@ -549,7 +549,7 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
             if (cell_id % num_part_transfers == transfer_part) {
                receives++;
                // reserve space for velocity block data in arriving remote cells
-               phiprof::Timer t {prepareReceives};
+               phiprof::Timer timer {prepareReceives};
                cell->prepare_to_receive_blocks(p);
                t.stop(1, "Spatial cells");
             }
@@ -557,15 +557,15 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
          if(receives == 0) {
             //empty phiprof timer, to avoid unneccessary divergence in unique
             //profiles (keep order same)
-            phiprof::Timer t {prepareReceives};
+            phiprof::Timer timer {prepareReceives};
             t.stop(0, "Spatial cells");
          }
 
          //do the actual transfer of data for the set of cells to be transferred
-         phiprof::Timer transfer {"transfer_all_data"};
+         phiprof::Timer transferTimer {"transfer_all_data"};
          SpatialCell::set_mpi_transfer_type(Transfer::ALL_DATA);
          mpiGrid.continue_balance_load();
-         transfer.stop();
+         transferTimer.stop();
 
          // Free memory for cells that have been sent (the block data)
          for (unsigned int i=0;i<outgoing_cells_list.size();i++){
@@ -579,12 +579,12 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
          }
       } // for-loop over populations
    } // for-loop over transfer parts
-   transfers.stop();
+   transfersTimer.stop();
 
    //finish up load balancing
-   phiprof::Timer finishLB {"dccrg.finish_balance_load"};
+   phiprof::Timer finishLBTimer {"dccrg.finish_balance_load"};
    mpiGrid.finish_balance_load();
-   finishLB.stop();
+   finishLBTimer.stop();
 
    //Make sure transfers are enabled for all cells
    recalculateLocalCellsCache();
@@ -594,27 +594,27 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
    }
 
    // flag transfers if AMR
-   phiprof::Timer computeTransfer {"compute_amr_transfer_flags"};
+   phiprof::Timer computeTransferTimer {"compute_amr_transfer_flags"};
    flagSpatialCellsForAmrCommunication(mpiGrid,cells);
-   computeTransfer.stop();
+   computeTransferTimer.stop();
 
    // Communicate all spatial data for FULL neighborhood, which
    // includes all data with the exception of dist function data
    SpatialCell::set_mpi_transfer_type(Transfer::ALL_SPATIAL_DATA);
    mpiGrid.update_copies_of_remote_neighbors(FULL_NEIGHBORHOOD_ID);
 
-   phiprof::Timer updateBlocks {"update block lists"};
+   phiprof::Timer updateBlocksTimer {"update block lists"};
    //new partition, re/initialize blocklists of remote cells.
    for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
       updateRemoteVelocityBlockLists(mpiGrid,popID);
    }
-   updateBlocks.stop();
+   updateBlocksTimer.stop();
 
-   phiprof::Timer updateBoundaries {"update sysboundaries"};
+   phiprof::Timer updateBoundariesTimer {"update sysboundaries"};
    sysBoundaries.updateSysBoundariesAfterLoadBalance( mpiGrid );
-   updateBoundaries.stop();
+   updateBoundariesTimer.stop();
 
-   phiprof::Timer initSolvers {"Init solvers"};
+   phiprof::Timer initSolversTimer {"Init solvers"};
    // Initialize field propagator (only if in use):
    if (Parameters::propagateField == true) {
       if (initializeFieldPropagatorAfterRebalance() == false) {
@@ -622,7 +622,7 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
          exit(1);
       }
    }
-   initSolvers.stop();
+   initSolversTimer.stop();
    
    // Record ranks of face neighbors
    if(P::amrMaxSpatialRefLevel > 0) {
@@ -648,28 +648,28 @@ bool adjustVelocityBlocks(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& m
                           const vector<CellID>& cellsToAdjust,
                           bool doPrepareToReceiveBlocks,
                           const uint popID) {
-   phiprof::Timer readjustBlocks {"re-adjust blocks", {"Block adjustment"}};
+   phiprof::Timer readjustBlocksTimer {"re-adjust blocks", {"Block adjustment"}};
    SpatialCell::setCommunicatedSpecies(popID);
    const vector<CellID>& cells = getLocalCells();
 
-   phiprof::Timer compute {"Compute with_content_list"};
+   phiprof::Timer computeTimer {"Compute with_content_list"};
    #pragma omp parallel for
    for (uint i=0; i<cells.size(); ++i) {
       mpiGrid[cells[i]]->updateSparseMinValue(popID);
       mpiGrid[cells[i]]->update_velocity_block_content_lists(popID);
    }
-   compute.stop();
+   computeTimer.stop();
    
-   phiprof::Timer transfer {"Transfer with_content_list", {"MPI"}};
+   phiprof::Timer transferTimer {"Transfer with_content_list", {"MPI"}};
    SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_WITH_CONTENT_STAGE1 );
    mpiGrid.update_copies_of_remote_neighbors(NEAREST_NEIGHBORHOOD_ID);
    SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_WITH_CONTENT_STAGE2 );
    mpiGrid.update_copies_of_remote_neighbors(NEAREST_NEIGHBORHOOD_ID);
-   transfer.stop();
+   transferTimer.stop();
    
    //Adjusts velocity blocks in local spatial cells, doesn't adjust velocity blocks in remote cells.
 
-   phiprof::Timer adjust {"Adjusting blocks"};
+   phiprof::Timer adjustimer {"Adjusting blocks"};
    #pragma omp parallel for schedule(dynamic)
    for (size_t i=0; i<cellsToAdjust.size(); ++i) {
       Real density_pre_adjust=0.0;
@@ -708,7 +708,7 @@ bool adjustVelocityBlocks(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& m
          }
       }
    }
-   adjust.stop();
+   adjustimer.stop();
 
    //Updated newly adjusted velocity block lists on remote cells, and
    //prepare to receive block data
@@ -823,15 +823,15 @@ void updateRemoteVelocityBlockLists(
    // update velocity block lists For small velocity spaces it is
    // faster to do it in one operation, and not by first sending size,
    // then list. For large we do it in two steps
-   phiprof::Timer update {"Velocity block list update", {"MPI"}};
+   phiprof::Timer updateTimer {"Velocity block list update", {"MPI"}};
    SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_LIST_STAGE1);
    mpiGrid.update_copies_of_remote_neighbors(neighborhood);
    SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_LIST_STAGE2);
    mpiGrid.update_copies_of_remote_neighbors(neighborhood);
-   update.stop();
+   updateTimer.stop();
 
    // Prepare spatial cells for receiving velocity block data
-   phiprof::Timer receives {"Preparing receives"};
+   phiprof::Timer receivesTimer {"Preparing receives"};
    const std::vector<uint64_t> incoming_cells = mpiGrid.get_remote_cells_on_process_boundary(neighborhood);
 
    #pragma omp parallel for
@@ -1113,7 +1113,7 @@ bool validateMesh(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,c
       return rvalue;
    #else
 
-   phiprof::Timer meshValidation {"mesh validation (init)"};
+   phiprof::Timer meshValidationTimer {"mesh validation (init)"};
          
    bool internallyValid = false;
       
@@ -1135,16 +1135,16 @@ bool validateMesh(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,c
       #endif
 
       // Update velocity mesh in remote cells
-      phiprof::Timer mpi {"MPI"};
+      phiprof::Timer mpiTimer {"MPI"};
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_LIST_STAGE1);
       mpiGrid.update_copies_of_remote_neighbors(NEAREST_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_LIST_STAGE2);
       mpiGrid.update_copies_of_remote_neighbors(NEAREST_NEIGHBORHOOD_ID);
-      mpi.stop();
+      mpiTimer.stop();
             
       // Iterate over all local spatial cells and calculate 
       // the necessary velocity block refinements
-      phiprof::Timer calc {"calc refinements"};
+      phiprof::Timer calcTimer {"calc refinements"};
       vector<set<vmesh::GlobalID> > refinements(cells.size());
             
       #pragma omp parallel for
@@ -1179,10 +1179,10 @@ bool validateMesh(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,c
             }
          }
       }
-      calc.stop();
+      calcTimer.stop();
             
       // Apply refinements
-      phiprof::Timer refine {"refine mesh"};
+      phiprof::Timer refineTimer {"refine mesh"};
       bool needAnotherPass=false;
       vector<vector<pair<vmesh::GlobalID,vmesh::LocalID> > > newBlocks(cells.size());
             
@@ -1204,10 +1204,10 @@ bool validateMesh(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,c
             }
          }
       }
-      refine.stop();
+      refineTimer.stop();
 
       // Recalculate distribution function values on all blocks that were refined
-      phiprof::Timer recalc {"recalculate distrib. functions"};
+      phiprof::Timer recalcTimer {"recalculate distrib. functions"};
       vector<vector<vmesh::GlobalID> > removedBlocks(cells.size());
 
 #ifdef _OPENMP
@@ -1276,7 +1276,7 @@ bool validateMesh(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,c
             cell->remove_velocity_block(removedBlocks[c][b],popID);
          }
       }
-      recalc.stop()
+      recalcTimer.stop()
        
       #ifdef DEBUG_VAMR_VALIDATE
          writeVelMesh(mpiGrid);
@@ -1315,7 +1315,7 @@ void mapRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
 }
 
 bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, SysBoundary& sysBoundaries, Project& project, bool useStatic) {
-   phiprof::Timer amr {"Re-refine spatial cells"};
+   phiprof::Timer amrTimer {"Re-refine spatial cells"};
    calculateScaledDeltasSimple(mpiGrid);
 
    if (useStatic) {
@@ -1324,14 +1324,14 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
       project.adaptRefinement(mpiGrid);
    }
 
-   phiprof::Timer dccrg {"dccrg refinement"};
+   phiprof::Timer dccrgTimer {"dccrg refinement"};
 
-   phiprof::Timer init {"initialize refines"};
+   phiprof::Timer initimer {"initialize refines"};
    mpiGrid.initialize_refines();
    double newBytes{0};
-   init.stop();
+   initimer.stop();
 
-   phiprof::Timer estimateMemory {"Estimate memory usage"};
+   phiprof::Timer estimateMemoryTimer {"Estimate memory usage"};
    for (auto id : mpiGrid.get_local_cells_to_refine()) {
       newBytes += 8 * mpiGrid[id]->get_cell_memory_capacity();
    }
@@ -1342,23 +1342,23 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
    }
    
    report_process_memory_consumption(newBytes);
-   estimateMemory.stop();
+   estimateMemoryTimer.stop();
 
    // Bailout from estimate
    // clunky...
    int bailout {0};
-   phiprof::Timer bailoutAllreduce {"Bailout-allreduce"};
+   phiprof::Timer bailoutAllreduceTimer {"Bailout-allreduce"};
    MPI_Allreduce(&(globalflags::bailingOut), &bailout, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
-   bailoutAllreduce.stop();
+   bailoutAllreduceTimer.stop();
 
    if (bailout) {
       return false;
    }
 
    // New cells created by refinement
-   phiprof::Timer execute {"execute refines"};
+   phiprof::Timer executeTimer {"execute refines"};
    auto newChildren = mpiGrid.execute_refines();
-   execute.stop();
+   executeTimer.stop();
 
    std::vector<CellID> receives;
    for (auto const& [key, val] : mpiGrid.get_cells_to_receive()) {
@@ -1367,7 +1367,7 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
       }
    }
 
-   phiprof::Timer transfers {"transfers"};
+   phiprof::Timer transfersTimer {"transfers"};
    for (size_t p=0; p<getObjectWrapper().particleSpecies.size(); ++p) {
       // Set active population
       SpatialCell::setCommunicatedSpecies(p);
@@ -1381,7 +1381,7 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
       int prepareReceives {phiprof::initializeTimer("Preparing receives")};
       for (CellID id : receives) {
          // reserve space for velocity block data in arriving remote cells
-         phiprof::Timer t {prepareReceives};
+         phiprof::Timer timer {prepareReceives};
          mpiGrid[id]->prepare_to_receive_blocks(p);
          t.stop(1, "Spatial cells");
       }
@@ -1389,19 +1389,19 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
       if(receives.empty()) {
          //empty phiprof timer, to avoid unneccessary divergence in unique
          //profiles (keep order same)
-         phiprof::Timer t {prepareReceives};
+         phiprof::Timer timer {prepareReceives};
          t.stop(0, "Spatial cells");
       }
       
       //do the actual transfer of data for the set of cells to be transferred
-      phiprof::Timer transfer {"transfer_all_data"};
+      phiprof::Timer transferTimer {"transfer_all_data"};
       SpatialCell::set_mpi_transfer_type(Transfer::ALL_DATA);
       mpiGrid.continue_refining();
-      transfer.stop();
+      transferTimer.stop();
    }
-   transfers.stop();
+   transfersTimer.stop();
 
-   phiprof::Timer copyChildren {"copy to children"};
+   phiprof::Timer copyChildrenTimer {"copy to children"};
    for (CellID id : newChildren) {
       *mpiGrid[id] = *mpiGrid[mpiGrid.get_parent(id)];
       // Irrelevant?
@@ -1412,7 +1412,7 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
    copyChildren.stop(newChildren.size(), "Spatial cells");
 
    // Old cells removed by refinement
-   phiprof::Timer copyParents {"copy to parents"};
+   phiprof::Timer copyParentsTimer {"copy to parents"};
    std::set<CellID> processed;
    for (CellID id : mpiGrid.get_removed_cells()) {
       CellID parent = mpiGrid.get_existing_cell(mpiGrid.get_center(id));
@@ -1433,10 +1433,10 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
    }
    copyParents.stop(processed.size(), "Spatial cells");
 
-   phiprof::Timer finish {"finish refining"};
+   phiprof::Timer finishTimer {"finish refining"};
    mpiGrid.finish_refining();
-   finish.stop();
-   dccrg.stop();
+   finishTimer.stop();
+   dccrgTimer.stop();
 
    recalculateLocalCellsCache();
    initSpatialCellCoordinates(mpiGrid);

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -939,9 +939,9 @@ template<unsigned long int N> bool readFsGridVariable(
          fileOffset += thatTasksSize[0] * thatTasksSize[1] * thatTasksSize[2];
       }
    }
-   phiprof::Timer updateGhosts {"updateGhostCells"};
+   phiprof::Timer updateGhostsTimer {"updateGhostCells"};
    targetGrid.updateGhostCells();
-   updateGhosts.stop();
+   updateGhostsTimer.stop();
    return true;
 }
 
@@ -1065,9 +1065,9 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
    MPI_Comm_size(MPI_COMM_WORLD,&processes);
 
-   phiprof::Timer readGrid {"readGrid"};
+   phiprof::Timer readGridTimer {"readGrid"};
 
-   phiprof::Timer readScalars {"readScalars"};
+   phiprof::Timer readScalarsTimer {"readScalars"};
 
    vlsv::ParallelReader file;
    MPI_Info mpiInfo = MPI_INFO_NULL;
@@ -1113,9 +1113,9 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    checkScalarParameter(file,"ycells_ini",P::ycells_ini,MASTER_RANK,MPI_COMM_WORLD);
    checkScalarParameter(file,"zcells_ini",P::zcells_ini,MASTER_RANK,MPI_COMM_WORLD);
 
-   readScalars.stop();
+   readScalarsTimer.stop();
 
-   phiprof::Timer readLayout {"readDatalayout"};
+   phiprof::Timer readLayoutimer {"readDatalayout"};
    if (success) {
 		success = readCellIds(file,fileCells,MASTER_RANK,MPI_COMM_WORLD);
 	}
@@ -1222,10 +1222,10 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    //for(uint64_t i=localCellStartOffset; i<localCellStartOffset+localCells; ++i) {
    //  localBlocks += nBlocks[i];
    //}
-   readLayout.stop();
+   readLayoutimer.stop();
 
    //todo, check file datatype, and do not just use double
-   phiprof::Timer readParameters {"readCellParameters"};
+   phiprof::Timer readParametersTimer {"readCellParameters"};
    if(success) { success=readCellParamsVariable(file,fileCells,localCellStartOffset,localCells,"moments",CellParams::RHOM,5,mpiGrid); }
    if(success) { success=readCellParamsVariable(file,fileCells,localCellStartOffset,localCells,"moments_dt2",CellParams::RHOM_DT2,5,mpiGrid); }
    if(success) { success=readCellParamsVariable(file,fileCells,localCellStartOffset,localCells,"moments_r",CellParams::RHOM_R,5,mpiGrid); }
@@ -1242,19 +1242,19 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    if(success) { success=readCellParamsVariable(file,fileCells,localCellStartOffset,localCells,"vg_bulk_forcing_flag",CellParams::FORCING_CELL_NUM,1,mpiGrid); }
 
    // Backround B has to be set, there are also the derivatives that should be written/read if we wanted to only read in background field
-   readParameters.stop();
+   readParametersTimer.stop();
 
-   phiprof::Timer readBlocks {"readBlockData"};
+   phiprof::Timer readBlocksTimer {"readBlockData"};
    if (success == true) {
       success = readBlockData(file,meshName,fileCells,localCellStartOffset,localCells,mpiGrid); 
    }
-   readBlocks.stop();
+   readBlocksTimer.stop();
 
-   phiprof::Timer updateNeighbors {"updateMpiGridNeighbors"};
+   phiprof::Timer updateNeighborsTimer {"updateMpiGridNeighbors"};
    mpiGrid.update_copies_of_remote_neighbors(FULL_NEIGHBORHOOD_ID);
-   updateNeighbors.stop();
+   updateNeighborsTimer.stop();
    
-   phiprof::Timer readfs {"readFsGrid"};
+   phiprof::Timer readfsTimer {"readFsGrid"};
    // Read fsgrid data back in
    int fsgridInputRanks=0;
    if(readScalarParameter(file,"numWritingRanks",fsgridInputRanks, MASTER_RANK, MPI_COMM_WORLD) == false) {
@@ -1264,9 +1264,9 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    if (success) { success = readFsGridVariable(file, "fg_PERB", fsgridInputRanks, perBGrid); }
    if (success) { success = readFsGridVariable(file, "fg_E", fsgridInputRanks, EGrid); }
    exitOnError(success,"(RESTART) Failure reading fsgrid restart variables",MPI_COMM_WORLD);
-   readfs.stop();
+   readfsTimer.stop();
    
-   phiprof::Timer readIonosphere {"readIonosphere"};
+   phiprof::Timer readIonosphereTimer {"readIonosphere"};
    bool ionosphereSuccess=true;
    ionosphereSuccess = readIonosphereNodeVariable(file, "ig_fac", SBC::ionosphereGrid, ionosphereParameters::SOURCE);
    // Reconstruct source term by multiplying the fac density with the element area
@@ -1297,7 +1297,7 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    if(ionosphereSuccess && !ionosphereOptionalSuccess) {
       logFile << "(RESTART) Restart file contains no ionosphere conductivity data. Ionosphere will run fine, but first output bulk file might have bogus conductivities." << std::endl;
    }
-   readIonosphere.stop();
+   readIonosphereTimer.stop();
 
    success = file.close();
 

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -939,9 +939,9 @@ template<unsigned long int N> bool readFsGridVariable(
          fileOffset += thatTasksSize[0] * thatTasksSize[1] * thatTasksSize[2];
       }
    }
-   phiprof::start("updateGhostCells");
+   phiprof::Timer updateGhosts {"updateGhostCells"};
    targetGrid.updateGhostCells();
-   phiprof::stop("updateGhostCells");
+   updateGhosts.stop();
    return true;
 }
 
@@ -1065,9 +1065,9 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
    MPI_Comm_size(MPI_COMM_WORLD,&processes);
 
-   phiprof::start("readGrid");
+   phiprof::Timer readGrid {"readGrid"};
 
-   phiprof::start("readScalars");
+   phiprof::Timer readScalars {"readScalars"};
 
    vlsv::ParallelReader file;
    MPI_Info mpiInfo = MPI_INFO_NULL;
@@ -1113,9 +1113,9 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    checkScalarParameter(file,"ycells_ini",P::ycells_ini,MASTER_RANK,MPI_COMM_WORLD);
    checkScalarParameter(file,"zcells_ini",P::zcells_ini,MASTER_RANK,MPI_COMM_WORLD);
 
-   phiprof::stop("readScalars");
+   readScalars.stop();
 
-   phiprof::start("readDatalayout");
+   phiprof::Timer readLayout {"readDatalayout"};
    if (success) {
 		success = readCellIds(file,fileCells,MASTER_RANK,MPI_COMM_WORLD);
 	}
@@ -1222,10 +1222,10 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    //for(uint64_t i=localCellStartOffset; i<localCellStartOffset+localCells; ++i) {
    //  localBlocks += nBlocks[i];
    //}
-   phiprof::stop("readDatalayout");
+   readLayout.stop();
 
    //todo, check file datatype, and do not just use double
-   phiprof::start("readCellParameters");
+   phiprof::Timer readParameters {"readCellParameters"};
    if(success) { success=readCellParamsVariable(file,fileCells,localCellStartOffset,localCells,"moments",CellParams::RHOM,5,mpiGrid); }
    if(success) { success=readCellParamsVariable(file,fileCells,localCellStartOffset,localCells,"moments_dt2",CellParams::RHOM_DT2,5,mpiGrid); }
    if(success) { success=readCellParamsVariable(file,fileCells,localCellStartOffset,localCells,"moments_r",CellParams::RHOM_R,5,mpiGrid); }
@@ -1242,19 +1242,19 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    if(success) { success=readCellParamsVariable(file,fileCells,localCellStartOffset,localCells,"vg_bulk_forcing_flag",CellParams::FORCING_CELL_NUM,1,mpiGrid); }
 
    // Backround B has to be set, there are also the derivatives that should be written/read if we wanted to only read in background field
-   phiprof::stop("readCellParameters");
+   readParameters.stop();
 
-   phiprof::start("readBlockData");
+   phiprof::Timer readBlocks {"readBlockData"};
    if (success == true) {
       success = readBlockData(file,meshName,fileCells,localCellStartOffset,localCells,mpiGrid); 
    }
-   phiprof::stop("readBlockData");
+   readBlocks.stop();
 
-   phiprof::start("updateMpiGridNeighbors");
+   phiprof::Timer updateNeighbors {"updateMpiGridNeighbors"};
    mpiGrid.update_copies_of_remote_neighbors(FULL_NEIGHBORHOOD_ID);
-   phiprof::stop("updateMpiGridNeighbors");
+   updateNeighbors.stop();
    
-   phiprof::start("readFsGrid");
+   phiprof::Timer readfs {"readFsGrid"};
    // Read fsgrid data back in
    int fsgridInputRanks=0;
    if(readScalarParameter(file,"numWritingRanks",fsgridInputRanks, MASTER_RANK, MPI_COMM_WORLD) == false) {
@@ -1264,9 +1264,9 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    if (success) { success = readFsGridVariable(file, "fg_PERB", fsgridInputRanks, perBGrid); }
    if (success) { success = readFsGridVariable(file, "fg_E", fsgridInputRanks, EGrid); }
    exitOnError(success,"(RESTART) Failure reading fsgrid restart variables",MPI_COMM_WORLD);
-   phiprof::stop("readFsGrid");
+   readfs.stop();
    
-   phiprof::start("readIonosphere");
+   phiprof::Timer readIonosphere {"readIonosphere"};
    bool ionosphereSuccess=true;
    ionosphereSuccess = readIonosphereNodeVariable(file, "ig_fac", SBC::ionosphereGrid, ionosphereParameters::SOURCE);
    // Reconstruct source term by multiplying the fac density with the element area
@@ -1297,10 +1297,9 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    if(ionosphereSuccess && !ionosphereOptionalSuccess) {
       logFile << "(RESTART) Restart file contains no ionosphere conductivity data. Ionosphere will run fine, but first output bulk file might have bogus conductivities." << std::endl;
    }
-   phiprof::stop("readIonosphere");
+   readIonosphere.stop();
 
    success = file.close();
-   phiprof::stop("readGrid");
 
    exitOnError(success,"(RESTART) Other failure",MPI_COMM_WORLD);
    return success;

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -939,9 +939,9 @@ template<unsigned long int N> bool readFsGridVariable(
          fileOffset += thatTasksSize[0] * thatTasksSize[1] * thatTasksSize[2];
       }
    }
-   phiprof::Timer updateGhostsTimer {"updateGhostCells"};
+   phiprof::Timer updateGhosts {"updateGhostCells"};
    targetGrid.updateGhostCells();
-   updateGhostsTimer.stop();
+   updateGhosts.stop();
    return true;
 }
 
@@ -1065,9 +1065,9 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
    MPI_Comm_size(MPI_COMM_WORLD,&processes);
 
-   phiprof::Timer readGridTimer {"readGrid"};
+   phiprof::Timer readGrid {"readGrid"};
 
-   phiprof::Timer readScalarsTimer {"readScalars"};
+   phiprof::Timer readScalars {"readScalars"};
 
    vlsv::ParallelReader file;
    MPI_Info mpiInfo = MPI_INFO_NULL;
@@ -1113,9 +1113,9 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    checkScalarParameter(file,"ycells_ini",P::ycells_ini,MASTER_RANK,MPI_COMM_WORLD);
    checkScalarParameter(file,"zcells_ini",P::zcells_ini,MASTER_RANK,MPI_COMM_WORLD);
 
-   readScalarsTimer.stop();
+   readScalars.stop();
 
-   phiprof::Timer readLayoutimer {"readDatalayout"};
+   phiprof::Timer readLayout {"readDatalayout"};
    if (success) {
 		success = readCellIds(file,fileCells,MASTER_RANK,MPI_COMM_WORLD);
 	}
@@ -1222,10 +1222,10 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    //for(uint64_t i=localCellStartOffset; i<localCellStartOffset+localCells; ++i) {
    //  localBlocks += nBlocks[i];
    //}
-   readLayoutimer.stop();
+   readLayout.stop();
 
    //todo, check file datatype, and do not just use double
-   phiprof::Timer readParametersTimer {"readCellParameters"};
+   phiprof::Timer readParameters {"readCellParameters"};
    if(success) { success=readCellParamsVariable(file,fileCells,localCellStartOffset,localCells,"moments",CellParams::RHOM,5,mpiGrid); }
    if(success) { success=readCellParamsVariable(file,fileCells,localCellStartOffset,localCells,"moments_dt2",CellParams::RHOM_DT2,5,mpiGrid); }
    if(success) { success=readCellParamsVariable(file,fileCells,localCellStartOffset,localCells,"moments_r",CellParams::RHOM_R,5,mpiGrid); }
@@ -1242,19 +1242,19 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    if(success) { success=readCellParamsVariable(file,fileCells,localCellStartOffset,localCells,"vg_bulk_forcing_flag",CellParams::FORCING_CELL_NUM,1,mpiGrid); }
 
    // Backround B has to be set, there are also the derivatives that should be written/read if we wanted to only read in background field
-   readParametersTimer.stop();
+   readParameters.stop();
 
-   phiprof::Timer readBlocksTimer {"readBlockData"};
+   phiprof::Timer readBlocks {"readBlockData"};
    if (success == true) {
       success = readBlockData(file,meshName,fileCells,localCellStartOffset,localCells,mpiGrid); 
    }
-   readBlocksTimer.stop();
+   readBlocks.stop();
 
-   phiprof::Timer updateNeighborsTimer {"updateMpiGridNeighbors"};
+   phiprof::Timer updateNeighbors {"updateMpiGridNeighbors"};
    mpiGrid.update_copies_of_remote_neighbors(FULL_NEIGHBORHOOD_ID);
-   updateNeighborsTimer.stop();
+   updateNeighbors.stop();
    
-   phiprof::Timer readfsTimer {"readFsGrid"};
+   phiprof::Timer readfs {"readFsGrid"};
    // Read fsgrid data back in
    int fsgridInputRanks=0;
    if(readScalarParameter(file,"numWritingRanks",fsgridInputRanks, MASTER_RANK, MPI_COMM_WORLD) == false) {
@@ -1264,9 +1264,9 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    if (success) { success = readFsGridVariable(file, "fg_PERB", fsgridInputRanks, perBGrid); }
    if (success) { success = readFsGridVariable(file, "fg_E", fsgridInputRanks, EGrid); }
    exitOnError(success,"(RESTART) Failure reading fsgrid restart variables",MPI_COMM_WORLD);
-   readfsTimer.stop();
+   readfs.stop();
    
-   phiprof::Timer readIonosphereTimer {"readIonosphere"};
+   phiprof::Timer readIonosphere {"readIonosphere"};
    bool ionosphereSuccess=true;
    ionosphereSuccess = readIonosphereNodeVariable(file, "ig_fac", SBC::ionosphereGrid, ionosphereParameters::SOURCE);
    // Reconstruct source term by multiplying the fac density with the element area
@@ -1297,7 +1297,7 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    if(ionosphereSuccess && !ionosphereOptionalSuccess) {
       logFile << "(RESTART) Restart file contains no ionosphere conductivity data. Ionosphere will run fine, but first output bulk file might have bogus conductivities." << std::endl;
    }
-   readIonosphereTimer.stop();
+   readIonosphere.stop();
 
    success = file.close();
 

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -335,7 +335,7 @@ bool writeDataReducer(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
    
    const string meshName = "SpatialGrid";
    variableName = dataReducer.getName(dataReducerIndex);
-   phiprof::Timer dro {"DRO_"+variableName};
+   phiprof::Timer droTimer {"DRO_"+variableName};
 
    //Get basic data on a variable:
    uint dataSize,vectorSize;
@@ -407,17 +407,17 @@ bool writeDataReducer(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
          //Cast the varBuffer to char:
          char * varBuffer_smaller_char = reinterpret_cast<char*>(varBuffer_smaller);
          //Write the array:
-         phiprof::Timer writeArray {"writeArray"};
+         phiprof::Timer writeArrayTimer {"writeArray"};
          if (vlsvWriter.writeArray("VARIABLE", attribs, dataType_smaller, arraySize_smaller, vectorSize_smaller, dataSize_smaller, varBuffer_smaller_char) == false) {
             success = false;
             logFile << "(MAIN) writeGrid: ERROR failed to write datareductionoperator data to file!" << endl << writeVerbose;
          }
-         writeArray.stop();
+         writeArrayTimer.stop();
          delete[] varBuffer_smaller;
          varBuffer_smaller = NULL;
       } else {
          // Write  reduced data to file if DROP was successful:
-         phiprof::Timer writeArray {"writeArray"};
+         phiprof::Timer writeArrayTimer {"writeArray"};
          if (vlsvWriter.writeArray("VARIABLE",attribs, dataType, cells.size(), vectorSize, dataSize, varBuffer) == false) {
             success = false;
             logFile << "(MAIN) writeGrid: ERROR failed to write datareductionoperator data to file!" << endl << writeVerbose;
@@ -427,14 +427,14 @@ bool writeDataReducer(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
    } else {
       // If the data reducer didn't want to write dccrg data, maybe it will be happy
       // dumping data straight from fsgrid into our file.
-      phiprof::Timer writeFs {"writeFsGrid"};
+      phiprof::Timer writeFsTimer {"writeFsGrid"};
       success = dataReducer.writeFsGridData(perBGrid,EGrid,EHallGrid,EGradPeGrid,momentsGrid,dPerBGrid,dMomentsGrid,BgBGrid,volGrid, technicalGrid, "fsgrid", dataReducerIndex, vlsvWriter, writeAsFloat);
-      writeFs.stop();
+      writeFsTimer.stop();
 
       // Or maybe it will be writing ionosphere data?
-      phiprof::Timer writeIonosphere {"writeIonosphere"};
+      phiprof::Timer writeIonosphereTimer {"writeIonosphere"};
       success |= dataReducer.writeIonosphereGridData(SBC::ionosphereGrid, "ionosphere", dataReducerIndex, vlsvWriter);
-      writeIonosphere.stop();
+      writeIonosphereTimer.stop();
    }
    
    // Check if the DataReducer wants to write paramters to the output file
@@ -1309,13 +1309,13 @@ bool writeGrid(
    double allStart = MPI_Wtime();
    bool success = true;
    int myRank;
-   phiprof::Timer barrierWritegrid {"Barrier-entering-writegrid", {"MPI","Barrier"}};
+   phiprof::Timer barrierWritegridTimer {"Barrier-entering-writegrid", {"MPI","Barrier"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   barrierWritegrid.stop();
+   barrierWritegridTimer.stop();
 
 
    MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
-   phiprof::Timer writeReduced {"writeGrid-reduced"};
+   phiprof::Timer writeReducedTimer {"writeGrid-reduced"};
    // Create a name for the output file and open it with VLSVWriter:
    stringstream fname;
    fname << P::systemWritePath.at(outputFileTypeIndex) << "/" << P::systemWriteName.at(outputFileTypeIndex) << ".";
@@ -1354,9 +1354,9 @@ bool writeGrid(
       MPI_Info_set(MPIinfo, factor, stripeChar);
    }
 
-   phiprof::Timer open {"open"};
+   phiprof::Timer openTimer {"open"};
    vlsvWriter.open( fname.str(), MPI_COMM_WORLD, masterProcessId, MPIinfo );
-   open.stop();
+   openTimer.stop();
    
    if( MPIinfo != MPI_INFO_NULL ) {
       MPI_Info_free(&MPIinfo);
@@ -1364,7 +1364,7 @@ bool writeGrid(
    
    vlsvWriter.setBuffer(P::vlsvBufferSize);
 
-   phiprof::Timer metadata {"metadataIO"};
+   phiprof::Timer metadataTimer {"metadataIO"};
 
    // Get all local cell Ids 
    const vector<CellID>& local_cells = getLocalCells();
@@ -1467,17 +1467,17 @@ bool writeGrid(
       return false;
    }
    
-   metadata.stop();
-   phiprof::Timer vspace {"velocityspaceIO"};
+   metadataTimer.stop();
+   phiprof::Timer vspaceTimer {"velocityspaceIO"};
    if(writeVelocitySpace( mpiGrid, vlsvWriter, outputFileTypeIndex, local_cells ) == false)  {
       return false;
    }
-   vspace.stop();
+   vspaceTimer.stop();
 
-   phiprof::Timer reduced {"reduceddataIO"};
+   phiprof::Timer reducedTimer {"reduceddataIO"};
    //Write necessary variables:
    //Determines whether we write in floats or doubles
-   phiprof::Timer writeData {"writeDataReducer"};
+   phiprof::Timer writeDataTimer {"writeDataReducer"};
    if (dataReducer != NULL) for( uint i = 0; i < dataReducer->size(); ++i ) {
       if( writeDataReducer( mpiGrid, local_cells,
             perBGrid, EGrid, EHallGrid, EGradPeGrid, momentsGrid, dPerBGrid, dMomentsGrid,
@@ -1489,11 +1489,11 @@ bool writeGrid(
          return false;
       }
    }
-   writeData.stop();
+   writeDataTimer.stop();
    
-   phiprof::Timer barrier {"Barrier", {"MPI","Barrier"}};
+   phiprof::Timer barrierTimer {"Barrier", {"MPI","Barrier"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   barrier.stop();
+   barrierTimer.stop();
    
    const uint64_t bytesWritten = vlsvWriter.getBytesWritten();
    const double writeTime = vlsvWriter.getWriteTime();
@@ -1512,12 +1512,12 @@ bool writeGrid(
    else logFile << bytesWritten/writeTime << " B/s";
    logFile << endl;
 
-   reduced.stop();
+   reducedTimer.stop();
 
-   phiprof::Timer close {"close"};
+   phiprof::Timer closeTimer {"close"};
    vlsvWriter.close();
-   close.stop();
-   writeReduced.stop(bytesWritten * 1e-9, "GB");
+   closeTimer.stop();
+   writeReducedTimer.stop(bytesWritten * 1e-9, "GB");
    return success;
 }
 
@@ -1555,15 +1555,15 @@ bool writeRestart(
    int myRank;
    
    MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
-   phiprof::Timer barrierEntering {"BarrierEnteringWriteRestart", {"MPI","Barrier"}};
+   phiprof::Timer barrierEnteringTimer {"BarrierEnteringWriteRestart", {"MPI","Barrier"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   barrierEntering.stop();
+   barrierEnteringTimer.stop();
 
-   phiprof::Timer write {"writeRestart"};
-   phiprof::Timer deallocate {"DeallocateRemoteBlocks"};
+   phiprof::Timer writeTimer {"writeRestart"};
+   phiprof::Timer deallocateTimer {"DeallocateRemoteBlocks"};
    //deallocate blocks in remote cells to decrease memory load
    deallocateRemoteCellBlocks(mpiGrid);
-   deallocate.stop();
+   deallocateTimer.stop();
    
    // Get the current time.
    // Avoid different times on different processes!
@@ -1582,7 +1582,7 @@ bool writeRestart(
    fname.fill('0');
    fname << fileIndex << "." << currentDate << ".vlsv";
 
-   phiprof::Timer open {"open"};
+   phiprof::Timer openTimer {"open"};
    //Open the file with vlsvWriter:
    Writer vlsvWriter;
    const int masterProcessId = 0;
@@ -1618,11 +1618,11 @@ bool writeRestart(
       MPI_Info_free(&MPIinfo);
    }
 
-   open.stop();
+   openTimer.stop();
 
    vlsvWriter.setBuffer(P::vlsvBufferSize);
 
-   phiprof::Timer metadata {"metadataIO"};
+   phiprof::Timer metadataTimer {"metadataIO"};
    
    // Get all local cell Ids 
    vector<CellID> local_cells = getLocalCells();
@@ -1664,8 +1664,8 @@ bool writeRestart(
    //Write Ionosphere Grid
    if( writeIonosphereGridMetadata( vlsvWriter ) == false ) return false;
 
-   metadata.stop();
-   phiprof::Timer reduced {"reduceddataIO"};
+   metadataTimer.stop();
+   phiprof::Timer reducedTimer {"reduceddataIO"};
    //write out DROs we need for restarts
    DataReducer restartReducer;
    restartReducer.addOperator(new DRO::DataReductionOperatorCellParams("moments",CellParams::RHOM,5));
@@ -1839,24 +1839,24 @@ bool writeRestart(
             BgBGrid, volGrid, technicalGrid,
             writeAsFloat, true, restartReducer, i, vlsvWriter);
    }
-   reduced.stop();
+   reducedTimer.stop();
    //write the velocity distribution data -- note: it's expecting a vector of pointers:
    // Note: restart should always write double values to ensure the accuracy of the restart runs. 
    // In case of distribution data it is not as important as they are mainly used for visualization purpose
-   phiprof::Timer vspace {"velocityspaceIO"};
+   phiprof::Timer vspaceTimer {"velocityspaceIO"};
    writeVelocityDistributionData(vlsvWriter, mpiGrid, local_cells, MPI_COMM_WORLD);
-   vspace.stop();
+   vspaceTimer.stop();
 
-   phiprof::Timer close {"close"};
+   phiprof::Timer closeTimer {"close"};
    vlsvWriter.close();
-   close.stop();
+   closeTimer.stop();
 
-   phiprof::Timer updateRemote {"updateRemoteBlocks"};
+   phiprof::Timer updateRemoteTimer {"updateRemoteBlocks"};
    //Updated newly adjusted velocity block lists on remote cells, and
    //prepare to receive block data
    for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID)
       updateRemoteVelocityBlockLists(mpiGrid,popID);
-   updateRemote.stop();
+   updateRemoteTimer.stop();
 
    const uint64_t bytesWritten = vlsvWriter.getBytesWritten();
    const double writeTime = vlsvWriter.getWriteTime();
@@ -1875,7 +1875,7 @@ bool writeRestart(
    else logFile << bytesWritten/writeTime << " B/s";
    logFile << endl;
    
-   write.stop(bytesWritten * 1e-9, "GB");
+   writeTimer.stop(bytesWritten * 1e-9, "GB");
    return success;
 }
 

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -688,7 +688,7 @@ namespace projects {
    }
 
    bool Magnetosphere::adaptRefinement( dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid ) const {
-      phiprof::start("Set refines");
+      phiprof::Timer refines {"Set refines"};
       int myRank;       
       MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
       if (myRank == MASTER_RANK)
@@ -749,8 +749,6 @@ namespace projects {
             }
          }
       }
-
-      phiprof::stop("Set refines");
       return true;
    }
 

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -688,7 +688,7 @@ namespace projects {
    }
 
    bool Magnetosphere::adaptRefinement( dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid ) const {
-      phiprof::Timer refinesTimer {"Set refines"};
+      phiprof::Timer refines {"Set refines"};
       int myRank;       
       MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
       if (myRank == MASTER_RANK)

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -688,7 +688,7 @@ namespace projects {
    }
 
    bool Magnetosphere::adaptRefinement( dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid ) const {
-      phiprof::Timer refines {"Set refines"};
+      phiprof::Timer refinesTimer {"Set refines"};
       int myRank;       
       MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
       if (myRank == MASTER_RANK)

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -301,7 +301,7 @@ namespace projects {
       LineDipole bgFieldLineDipole;
       VectorDipole bgVectorDipole;
 
-      phiprof::start("switch-dipoleType");
+      phiprof::Timer switchDipoleTypeTimer {"switch-dipoleType"};
       // The hardcoded constants of dipole and line dipole moments are obtained
       // from Daldorff et al (2014), see
       // https://github.com/fmihpc/vlasiator/issues/20 for a derivation of the
@@ -350,11 +350,11 @@ namespace projects {
             default:
                setBackgroundFieldToZero(BgBGrid);
       }
-      phiprof::stop("switch-dipoleType");
+      switchDipoleTypeTimer.stop();
 
       const auto localSize = BgBGrid.getLocalSize().data();
       
-      phiprof::start("zeroing-out");
+      phiprof::Timer zeroingTimer {"zeroing-out"};
 
 #pragma omp parallel
       {
@@ -452,9 +452,9 @@ namespace projects {
          }
       } // end of omp parallel region
 
-      phiprof::stop("zeroing-out");
+      zeroingTimer.stop();
 
-      phiprof::start("add-constant-field");
+      phiprof::Timer addConstantTimer {"add-constant-field"};
       // Superimpose constant background field if needed
       if(this->constBgB[0] != 0.0 || this->constBgB[1] != 0.0 || this->constBgB[2] != 0.0) {
          ConstantField bgConstantField;
@@ -462,10 +462,10 @@ namespace projects {
          setBackgroundField(bgConstantField, BgBGrid, true);
          SBC::ionosphereGrid.setConstantBackgroundField(this->constBgB);
       }
-      phiprof::stop("add-constant-field");
-      phiprof::start("ionosphereGrid.storeNodeB");
+      addConstantTimer.stop();
+      phiprof::Timer storeNodeTimer {"ionosphereGrid.storeNodeB"};
       SBC::ionosphereGrid.storeNodeB();
-      phiprof::stop("ionosphereGrid.storeNodeB");
+      storeNodeTimer.stop();
    }
    
    

--- a/sysboundary/conductingsphere.cpp
+++ b/sysboundary/conductingsphere.cpp
@@ -206,7 +206,7 @@ namespace SBC {
       cint j,
       cint k
    ) {
-      phiprof::start("Conductingsphere::fieldSolverGetNormalDirection");
+      phiprof::Timer timer {"Conductingsphere::fieldSolverGetNormalDirection"};
       std::array<Real, 3> normalDirection{{ 0.0, 0.0, 0.0 }};
       
       static creal DIAG2 = 1.0 / sqrt(2.0);
@@ -468,8 +468,6 @@ namespace SBC {
          }
          // end of 3D
       }
-      
-      phiprof::stop("Conductingsphere::fieldSolverGetNormalDirection");
       return normalDirection;
    }
    
@@ -770,7 +768,7 @@ namespace SBC {
       const uint popID,
       const bool calculate_V_moments
    ) {
-      phiprof::start("vlasovBoundaryCondition (Conductingsphere)");
+      phiprof::Timer timer {"vlasovBoundaryCondition (Conductingsphere)"};
       this->vlasovBoundaryFluffyCopyFromAllCloseNbrs(mpiGrid, cellID, popID, calculate_V_moments, this->speciesParams[popID].fluffiness);
       phiprof::stop("vlasovBoundaryCondition (Conductingsphere)");
    }

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -792,15 +792,12 @@ void SysBoundary::applySysBoundaryVlasovConditions(
       updateRemoteVelocityBlockLists(mpiGrid, popID, SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID);
 
       // Then the block data in the reduced neighbourhood:
-      int timer = phiprof::initializeTimer("Start comm of cell and block data", "MPI");
-      phiprof::start(timer);
+      phiprof::Timer comm {"Start comm of cell and block data", {"MPI"}};
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA, true);
       mpiGrid.start_remote_neighbor_copy_updates(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID);
-      phiprof::stop(timer);
+      comm.stop();
 
-      timer = phiprof::initializeTimer("Compute process inner cells");
-      phiprof::start(timer);
-
+      phiprof::Timer computeInner {"Compute process inner cells"};
       // Compute Vlasov boundary condition on system boundary/process inner cells
       vector<CellID> localCells;
       getBoundaryCellList(mpiGrid, mpiGrid.get_local_cells_not_on_process_boundary(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID), localCells);
@@ -815,16 +812,14 @@ void SysBoundary::applySysBoundaryVlasovConditions(
       } else {
          calculateMoments_R(mpiGrid, localCells, true);
       }
-      phiprof::stop(timer);
+      computeInner.stop();
 
-      timer = phiprof::initializeTimer("Wait for receives", "MPI", "Wait");
-      phiprof::start(timer);
+      phiprof::Timer wait {"Wait for receives", {"MPI", "Wait"}};
       mpiGrid.wait_remote_neighbor_copy_updates(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID);
-      phiprof::stop(timer);
+      wait.stop();
 
       // Compute vlasov boundary on system boundary/process boundary cells
-      timer = phiprof::initializeTimer("Compute process boundary cells");
-      phiprof::start(timer);
+      phiprof::Timer computeBoundary {"Compute process boundary cells"};
       vector<CellID> boundaryCells;
       getBoundaryCellList(mpiGrid, mpiGrid.get_local_cells_on_process_boundary(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID),
                           boundaryCells);
@@ -838,7 +833,7 @@ void SysBoundary::applySysBoundaryVlasovConditions(
       } else {
          calculateMoments_R(mpiGrid, boundaryCells, true);
       }
-      phiprof::stop(timer);
+      computeBoundary.stop();
 
       // WARNING Blocks are changed but lists not updated now, if you need to use/communicate them before the next
       // update is done, add an update here. reset lists in smaller default neighborhood
@@ -904,14 +899,12 @@ bool getBoundaryCellList(const dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geomet
  * \retval Returns true if the operation is successful
  */
 bool SysBoundary::updateSysBoundariesAfterLoadBalance(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid) {
-   phiprof::start("updateSysBoundariesAfterLoadBalance");
+   phiprof::Timer timer {"updateSysBoundariesAfterLoadBalance"};
    vector<uint64_t> local_cells_on_boundary;
    getBoundaryCellList(mpiGrid, mpiGrid.get_cells(), local_cells_on_boundary);
    // Loop over sysboundaries:
    for (list<SBC::SysBoundaryCondition*>::iterator it = sysBoundaries.begin(); it != sysBoundaries.end(); ++it) {
       (*it)->updateSysBoundaryConditionsAfterLoadBalance(mpiGrid, local_cells_on_boundary);
    }
-
-   phiprof::stop("updateSysBoundariesAfterLoadBalance");
    return true;
 }

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -792,12 +792,12 @@ void SysBoundary::applySysBoundaryVlasovConditions(
       updateRemoteVelocityBlockLists(mpiGrid, popID, SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID);
 
       // Then the block data in the reduced neighbourhood:
-      phiprof::Timer commTimer {"Start comm of cell and block data", {"MPI"}};
+      phiprof::Timer comm {"Start comm of cell and block data", {"MPI"}};
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA, true);
       mpiGrid.start_remote_neighbor_copy_updates(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID);
-      commTimer.stop();
+      comm.stop();
 
-      phiprof::Timer computeInnerTimer {"Compute process inner cells"};
+      phiprof::Timer computeInner {"Compute process inner cells"};
       // Compute Vlasov boundary condition on system boundary/process inner cells
       vector<CellID> localCells;
       getBoundaryCellList(mpiGrid, mpiGrid.get_local_cells_not_on_process_boundary(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID), localCells);
@@ -812,14 +812,14 @@ void SysBoundary::applySysBoundaryVlasovConditions(
       } else {
          calculateMoments_R(mpiGrid, localCells, true);
       }
-      computeInnerTimer.stop();
+      computeInner.stop();
 
-      phiprof::Timer waitimer {"Wait for receives", {"MPI", "Wait"}};
+      phiprof::Timer wait {"Wait for receives", {"MPI", "Wait"}};
       mpiGrid.wait_remote_neighbor_copy_updates(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID);
-      waitimer.stop();
+      wait.stop();
 
       // Compute vlasov boundary on system boundary/process boundary cells
-      phiprof::Timer computeBoundaryTimer {"Compute process boundary cells"};
+      phiprof::Timer computeBoundary {"Compute process boundary cells"};
       vector<CellID> boundaryCells;
       getBoundaryCellList(mpiGrid, mpiGrid.get_local_cells_on_process_boundary(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID),
                           boundaryCells);
@@ -833,7 +833,7 @@ void SysBoundary::applySysBoundaryVlasovConditions(
       } else {
          calculateMoments_R(mpiGrid, boundaryCells, true);
       }
-      computeBoundaryTimer.stop();
+      computeBoundary.stop();
 
       // WARNING Blocks are changed but lists not updated now, if you need to use/communicate them before the next
       // update is done, add an update here. reset lists in smaller default neighborhood

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -792,12 +792,12 @@ void SysBoundary::applySysBoundaryVlasovConditions(
       updateRemoteVelocityBlockLists(mpiGrid, popID, SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID);
 
       // Then the block data in the reduced neighbourhood:
-      phiprof::Timer comm {"Start comm of cell and block data", {"MPI"}};
+      phiprof::Timer commTimer {"Start comm of cell and block data", {"MPI"}};
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA, true);
       mpiGrid.start_remote_neighbor_copy_updates(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID);
-      comm.stop();
+      commTimer.stop();
 
-      phiprof::Timer computeInner {"Compute process inner cells"};
+      phiprof::Timer computeInnerTimer {"Compute process inner cells"};
       // Compute Vlasov boundary condition on system boundary/process inner cells
       vector<CellID> localCells;
       getBoundaryCellList(mpiGrid, mpiGrid.get_local_cells_not_on_process_boundary(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID), localCells);
@@ -812,14 +812,14 @@ void SysBoundary::applySysBoundaryVlasovConditions(
       } else {
          calculateMoments_R(mpiGrid, localCells, true);
       }
-      computeInner.stop();
+      computeInnerTimer.stop();
 
-      phiprof::Timer wait {"Wait for receives", {"MPI", "Wait"}};
+      phiprof::Timer waitimer {"Wait for receives", {"MPI", "Wait"}};
       mpiGrid.wait_remote_neighbor_copy_updates(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID);
-      wait.stop();
+      waitimer.stop();
 
       // Compute vlasov boundary on system boundary/process boundary cells
-      phiprof::Timer computeBoundary {"Compute process boundary cells"};
+      phiprof::Timer computeBoundaryTimer {"Compute process boundary cells"};
       vector<CellID> boundaryCells;
       getBoundaryCellList(mpiGrid, mpiGrid.get_local_cells_on_process_boundary(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID),
                           boundaryCells);
@@ -833,7 +833,7 @@ void SysBoundary::applySysBoundaryVlasovConditions(
       } else {
          calculateMoments_R(mpiGrid, boundaryCells, true);
       }
-      computeBoundary.stop();
+      computeBoundaryTimer.stop();
 
       // WARNING Blocks are changed but lists not updated now, if you need to use/communicate them before the next
       // update is done, add an update here. reset lists in smaller default neighborhood

--- a/sysboundary/sysboundarycondition.cpp
+++ b/sysboundary/sysboundarycondition.cpp
@@ -861,9 +861,8 @@ namespace SBC {
    array<SpatialCell*,27> & SysBoundaryCondition::getFlowtoCells(
       const CellID& cellID
    ) {
-      phiprof::start("getFlowtoCells");
+      phiprof::Timer timer {"getFlowtoCells"};
       array<SpatialCell*,27> & flowtoCells = allFlowtoCells.at(cellID);
-      phiprof::stop("getFlowtoCells");
       return flowtoCells;
    }
    
@@ -872,7 +871,7 @@ namespace SBC {
       const vmesh::GlobalID blockGID,
       const uint popID
    ) {
-      phiprof::start("getFlowtoCellsBlock");
+      phiprof::Timer timer {"getFlowtoCellsBlock"};
       array<Realf*,27> flowtoCellsBlock;
       flowtoCellsBlock.fill(NULL);
       for (uint i=0; i<27; i++) {
@@ -880,7 +879,6 @@ namespace SBC {
             flowtoCellsBlock.at(i) = flowtoCells.at(i)->get_data(flowtoCells.at(i)->get_velocity_block_local_id(blockGID,popID), popID);
          }
       }
-      phiprof::stop("getFlowtoCellsBlock");
       return flowtoCellsBlock;
    }
    

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -86,14 +86,14 @@ void addTimedBarrier(string name){
 //let's not do  a barrier
    return; 
 #endif
-   phiprof::Timer bt {name, {"Barriers", "MPI"}};
+   phiprof::Timer btimer {name, {"Barriers", "MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 void computeNewTimeStep(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
 			FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, Real &newDt, bool &isChanged) {
 
-   phiprof::Timer computeTimestep {"compute-timestep"};
+   phiprof::Timer computeTimestepTimer {"compute-timestep"};
    // Compute maximum time step. This cannot be done at the first step as the solvers compute the limits for each cell.
 
    isChanged = false;
@@ -284,9 +284,9 @@ int main(int argn,char* args[]) {
    signal(SIGFPE, fpehandler);
    #endif
 
-   phiprof::Timer main {"main"};
-   phiprof::Timer init {"Initialization"};
-   phiprof::Timer readParams {"Read parameters"};
+   phiprof::Timer mainTimer {"main"};
+   phiprof::Timer initimer {"Initialization"};
+   phiprof::Timer readParamsTimer {"Read parameters"};
 
    //init parameter file reader
    Readparameters readparameters(argn,args);
@@ -310,7 +310,7 @@ int main(int argn,char* args[]) {
    getObjectWrapper().getParameters();
    sysBoundaryContainer.getParameters();
    project->getParameters();
-   readParams.stop();
+   readParamsTimer.stop();
 
    //Get version and config info here
    std::string version;
@@ -325,7 +325,7 @@ int main(int argn,char* args[]) {
 
    // Init parallel logger:
 
-   phiprof::Timer openLogger {"open logFile & diagnostic"};
+   phiprof::Timer openLoggerTimer {"open logFile & diagnostic"};
    //if restarting we will append to logfiles
    if (logFile.open(MPI_COMM_WORLD,MASTER_RANK,"logfile.txt",P::isRestart) == false) {
       if(myRank == MASTER_RANK) cerr << "(MAIN) ERROR: Logger failed to open logfile!" << endl;
@@ -348,10 +348,10 @@ int main(int argn,char* args[]) {
       #endif
       logFile << " OpenMP threads per process" << endl << writeVerbose;      
    }
-   openLogger.stop();
+   openLoggerTimer.stop();
    
    // Init project
-   phiprof::Timer initProject {"Init project"};
+   phiprof::Timer initProjectimer {"Init project"};
    if (project->initialize() == false) {
       if(myRank == MASTER_RANK) cerr << "(MAIN): Project did not initialize correctly!" << endl;
       exit(1);
@@ -363,14 +363,14 @@ int main(int argn,char* args[]) {
          exit(1);
       }
    }
-   initProject.stop();
+   initProjectimer.stop();
 
    // Add VAMR refinement criterias:
    vamr_ref_criteria::addRefinementCriteria();
 
    // Initialize simplified Fieldsolver grids.
    // Needs to be done here already ad the background field will be set right away, before going to initializeGrid even
-   phiprof::Timer initFs {"Init fieldsolver grids"};
+   phiprof::Timer initFsTimer {"Init fieldsolver grids"};
 
    const std::array<int,3> fsGridDimensions = {convert<int>(P::xcells_ini * pow(2,P::amrMaxSpatialRefLevel)),
 							    convert<int>(P::ycells_ini * pow(2,P::amrMaxSpatialRefLevel)),
@@ -424,7 +424,7 @@ int main(int argn,char* args[]) {
                    << std::endl;
       }
    }
-   initFs.stop();
+   initFsTimer.stop();
 
    // Initialize grid.  After initializeGrid local cells have dist
    // functions, and B fields set. Cells have also been classified for
@@ -432,7 +432,7 @@ int main(int argn,char* args[]) {
    // created. All spatial date computed this far is up to date for
    // FULL_NEIGHBORHOOD. Block lists up to date for
    // VLASOV_SOLVER_NEIGHBORHOOD (but dist function has not been communicated)
-   phiprof::Timer initGrids {"Init grids"};
+   phiprof::Timer initGridsTimer {"Init grids"};
    initializeGrids(
       argn,
       args,
@@ -452,14 +452,14 @@ int main(int argn,char* args[]) {
    
    const std::vector<CellID>& cells = getLocalCells();
    
-   initGrids.stop();
+   initGridsTimer.stop();
    
    // Initialize data reduction operators. This should be done elsewhere in order to initialize 
    // user-defined operators:
-   phiprof::Timer initDROs {"Init DROs"};
+   phiprof::Timer initDROsTimer {"Init DROs"};
    DataReducer outputReducer, diagnosticReducer;
    initializeDataReducers(&outputReducer, &diagnosticReducer);
-   initDROs.stop();
+   initDROsTimer.stop();
    
    // Free up memory:
    readparameters.~Readparameters();
@@ -486,10 +486,10 @@ int main(int argn,char* args[]) {
       );
    }
 
-   phiprof::Timer getFields {"getFieldsFromFsGrid"};
+   phiprof::Timer getFieldsTimer {"getFieldsFromFsGrid"};
    volGrid.updateGhostCells();
    getFieldsFromFsGrid(volGrid, BgBGrid, EGradPeGrid, technicalGrid, mpiGrid, cells);
-   getFields.stop();
+   getFieldsTimer.stop();
 
    // Build communicator for ionosphere solving
    SBC::ionosphereGrid.updateIonosphereCommunicator(mpiGrid, technicalGrid);
@@ -502,7 +502,7 @@ int main(int argn,char* args[]) {
    }
 
    if (P::isRestart == false) {
-      phiprof::Timer t {"compute-dt"};
+      phiprof::Timer timer {"compute-dt"};
       // Run Vlasov solver once with zero dt to initialize
       // per-cell dt limits. In restarts, we read the dt from file.
       calculateSpatialTranslation(mpiGrid,0.0);
@@ -513,7 +513,7 @@ int main(int argn,char* args[]) {
    if (P::writeInitialState) {
       FieldTracing::reduceData(technicalGrid, perBGrid, dPerBGrid, mpiGrid, SBC::ionosphereGrid.nodes); /*!< Call the reductions (e.g. field tracing) */
       
-      phiprof::Timer t {"write-initial-state"};
+      phiprof::Timer timer {"write-initial-state"};
       
       if (myRank == MASTER_RANK)
          logFile << "(IO): Writing initial state to disk, tstep = "  << endl << writeVerbose;
@@ -563,34 +563,34 @@ int main(int argn,char* args[]) {
 
    if (P::isRestart == false) {
       //compute new dt
-      phiprof::Timer computeDt {"compute-dt"};
+      phiprof::Timer computeDtimer {"compute-dt"};
       computeNewTimeStep(mpiGrid, technicalGrid, newDt, dtIsChanged);
       if (P::dynamicTimestep == true && dtIsChanged == true) {
          // Only actually update the timestep if dynamicTimestep is on
          P::dt=newDt;
       }
-      computeDt.stop();
+      computeDtimer.stop();
       
       //go forward by dt/2 in V, initializes leapfrog split. In restarts the
       //the distribution function is already propagated forward in time by dt/2
-      phiprof::Timer propagateHalf {"propagate-velocity-space-dt/2"};
+      phiprof::Timer propagateHalfTimer {"propagate-velocity-space-dt/2"};
       if (P::propagateVlasovAcceleration) {
          calculateAcceleration(mpiGrid, 0.5*P::dt);
       } else {
          //zero step to set up moments _v
          calculateAcceleration(mpiGrid, 0.0);
       }
-      propagateHalf.stop();
+      propagateHalfTimer.stop();
 
       // Apply boundary conditions
       if (P::propagateVlasovTranslation || P::propagateVlasovAcceleration ) {
-         phiprof::Timer updateBoundaries {("update system boundaries (Vlasov post-acceleration)")};
+         phiprof::Timer updateBoundariesTimer {("update system boundaries (Vlasov post-acceleration)")};
          sysBoundaryContainer.applySysBoundaryVlasovConditions(mpiGrid, 0.5*P::dt, true);
-         updateBoundaries.stop();
+         updateBoundariesTimer.stop();
          addTimedBarrier("barrier-boundary-conditions");
       }
       // Also update all moments. They won't be transmitted to FSgrid until the field solver is called, though.
-      phiprof::Timer computeMoments {"Compute interp moments"};
+      phiprof::Timer computeMomentsTimer {"Compute interp moments"};
       calculateInterpolatedVelocityMoments(
          mpiGrid,
          CellParams::RHOM,
@@ -602,10 +602,10 @@ int main(int argn,char* args[]) {
          CellParams::P_22,
          CellParams::P_33
       );
-      computeMoments.stop();
+      computeMomentsTimer.stop();
    }
 
-   init.stop();
+   initimer.stop();
 
    // ***********************************
    // ***** INITIALIZATION COMPLETE *****
@@ -625,9 +625,9 @@ int main(int argn,char* args[]) {
    } 
    
 
-   phiprof::Timer reportMem {"report-memory-consumption"};
+   phiprof::Timer reportMemTimer {"report-memory-consumption"};
    report_process_memory_consumption();
-   reportMem.stop();
+   reportMemTimer.stop();
    
    unsigned int computedCells=0;
    unsigned int computedTotalCells=0;
@@ -659,7 +659,7 @@ int main(int argn,char* args[]) {
    
    addTimedBarrier("barrier-end-initialization");
    
-   phiprof::Timer simulation {"Simulation"};
+   phiprof::Timer simulationTimer {"Simulation"};
    double startTime=  MPI_Wtime();
    double beforeTime = MPI_Wtime();
    double beforeSimulationTime=P::t_min;
@@ -671,18 +671,18 @@ int main(int argn,char* args[]) {
       
       addTimedBarrier("barrier-loop-start");
       
-      phiprof::Timer io {"IO"};
+      phiprof::Timer ioTimer {"IO"};
 
-      phiprof::Timer externals {"checkExternalCommands"};
+      phiprof::Timer externalsTimer {"checkExternalCommands"};
       if(myRank ==  MASTER_RANK) {
          // check whether STOP or KILL or SAVE has been passed, should be done by MASTER_RANK only as it can reset P::bailout_write_restart
          checkExternalCommands();
       }
-      externals.stop();
+      externalsTimer.stop();
 
       //write out phiprof profiles and logs with a lower interval than normal
       //diagnostic (every 10 diagnostic intervals).
-      phiprof::Timer logging {"logfile-io"};
+      phiprof::Timer loggingTimer {"logfile-io"};
       logFile << "---------- tstep = " << P::tstep << " t = " << P::t <<" dt = " << P::dt << " FS cycles = " << P::fieldSolverSubcycles << " ----------" << endl;
       if (P::diagnosticInterval != 0 &&
           P::tstep % (P::diagnosticInterval*10) == 0 &&
@@ -707,12 +707,12 @@ int main(int argn,char* args[]) {
          report_process_memory_consumption();
       }
       logFile << writeVerbose;
-      logging.stop();
+      loggingTimer.stop();
 
 // Check whether diagnostic output has to be produced
       if (P::diagnosticInterval != 0 && P::tstep % P::diagnosticInterval == 0) {
          
-         phiprof::Timer diagnostic {"diagnostic-io"};
+         phiprof::Timer diagnosticTimer {"diagnostic-io"};
          if (writeDiagnostic(mpiGrid, diagnosticReducer) == false) {
             if(myRank == MASTER_RANK)  cerr << "ERROR with diagnostic computation" << endl;
             
@@ -737,7 +737,7 @@ int main(int argn,char* args[]) {
             
             FieldTracing::reduceData(technicalGrid, perBGrid, dPerBGrid, mpiGrid, SBC::ionosphereGrid.nodes); /*!< Call the reductions (e.g. field tracing) */
             
-            phiprof::Timer writeSys {"write-system"};
+            phiprof::Timer writeSysTimer {"write-system"};
             logFile << "(IO): Writing spatial cell and reduced system data to disk, tstep = " << P::tstep << " t = " << P::t << endl << writeVerbose;
             const bool writeGhosts = true;
             if(writeGrid(mpiGrid,
@@ -770,13 +770,13 @@ int main(int argn,char* args[]) {
       }
 
       // Reduce globalflags::bailingOut from all processes
-      phiprof::Timer bailoutReduce {"Bailout-allreduce"};
+      phiprof::Timer bailoutReduceTimer {"Bailout-allreduce"};
       MPI_Allreduce(&(globalflags::bailingOut), &(doBailout), 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
-      bailoutReduce.stop();
+      bailoutReduceTimer.stop();
 
       // Write restart data if needed
       // Combined with checking of additional load balancing to have only one collective call.
-      phiprof::Timer restartCheck {"compute-is-restart-written-and-extra-LB"};
+      phiprof::Timer restartCheckTimer {"compute-is-restart-written-and-extra-LB"};
       if (myRank == MASTER_RANK) {
          if (  (P::saveRestartWalltimeInterval >= 0.0
             && (P::saveRestartWalltimeInterval*wallTimeRestartCounter <=  MPI_Wtime()-initialWtime
@@ -806,10 +806,10 @@ int main(int argn,char* args[]) {
          P::prepareForRebalance = true;
          doNow[1] = 0;
       }
-      restartCheck.stop();
+      restartCheckTimer.stop();
 
       if (writeRestartNow >= 1){
-         phiprof::Timer t {"write-restart"};
+         phiprof::Timer timer {"write-restart"};
          if (writeRestartNow == 1) {
             wallTimeRestartCounter++;
          }
@@ -837,10 +837,10 @@ int main(int argn,char* args[]) {
          if (myRank == MASTER_RANK) {
             logFile << "(IO): .... done!"<< endl << writeVerbose;
          }
-         t.stop();
+         timer.stop();
       }
       
-      io.stop();
+      ioTimer.stop();
       addTimedBarrier("barrier-end-io");
       
       //no need to propagate if we are on the final step, we just
@@ -862,16 +862,16 @@ int main(int argn,char* args[]) {
                continue;   // Refinement failed and we're bailing out
 
             // Calculate new dt limits since we might break CFL when refining
-            phiprof::Timer computeDt {"compute-dt"};
+            phiprof::Timer computeDtimer {"compute-dt"};
             calculateSpatialTranslation(mpiGrid,0.0);
             calculateAcceleration(mpiGrid,0.0);      
          }
          balanceLoad(mpiGrid, sysBoundaryContainer);
          addTimedBarrier("barrier-end-load-balance");
-         phiprof::Timer shrink {"Shrink_to_fit"};
+         phiprof::Timer shrinkTimer {"Shrink_to_fit"};
          // * shrink to fit after LB * //
          shrink_to_fit_grid_data(mpiGrid);
-         shrink.stop();
+         shrinkTimer.stop();
          logFile << "(LB): ... done!"  << endl << writeVerbose;
          P::prepareForRebalance = false;
 
@@ -901,7 +901,7 @@ int main(int argn,char* args[]) {
          computeNewTimeStep(mpiGrid, technicalGrid, newDt, dtIsChanged);
          addTimedBarrier("barrier-check-dt");
          if(dtIsChanged) {
-            phiprof::Timer updateDt {"update-dt"};
+            phiprof::Timer updateDtimer {"update-dt"};
             //propagate velocity space back to real-time
             if( P::propagateVlasovAcceleration ) {
                // Back half dt to real time, forward by new half dt
@@ -915,7 +915,7 @@ int main(int argn,char* args[]) {
             P::dt=newDt;
             
             logFile <<" dt changed to "<<P::dt <<"s, distribution function was half-stepped to real-time and back"<<endl<<writeVerbose;
-            updateDt.stop();
+            updateDtimer.stop();
             continue; //
             addTimedBarrier("barrier-new-dt-set");
          }
@@ -933,10 +933,10 @@ int main(int argn,char* args[]) {
          }
       }
       
-      phiprof::Timer propagate {"Propagate"};
+      phiprof::Timer propagateTimer {"Propagate"};
       //Propagate the state of simulation forward in time by dt:
       
-      phiprof::Timer spatialSpace {"Spatial-space"};
+      phiprof::Timer spatialSpaceTimer {"Spatial-space"};
       if( P::propagateVlasovTranslation) {
          calculateSpatialTranslation(mpiGrid,P::dt);
       } else {
@@ -946,13 +946,13 @@ int main(int argn,char* args[]) {
       
       // Apply boundary conditions
       if (P::propagateVlasovTranslation || P::propagateVlasovAcceleration ) {
-         phiprof::Timer t {"Update system boundaries (Vlasov post-translation)"};
+         phiprof::Timer timer {"Update system boundaries (Vlasov post-translation)"};
          sysBoundaryContainer.applySysBoundaryVlasovConditions(mpiGrid, P::t+0.5*P::dt, false);
-         t.stop();
+         timer.stop();
          addTimedBarrier("barrier-boundary-conditions");
       }
       
-      phiprof::Timer moments {"Compute interp moments"};
+      phiprof::Timer momentsTimer {"Compute interp moments"};
       calculateInterpolatedVelocityMoments(
          mpiGrid,
          CellParams::RHOM_DT2,
@@ -964,19 +964,19 @@ int main(int argn,char* args[]) {
          CellParams::P_22_DT2,
          CellParams::P_33_DT2
       );
-      moments.stop();
+      momentsTimer.stop();
       
       // Propagate fields forward in time by dt. This needs to be done before the
       // moments for t + dt are computed (field uses t and t+0.5dt)
       if (P::propagateField) {
-         phiprof::Timer propagate {"Propagate Fields"};
+         phiprof::Timer propagateTimer {"Propagate Fields"};
 
-         phiprof::Timer couplingIn {"fsgrid-coupling-in"};
+         phiprof::Timer couplingInTimer {"fsgrid-coupling-in"};
          // Copy moments over into the fsgrid.
          //setupTechnicalFsGrid(mpiGrid, cells, technicalGrid);
          feedMomentsIntoFsGrid(mpiGrid, cells, momentsGrid, technicalGrid, false);
          feedMomentsIntoFsGrid(mpiGrid, cells, momentsDt2Grid, technicalGrid, true);
-         couplingIn.stop();
+         couplingInTimer.stop();
          
          propagateFields(
             perBGrid,
@@ -997,12 +997,12 @@ int main(int argn,char* args[]) {
             P::fieldSolverSubcycles
          );
 
-         phiprof::Timer getFields {"getFieldsFromFsGrid"};
+         phiprof::Timer getFieldsTimer {"getFieldsFromFsGrid"};
          // Copy results back from fsgrid.
          volGrid.updateGhostCells();
          technicalGrid.updateGhostCells();
          getFieldsFromFsGrid(volGrid, BgBGrid, EGradPeGrid, technicalGrid, mpiGrid, cells);
-         getFields.stop();
+         getFieldsTimer.stop();
          propagate.stop(cells.size(),"SpatialCells");
          addTimedBarrier("barrier-after-field-solver");
       }
@@ -1045,7 +1045,7 @@ int main(int argn,char* args[]) {
          }
       }
       
-      phiprof::Timer vspace {"Velocity-space"};
+      phiprof::Timer vspaceTimer {"Velocity-space"};
       if ( P::propagateVlasovAcceleration ) {
          calculateAcceleration(mpiGrid,P::dt);
          addTimedBarrier("barrier-after-ad just-blocks");
@@ -1057,13 +1057,13 @@ int main(int argn,char* args[]) {
       addTimedBarrier("barrier-after-acceleration");
       
       if (P::propagateVlasovTranslation || P::propagateVlasovAcceleration ) {
-         phiprof::Timer t {"Update system boundaries (Vlasov post-acceleration)"};
+         phiprof::Timer timer {"Update system boundaries (Vlasov post-acceleration)"};
          sysBoundaryContainer.applySysBoundaryVlasovConditions(mpiGrid, P::t+0.5*P::dt, true);
-         t.stop();
+         timer.stop();
          addTimedBarrier("barrier-boundary-conditions");
       }
       
-      moments.start();
+      momentsTimer.start();
       // *here we compute rho and rho_v for timestep t + dt, so next
       // timestep * //
       calculateInterpolatedVelocityMoments(
@@ -1077,13 +1077,13 @@ int main(int argn,char* args[]) {
          CellParams::P_22,
          CellParams::P_33
       );
-      moments.stop();
+      momentsTimer.stop();
 
       propagate.stop(computedCells,"Cells");
       
-      phiprof::Timer endStep {"Project endTimeStep"};
+      phiprof::Timer endStepTimer {"Project endTimeStep"};
       project->hook(hook::END_OF_TIME_STEP, mpiGrid, perBGrid);
-      endStep.stop();
+      endStepTimer.stop();
 
       // Check timestep
       if (P::dt < P::bailout_min_dt) {
@@ -1101,8 +1101,8 @@ int main(int argn,char* args[]) {
 
    double after = MPI_Wtime();
 
-   simulation.stop();
-   phiprof::Timer finalization {"Finalization"};
+   simulationTimer.stop();
+   phiprof::Timer finalizationTimer {"Finalization"};
    if (P::propagateField ) { 
       finalizeFieldPropagator();
    }
@@ -1127,8 +1127,8 @@ int main(int argn,char* args[]) {
       logFile << writeVerbose;
    }
    
-   finalization.stop();
-   main.stop();
+   finalizationTimer.stop();
+   mainTimer.stop();
    
    phiprof::print(MPI_COMM_WORLD,"phiprof");
    

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -86,16 +86,14 @@ void addTimedBarrier(string name){
 //let's not do  a barrier
    return; 
 #endif
-   int bt=phiprof::initializeTimer(name,"Barriers","MPI");
-   phiprof::start(bt);
+   phiprof::Timer bt {name, {"Barriers", "MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   phiprof::stop(bt);
 }
 
 void computeNewTimeStep(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
 			FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, Real &newDt, bool &isChanged) {
 
-   phiprof::start("compute-timestep");
+   phiprof::Timer computeTimestep {"compute-timestep"};
    // Compute maximum time step. This cannot be done at the first step as the solvers compute the limits for each cell.
 
    isChanged = false;
@@ -229,8 +227,6 @@ void computeNewTimeStep(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
    } else {
       P::fieldSolverSubcycles = 1;
    }
-
-   phiprof::stop("compute-timestep");
 }
 
 ObjectWrapper& getObjectWrapper() {
@@ -288,11 +284,10 @@ int main(int argn,char* args[]) {
    signal(SIGFPE, fpehandler);
    #endif
 
+   phiprof::Timer main {"main"};
+   phiprof::Timer init {"Initialization"};
+   phiprof::Timer readParams {"Read parameters"};
 
-
-   phiprof::start("main");
-   phiprof::start("Initialization");
-   phiprof::start("Read parameters");
    //init parameter file reader
    Readparameters readparameters(argn,args);
 
@@ -315,10 +310,7 @@ int main(int argn,char* args[]) {
    getObjectWrapper().getParameters();
    sysBoundaryContainer.getParameters();
    project->getParameters();
-   phiprof::stop("Read parameters");
-
-
-
+   readParams.stop();
 
    //Get version and config info here
    std::string version;
@@ -332,7 +324,8 @@ int main(int argn,char* args[]) {
 
 
    // Init parallel logger:
-   phiprof::start("open logFile & diagnostic");
+
+   phiprof::Timer openLogger {"open logFile & diagnostic"};
    //if restarting we will append to logfiles
    if (logFile.open(MPI_COMM_WORLD,MASTER_RANK,"logfile.txt",P::isRestart) == false) {
       if(myRank == MASTER_RANK) cerr << "(MAIN) ERROR: Logger failed to open logfile!" << endl;
@@ -355,10 +348,10 @@ int main(int argn,char* args[]) {
       #endif
       logFile << " OpenMP threads per process" << endl << writeVerbose;      
    }
-   phiprof::stop("open logFile & diagnostic");
+   openLogger.stop();
    
    // Init project
-   phiprof::start("Init project");
+   phiprof::Timer initProject {"Init project"};
    if (project->initialize() == false) {
       if(myRank == MASTER_RANK) cerr << "(MAIN): Project did not initialize correctly!" << endl;
       exit(1);
@@ -370,14 +363,14 @@ int main(int argn,char* args[]) {
          exit(1);
       }
    }
-   phiprof::stop("Init project");
+   initProject.stop();
 
    // Add VAMR refinement criterias:
    vamr_ref_criteria::addRefinementCriteria();
 
    // Initialize simplified Fieldsolver grids.
    // Needs to be done here already ad the background field will be set right away, before going to initializeGrid even
-   phiprof::start("Init fieldsolver grids");
+   phiprof::Timer initFs {"Init fieldsolver grids"};
 
    const std::array<int,3> fsGridDimensions = {convert<int>(P::xcells_ini * pow(2,P::amrMaxSpatialRefLevel)),
 							    convert<int>(P::ycells_ini * pow(2,P::amrMaxSpatialRefLevel)),
@@ -431,7 +424,7 @@ int main(int argn,char* args[]) {
                    << std::endl;
       }
    }
-   phiprof::stop("Init fieldsolver grids");
+   initFs.stop();
 
    // Initialize grid.  After initializeGrid local cells have dist
    // functions, and B fields set. Cells have also been classified for
@@ -439,7 +432,7 @@ int main(int argn,char* args[]) {
    // created. All spatial date computed this far is up to date for
    // FULL_NEIGHBORHOOD. Block lists up to date for
    // VLASOV_SOLVER_NEIGHBORHOOD (but dist function has not been communicated)
-   phiprof::start("Init grids");
+   phiprof::Timer initGrids {"Init grids"};
    initializeGrids(
       argn,
       args,
@@ -459,14 +452,14 @@ int main(int argn,char* args[]) {
    
    const std::vector<CellID>& cells = getLocalCells();
    
-   phiprof::stop("Init grids");
+   initGrids.stop();
    
    // Initialize data reduction operators. This should be done elsewhere in order to initialize 
    // user-defined operators:
-   phiprof::start("Init DROs");
+   phiprof::Timer initDROs {"Init DROs"};
    DataReducer outputReducer, diagnosticReducer;
    initializeDataReducers(&outputReducer, &diagnosticReducer);
-   phiprof::stop("Init DROs");  
+   initDROs.stop();
    
    // Free up memory:
    readparameters.~Readparameters();
@@ -493,10 +486,10 @@ int main(int argn,char* args[]) {
       );
    }
 
-   phiprof::start("getFieldsFromFsGrid");
+   phiprof::Timer getFields {"getFieldsFromFsGrid"};
    volGrid.updateGhostCells();
    getFieldsFromFsGrid(volGrid, BgBGrid, EGradPeGrid, technicalGrid, mpiGrid, cells);
-   phiprof::stop("getFieldsFromFsGrid");
+   getFields.stop();
 
    // Build communicator for ionosphere solving
    SBC::ionosphereGrid.updateIonosphereCommunicator(mpiGrid, technicalGrid);
@@ -509,19 +502,18 @@ int main(int argn,char* args[]) {
    }
 
    if (P::isRestart == false) {
-      phiprof::start("compute-dt");
+      phiprof::Timer t {"compute-dt"};
       // Run Vlasov solver once with zero dt to initialize
       // per-cell dt limits. In restarts, we read the dt from file.
       calculateSpatialTranslation(mpiGrid,0.0);
       calculateAcceleration(mpiGrid,0.0);      
-      phiprof::stop("compute-dt");
    }
 
    // Save restart data
    if (P::writeInitialState) {
       FieldTracing::reduceData(technicalGrid, perBGrid, dPerBGrid, mpiGrid, SBC::ionosphereGrid.nodes); /*!< Call the reductions (e.g. field tracing) */
       
-      phiprof::start("write-initial-state");
+      phiprof::Timer t {"write-initial-state"};
       
       if (myRank == MASTER_RANK)
          logFile << "(IO): Writing initial state to disk, tstep = "  << endl << writeVerbose;
@@ -567,40 +559,38 @@ int main(int argn,char* args[]) {
       P::systemWriteDistributionWriteZlineStride.pop_back();
       P::systemWritePath.pop_back();
       P::systemWriteFsGrid.pop_back();
-
-      phiprof::stop("write-initial-state");
    }
 
    if (P::isRestart == false) {
       //compute new dt
-      phiprof::start("compute-dt");
+      phiprof::Timer computeDt {"compute-dt"};
       computeNewTimeStep(mpiGrid, technicalGrid, newDt, dtIsChanged);
       if (P::dynamicTimestep == true && dtIsChanged == true) {
          // Only actually update the timestep if dynamicTimestep is on
          P::dt=newDt;
       }
-      phiprof::stop("compute-dt");
+      computeDt.stop();
       
       //go forward by dt/2 in V, initializes leapfrog split. In restarts the
       //the distribution function is already propagated forward in time by dt/2
-      phiprof::start("propagate-velocity-space-dt/2");
+      phiprof::Timer propagateHalf {"propagate-velocity-space-dt/2"};
       if (P::propagateVlasovAcceleration) {
          calculateAcceleration(mpiGrid, 0.5*P::dt);
       } else {
          //zero step to set up moments _v
          calculateAcceleration(mpiGrid, 0.0);
       }
-      phiprof::stop("propagate-velocity-space-dt/2");
+      propagateHalf.stop();
 
       // Apply boundary conditions
       if (P::propagateVlasovTranslation || P::propagateVlasovAcceleration ) {
-         phiprof::start("Update system boundaries (Vlasov post-acceleration)");
+         phiprof::Timer updateBoundaries {("update system boundaries (Vlasov post-acceleration)")};
          sysBoundaryContainer.applySysBoundaryVlasovConditions(mpiGrid, 0.5*P::dt, true);
-         phiprof::stop("Update system boundaries (Vlasov post-acceleration)");
+         updateBoundaries.stop();
          addTimedBarrier("barrier-boundary-conditions");
       }
       // Also update all moments. They won't be transmitted to FSgrid until the field solver is called, though.
-      phiprof::start("Compute interp moments");
+      phiprof::Timer computeMoments {"Compute interp moments"};
       calculateInterpolatedVelocityMoments(
          mpiGrid,
          CellParams::RHOM,
@@ -611,11 +601,11 @@ int main(int argn,char* args[]) {
          CellParams::P_11,
          CellParams::P_22,
          CellParams::P_33
-         );
-      phiprof::stop("Compute interp moments");
+      );
+      computeMoments.stop();
    }
 
-   phiprof::stop("Initialization");
+   init.stop();
 
    // ***********************************
    // ***** INITIALIZATION COMPLETE *****
@@ -635,9 +625,9 @@ int main(int argn,char* args[]) {
    } 
    
 
-   phiprof::start("report-memory-consumption");
+   phiprof::Timer reportMem {"report-memory-consumption"};
    report_process_memory_consumption();
-   phiprof::stop("report-memory-consumption");
+   reportMem.stop();
    
    unsigned int computedCells=0;
    unsigned int computedTotalCells=0;
@@ -669,7 +659,7 @@ int main(int argn,char* args[]) {
    
    addTimedBarrier("barrier-end-initialization");
    
-   phiprof::start("Simulation");
+   phiprof::Timer simulation {"Simulation"};
    double startTime=  MPI_Wtime();
    double beforeTime = MPI_Wtime();
    double beforeSimulationTime=P::t_min;
@@ -681,18 +671,18 @@ int main(int argn,char* args[]) {
       
       addTimedBarrier("barrier-loop-start");
       
-      phiprof::start("IO");
+      phiprof::Timer io {"IO"};
 
-      phiprof::start("checkExternalCommands");
+      phiprof::Timer externals {"checkExternalCommands"};
       if(myRank ==  MASTER_RANK) {
          // check whether STOP or KILL or SAVE has been passed, should be done by MASTER_RANK only as it can reset P::bailout_write_restart
          checkExternalCommands();
       }
-      phiprof::stop("checkExternalCommands");
+      externals.stop();
 
       //write out phiprof profiles and logs with a lower interval than normal
       //diagnostic (every 10 diagnostic intervals).
-      phiprof::start("logfile-io");
+      phiprof::Timer logging {"logfile-io"};
       logFile << "---------- tstep = " << P::tstep << " t = " << P::t <<" dt = " << P::dt << " FS cycles = " << P::fieldSolverSubcycles << " ----------" << endl;
       if (P::diagnosticInterval != 0 &&
           P::tstep % (P::diagnosticInterval*10) == 0 &&
@@ -717,17 +707,16 @@ int main(int argn,char* args[]) {
          report_process_memory_consumption();
       }
       logFile << writeVerbose;
-      phiprof::stop("logfile-io");
+      logging.stop();
 
 // Check whether diagnostic output has to be produced
       if (P::diagnosticInterval != 0 && P::tstep % P::diagnosticInterval == 0) {
          
-         phiprof::start("diagnostic-io");
+         phiprof::Timer diagnostic {"diagnostic-io"};
          if (writeDiagnostic(mpiGrid, diagnosticReducer) == false) {
             if(myRank == MASTER_RANK)  cerr << "ERROR with diagnostic computation" << endl;
             
          }
-         phiprof::stop("diagnostic-io");
       }
 
       // write system, loop through write classes
@@ -748,7 +737,7 @@ int main(int argn,char* args[]) {
             
             FieldTracing::reduceData(technicalGrid, perBGrid, dPerBGrid, mpiGrid, SBC::ionosphereGrid.nodes); /*!< Call the reductions (e.g. field tracing) */
             
-            phiprof::start("write-system");
+            phiprof::Timer writeSys {"write-system"};
             logFile << "(IO): Writing spatial cell and reduced system data to disk, tstep = " << P::tstep << " t = " << P::t << endl << writeVerbose;
             const bool writeGhosts = true;
             if(writeGrid(mpiGrid,
@@ -777,18 +766,17 @@ int main(int argn,char* args[]) {
             int index2=(int)((P::t+P::dt)/P::systemWriteTimeInterval[i]);
             if (index2>P::systemWrites[i]) P::systemWrites[i]=index2;
             logFile << "(IO): .... done!" << endl << writeVerbose;
-            phiprof::stop("write-system");
          }
       }
 
       // Reduce globalflags::bailingOut from all processes
-      phiprof::start("Bailout-allreduce");
+      phiprof::Timer bailoutReduce {"Bailout-allreduce"};
       MPI_Allreduce(&(globalflags::bailingOut), &(doBailout), 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
-      phiprof::stop("Bailout-allreduce");
+      bailoutReduce.stop();
 
       // Write restart data if needed
       // Combined with checking of additional load balancing to have only one collective call.
-      phiprof::start("compute-is-restart-written-and-extra-LB");
+      phiprof::Timer restartCheck {"compute-is-restart-written-and-extra-LB"};
       if (myRank == MASTER_RANK) {
          if (  (P::saveRestartWalltimeInterval >= 0.0
             && (P::saveRestartWalltimeInterval*wallTimeRestartCounter <=  MPI_Wtime()-initialWtime
@@ -818,10 +806,10 @@ int main(int argn,char* args[]) {
          P::prepareForRebalance = true;
          doNow[1] = 0;
       }
-      phiprof::stop("compute-is-restart-written-and-extra-LB");
+      restartCheck.stop();
 
       if (writeRestartNow >= 1){
-         phiprof::start("write-restart");
+         phiprof::Timer t {"write-restart"};
          if (writeRestartNow == 1) {
             wallTimeRestartCounter++;
          }
@@ -846,12 +834,13 @@ int main(int argn,char* args[]) {
             logFile << "(IO): ERROR Failed to write restart!" << endl << writeVerbose;
             cerr << "FAILED TO WRITE RESTART" << endl;
          }
-         if (myRank == MASTER_RANK)
+         if (myRank == MASTER_RANK) {
             logFile << "(IO): .... done!"<< endl << writeVerbose;
-         phiprof::stop("write-restart");
+         }
+         t.stop();
       }
       
-      phiprof::stop("IO");
+      io.stop();
       addTimedBarrier("barrier-end-io");
       
       //no need to propagate if we are on the final step, we just
@@ -873,17 +862,16 @@ int main(int argn,char* args[]) {
                continue;   // Refinement failed and we're bailing out
 
             // Calculate new dt limits since we might break CFL when refining
-            phiprof::start("compute-dt");
+            phiprof::Timer computeDt {"compute-dt"};
             calculateSpatialTranslation(mpiGrid,0.0);
             calculateAcceleration(mpiGrid,0.0);      
-            phiprof::stop("compute-dt");
          }
          balanceLoad(mpiGrid, sysBoundaryContainer);
          addTimedBarrier("barrier-end-load-balance");
-         phiprof::start("Shrink_to_fit");
+         phiprof::Timer shrink {"Shrink_to_fit"};
          // * shrink to fit after LB * //
          shrink_to_fit_grid_data(mpiGrid);
-         phiprof::stop("Shrink_to_fit");
+         shrink.stop();
          logFile << "(LB): ... done!"  << endl << writeVerbose;
          P::prepareForRebalance = false;
 
@@ -913,7 +901,7 @@ int main(int argn,char* args[]) {
          computeNewTimeStep(mpiGrid, technicalGrid, newDt, dtIsChanged);
          addTimedBarrier("barrier-check-dt");
          if(dtIsChanged) {
-            phiprof::start("update-dt");
+            phiprof::Timer updateDt {"update-dt"};
             //propagate velocity space back to real-time
             if( P::propagateVlasovAcceleration ) {
                // Back half dt to real time, forward by new half dt
@@ -927,7 +915,7 @@ int main(int argn,char* args[]) {
             P::dt=newDt;
             
             logFile <<" dt changed to "<<P::dt <<"s, distribution function was half-stepped to real-time and back"<<endl<<writeVerbose;
-            phiprof::stop("update-dt");
+            updateDt.stop();
             continue; //
             addTimedBarrier("barrier-new-dt-set");
          }
@@ -945,26 +933,26 @@ int main(int argn,char* args[]) {
          }
       }
       
-      phiprof::start("Propagate");
+      phiprof::Timer propagate {"Propagate"};
       //Propagate the state of simulation forward in time by dt:
       
-      phiprof::start("Spatial-space");
+      phiprof::Timer spatialSpace {"Spatial-space"};
       if( P::propagateVlasovTranslation) {
          calculateSpatialTranslation(mpiGrid,P::dt);
       } else {
          calculateSpatialTranslation(mpiGrid,0.0);
       }
-      phiprof::stop("Spatial-space",computedCells,"Cells");
+      spatialSpace.stop(computedCells, "Cells");
       
       // Apply boundary conditions
       if (P::propagateVlasovTranslation || P::propagateVlasovAcceleration ) {
-         phiprof::start("Update system boundaries (Vlasov post-translation)");
+         phiprof::Timer t {"Update system boundaries (Vlasov post-translation)"};
          sysBoundaryContainer.applySysBoundaryVlasovConditions(mpiGrid, P::t+0.5*P::dt, false);
-         phiprof::stop("Update system boundaries (Vlasov post-translation)");
+         t.stop();
          addTimedBarrier("barrier-boundary-conditions");
       }
       
-      phiprof::start("Compute interp moments");
+      phiprof::Timer moments {"Compute interp moments"};
       calculateInterpolatedVelocityMoments(
          mpiGrid,
          CellParams::RHOM_DT2,
@@ -976,19 +964,19 @@ int main(int argn,char* args[]) {
          CellParams::P_22_DT2,
          CellParams::P_33_DT2
       );
-      phiprof::stop("Compute interp moments");
+      moments.stop();
       
       // Propagate fields forward in time by dt. This needs to be done before the
       // moments for t + dt are computed (field uses t and t+0.5dt)
       if (P::propagateField) {
-         phiprof::start("Propagate Fields");
+         phiprof::Timer propagate {"Propagate Fields"};
 
-         phiprof::start("fsgrid-coupling-in");
+         phiprof::Timer couplingIn {"fsgrid-coupling-in"};
          // Copy moments over into the fsgrid.
          //setupTechnicalFsGrid(mpiGrid, cells, technicalGrid);
          feedMomentsIntoFsGrid(mpiGrid, cells, momentsGrid, technicalGrid, false);
          feedMomentsIntoFsGrid(mpiGrid, cells, momentsDt2Grid, technicalGrid, true);
-         phiprof::stop("fsgrid-coupling-in");
+         couplingIn.stop();
          
          propagateFields(
             perBGrid,
@@ -1009,13 +997,13 @@ int main(int argn,char* args[]) {
             P::fieldSolverSubcycles
          );
 
-         phiprof::start("getFieldsFromFsGrid");
+         phiprof::Timer getFields {"getFieldsFromFsGrid"};
          // Copy results back from fsgrid.
          volGrid.updateGhostCells();
          technicalGrid.updateGhostCells();
          getFieldsFromFsGrid(volGrid, BgBGrid, EGradPeGrid, technicalGrid, mpiGrid, cells);
-         phiprof::stop("getFieldsFromFsGrid");
-         phiprof::stop("Propagate Fields",cells.size(),"SpatialCells");
+         getFields.stop();
+         propagate.stop(cells.size(),"SpatialCells");
          addTimedBarrier("barrier-after-field-solver");
       }
       
@@ -1057,7 +1045,7 @@ int main(int argn,char* args[]) {
          }
       }
       
-      phiprof::start("Velocity-space");
+      phiprof::Timer vspace {"Velocity-space"};
       if ( P::propagateVlasovAcceleration ) {
          calculateAcceleration(mpiGrid,P::dt);
          addTimedBarrier("barrier-after-ad just-blocks");
@@ -1065,17 +1053,17 @@ int main(int argn,char* args[]) {
          //zero step to set up moments _v
          calculateAcceleration(mpiGrid, 0.0);
       }
-      phiprof::stop("Velocity-space",computedCells,"Cells");
+      vspace.stop(computedCells, "Cells");
       addTimedBarrier("barrier-after-acceleration");
       
       if (P::propagateVlasovTranslation || P::propagateVlasovAcceleration ) {
-         phiprof::start("Update system boundaries (Vlasov post-acceleration)");
+         phiprof::Timer t {"Update system boundaries (Vlasov post-acceleration)"};
          sysBoundaryContainer.applySysBoundaryVlasovConditions(mpiGrid, P::t+0.5*P::dt, true);
-         phiprof::stop("Update system boundaries (Vlasov post-acceleration)");
+         t.stop();
          addTimedBarrier("barrier-boundary-conditions");
       }
       
-      phiprof::start("Compute interp moments");
+      moments.start();
       // *here we compute rho and rho_v for timestep t + dt, so next
       // timestep * //
       calculateInterpolatedVelocityMoments(
@@ -1089,13 +1077,13 @@ int main(int argn,char* args[]) {
          CellParams::P_22,
          CellParams::P_33
       );
-      phiprof::stop("Compute interp moments");
+      moments.stop();
 
-      phiprof::stop("Propagate",computedCells,"Cells");
+      propagate.stop(computedCells,"Cells");
       
-      phiprof::start("Project endTimeStep");
+      phiprof::Timer endStep {"Project endTimeStep"};
       project->hook(hook::END_OF_TIME_STEP, mpiGrid, perBGrid);
-      phiprof::stop("Project endTimeStep");
+      endStep.stop();
 
       // Check timestep
       if (P::dt < P::bailout_min_dt) {
@@ -1113,8 +1101,8 @@ int main(int argn,char* args[]) {
 
    double after = MPI_Wtime();
 
-   phiprof::stop("Simulation");
-   phiprof::start("Finalization");
+   simulation.stop();
+   phiprof::Timer finalization {"Finalization"};
    if (P::propagateField ) { 
       finalizeFieldPropagator();
    }
@@ -1139,8 +1127,8 @@ int main(int argn,char* args[]) {
       logFile << writeVerbose;
    }
    
-   phiprof::stop("Finalization");
-   phiprof::stop("main");
+   finalization.stop();
+   main.stop();
    
    phiprof::print(MPI_COMM_WORLD,"phiprof");
    

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -86,14 +86,14 @@ void addTimedBarrier(string name){
 //let's not do  a barrier
    return; 
 #endif
-   phiprof::Timer bt {name, {"Barriers", "MPI"}};
+   phiprof::Timer btimer {name, {"Barriers", "MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 void computeNewTimeStep(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
 			FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, Real &newDt, bool &isChanged) {
 
-   phiprof::Timer computeTimestep {"compute-timestep"};
+   phiprof::Timer computeTimestepTimer {"compute-timestep"};
    // Compute maximum time step. This cannot be done at the first step as the solvers compute the limits for each cell.
 
    isChanged = false;
@@ -284,9 +284,9 @@ int main(int argn,char* args[]) {
    signal(SIGFPE, fpehandler);
    #endif
 
-   phiprof::Timer main {"main"};
-   phiprof::Timer init {"Initialization"};
-   phiprof::Timer readParams {"Read parameters"};
+   phiprof::Timer mainTimer {"main"};
+   phiprof::Timer initimer {"Initialization"};
+   phiprof::Timer readParamsTimer {"Read parameters"};
 
    //init parameter file reader
    Readparameters readparameters(argn,args);
@@ -310,7 +310,7 @@ int main(int argn,char* args[]) {
    getObjectWrapper().getParameters();
    sysBoundaryContainer.getParameters();
    project->getParameters();
-   readParams.stop();
+   readParamsTimer.stop();
 
    //Get version and config info here
    std::string version;
@@ -325,7 +325,7 @@ int main(int argn,char* args[]) {
 
    // Init parallel logger:
 
-   phiprof::Timer openLogger {"open logFile & diagnostic"};
+   phiprof::Timer openLoggerTimer {"open logFile & diagnostic"};
    //if restarting we will append to logfiles
    if (logFile.open(MPI_COMM_WORLD,MASTER_RANK,"logfile.txt",P::isRestart) == false) {
       if(myRank == MASTER_RANK) cerr << "(MAIN) ERROR: Logger failed to open logfile!" << endl;
@@ -348,10 +348,10 @@ int main(int argn,char* args[]) {
       #endif
       logFile << " OpenMP threads per process" << endl << writeVerbose;      
    }
-   openLogger.stop();
+   openLoggerTimer.stop();
    
    // Init project
-   phiprof::Timer initProject {"Init project"};
+   phiprof::Timer initProjectimer {"Init project"};
    if (project->initialize() == false) {
       if(myRank == MASTER_RANK) cerr << "(MAIN): Project did not initialize correctly!" << endl;
       exit(1);
@@ -363,14 +363,14 @@ int main(int argn,char* args[]) {
          exit(1);
       }
    }
-   initProject.stop();
+   initProjectimer.stop();
 
    // Add VAMR refinement criterias:
    vamr_ref_criteria::addRefinementCriteria();
 
    // Initialize simplified Fieldsolver grids.
    // Needs to be done here already ad the background field will be set right away, before going to initializeGrid even
-   phiprof::Timer initFs {"Init fieldsolver grids"};
+   phiprof::Timer initFsTimer {"Init fieldsolver grids"};
 
    const std::array<int,3> fsGridDimensions = {convert<int>(P::xcells_ini * pow(2,P::amrMaxSpatialRefLevel)),
 							    convert<int>(P::ycells_ini * pow(2,P::amrMaxSpatialRefLevel)),
@@ -424,7 +424,7 @@ int main(int argn,char* args[]) {
                    << std::endl;
       }
    }
-   initFs.stop();
+   initFsTimer.stop();
 
    // Initialize grid.  After initializeGrid local cells have dist
    // functions, and B fields set. Cells have also been classified for
@@ -432,7 +432,7 @@ int main(int argn,char* args[]) {
    // created. All spatial date computed this far is up to date for
    // FULL_NEIGHBORHOOD. Block lists up to date for
    // VLASOV_SOLVER_NEIGHBORHOOD (but dist function has not been communicated)
-   phiprof::Timer initGrids {"Init grids"};
+   phiprof::Timer initGridsTimer {"Init grids"};
    initializeGrids(
       argn,
       args,
@@ -452,14 +452,14 @@ int main(int argn,char* args[]) {
    
    const std::vector<CellID>& cells = getLocalCells();
    
-   initGrids.stop();
+   initGridsTimer.stop();
    
    // Initialize data reduction operators. This should be done elsewhere in order to initialize 
    // user-defined operators:
-   phiprof::Timer initDROs {"Init DROs"};
+   phiprof::Timer initDROsTimer {"Init DROs"};
    DataReducer outputReducer, diagnosticReducer;
    initializeDataReducers(&outputReducer, &diagnosticReducer);
-   initDROs.stop();
+   initDROsTimer.stop();
    
    // Free up memory:
    readparameters.~Readparameters();
@@ -486,10 +486,10 @@ int main(int argn,char* args[]) {
       );
    }
 
-   phiprof::Timer getFields {"getFieldsFromFsGrid"};
+   phiprof::Timer getFieldsTimer {"getFieldsFromFsGrid"};
    volGrid.updateGhostCells();
    getFieldsFromFsGrid(volGrid, BgBGrid, EGradPeGrid, technicalGrid, mpiGrid, cells);
-   getFields.stop();
+   getFieldsTimer.stop();
 
    // Build communicator for ionosphere solving
    SBC::ionosphereGrid.updateIonosphereCommunicator(mpiGrid, technicalGrid);
@@ -502,7 +502,7 @@ int main(int argn,char* args[]) {
    }
 
    if (P::isRestart == false) {
-      phiprof::Timer t {"compute-dt"};
+      phiprof::Timer timer {"compute-dt"};
       // Run Vlasov solver once with zero dt to initialize
       // per-cell dt limits. In restarts, we read the dt from file.
       calculateSpatialTranslation(mpiGrid,0.0);
@@ -513,7 +513,7 @@ int main(int argn,char* args[]) {
    if (P::writeInitialState) {
       FieldTracing::reduceData(technicalGrid, perBGrid, dPerBGrid, mpiGrid, SBC::ionosphereGrid.nodes); /*!< Call the reductions (e.g. field tracing) */
       
-      phiprof::Timer t {"write-initial-state"};
+      phiprof::Timer timer {"write-initial-state"};
       
       if (myRank == MASTER_RANK)
          logFile << "(IO): Writing initial state to disk, tstep = "  << endl << writeVerbose;
@@ -563,34 +563,34 @@ int main(int argn,char* args[]) {
 
    if (P::isRestart == false) {
       //compute new dt
-      phiprof::Timer computeDt {"compute-dt"};
+      phiprof::Timer computeDtimer {"compute-dt"};
       computeNewTimeStep(mpiGrid, technicalGrid, newDt, dtIsChanged);
       if (P::dynamicTimestep == true && dtIsChanged == true) {
          // Only actually update the timestep if dynamicTimestep is on
          P::dt=newDt;
       }
-      computeDt.stop();
+      computeDtimer.stop();
       
       //go forward by dt/2 in V, initializes leapfrog split. In restarts the
       //the distribution function is already propagated forward in time by dt/2
-      phiprof::Timer propagateHalf {"propagate-velocity-space-dt/2"};
+      phiprof::Timer propagateHalfTimer {"propagate-velocity-space-dt/2"};
       if (P::propagateVlasovAcceleration) {
          calculateAcceleration(mpiGrid, 0.5*P::dt);
       } else {
          //zero step to set up moments _v
          calculateAcceleration(mpiGrid, 0.0);
       }
-      propagateHalf.stop();
+      propagateHalfTimer.stop();
 
       // Apply boundary conditions
       if (P::propagateVlasovTranslation || P::propagateVlasovAcceleration ) {
-         phiprof::Timer updateBoundaries {("update system boundaries (Vlasov post-acceleration)")};
+         phiprof::Timer updateBoundariesTimer {("update system boundaries (Vlasov post-acceleration)")};
          sysBoundaryContainer.applySysBoundaryVlasovConditions(mpiGrid, 0.5*P::dt, true);
-         updateBoundaries.stop();
+         updateBoundariesTimer.stop();
          addTimedBarrier("barrier-boundary-conditions");
       }
       // Also update all moments. They won't be transmitted to FSgrid until the field solver is called, though.
-      phiprof::Timer computeMoments {"Compute interp moments"};
+      phiprof::Timer computeMomentsTimer {"Compute interp moments"};
       calculateInterpolatedVelocityMoments(
          mpiGrid,
          CellParams::RHOM,
@@ -602,10 +602,10 @@ int main(int argn,char* args[]) {
          CellParams::P_22,
          CellParams::P_33
       );
-      computeMoments.stop();
+      computeMomentsTimer.stop();
    }
 
-   init.stop();
+   initimer.stop();
 
    // ***********************************
    // ***** INITIALIZATION COMPLETE *****
@@ -625,9 +625,9 @@ int main(int argn,char* args[]) {
    } 
    
 
-   phiprof::Timer reportMem {"report-memory-consumption"};
+   phiprof::Timer reportMemTimer {"report-memory-consumption"};
    report_process_memory_consumption();
-   reportMem.stop();
+   reportMemTimer.stop();
    
    unsigned int computedCells=0;
    unsigned int computedTotalCells=0;
@@ -659,7 +659,7 @@ int main(int argn,char* args[]) {
    
    addTimedBarrier("barrier-end-initialization");
    
-   phiprof::Timer simulation {"Simulation"};
+   phiprof::Timer simulationTimer {"Simulation"};
    double startTime=  MPI_Wtime();
    double beforeTime = MPI_Wtime();
    double beforeSimulationTime=P::t_min;
@@ -671,18 +671,18 @@ int main(int argn,char* args[]) {
       
       addTimedBarrier("barrier-loop-start");
       
-      phiprof::Timer io {"IO"};
+      phiprof::Timer ioTimer {"IO"};
 
-      phiprof::Timer externals {"checkExternalCommands"};
+      phiprof::Timer externalsTimer {"checkExternalCommands"};
       if(myRank ==  MASTER_RANK) {
          // check whether STOP or KILL or SAVE has been passed, should be done by MASTER_RANK only as it can reset P::bailout_write_restart
          checkExternalCommands();
       }
-      externals.stop();
+      externalsTimer.stop();
 
       //write out phiprof profiles and logs with a lower interval than normal
       //diagnostic (every 10 diagnostic intervals).
-      phiprof::Timer logging {"logfile-io"};
+      phiprof::Timer loggingTimer {"logfile-io"};
       logFile << "---------- tstep = " << P::tstep << " t = " << P::t <<" dt = " << P::dt << " FS cycles = " << P::fieldSolverSubcycles << " ----------" << endl;
       if (P::diagnosticInterval != 0 &&
           P::tstep % (P::diagnosticInterval*10) == 0 &&
@@ -707,12 +707,12 @@ int main(int argn,char* args[]) {
          report_process_memory_consumption();
       }
       logFile << writeVerbose;
-      logging.stop();
+      loggingTimer.stop();
 
 // Check whether diagnostic output has to be produced
       if (P::diagnosticInterval != 0 && P::tstep % P::diagnosticInterval == 0) {
          
-         phiprof::Timer diagnostic {"diagnostic-io"};
+         phiprof::Timer diagnosticTimer {"diagnostic-io"};
          if (writeDiagnostic(mpiGrid, diagnosticReducer) == false) {
             if(myRank == MASTER_RANK)  cerr << "ERROR with diagnostic computation" << endl;
             
@@ -737,7 +737,7 @@ int main(int argn,char* args[]) {
             
             FieldTracing::reduceData(technicalGrid, perBGrid, dPerBGrid, mpiGrid, SBC::ionosphereGrid.nodes); /*!< Call the reductions (e.g. field tracing) */
             
-            phiprof::Timer writeSys {"write-system"};
+            phiprof::Timer writeSysTimer {"write-system"};
             logFile << "(IO): Writing spatial cell and reduced system data to disk, tstep = " << P::tstep << " t = " << P::t << endl << writeVerbose;
             const bool writeGhosts = true;
             if(writeGrid(mpiGrid,
@@ -770,13 +770,13 @@ int main(int argn,char* args[]) {
       }
 
       // Reduce globalflags::bailingOut from all processes
-      phiprof::Timer bailoutReduce {"Bailout-allreduce"};
+      phiprof::Timer bailoutReduceTimer {"Bailout-allreduce"};
       MPI_Allreduce(&(globalflags::bailingOut), &(doBailout), 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
-      bailoutReduce.stop();
+      bailoutReduceTimer.stop();
 
       // Write restart data if needed
       // Combined with checking of additional load balancing to have only one collective call.
-      phiprof::Timer restartCheck {"compute-is-restart-written-and-extra-LB"};
+      phiprof::Timer restartCheckTimer {"compute-is-restart-written-and-extra-LB"};
       if (myRank == MASTER_RANK) {
          if (  (P::saveRestartWalltimeInterval >= 0.0
             && (P::saveRestartWalltimeInterval*wallTimeRestartCounter <=  MPI_Wtime()-initialWtime
@@ -806,10 +806,10 @@ int main(int argn,char* args[]) {
          P::prepareForRebalance = true;
          doNow[1] = 0;
       }
-      restartCheck.stop();
+      restartCheckTimer.stop();
 
       if (writeRestartNow >= 1){
-         phiprof::Timer t {"write-restart"};
+         phiprof::Timer timer {"write-restart"};
          if (writeRestartNow == 1) {
             wallTimeRestartCounter++;
          }
@@ -837,10 +837,10 @@ int main(int argn,char* args[]) {
          if (myRank == MASTER_RANK) {
             logFile << "(IO): .... done!"<< endl << writeVerbose;
          }
-         t.stop();
+         timer.stop();
       }
       
-      io.stop();
+      ioTimer.stop();
       addTimedBarrier("barrier-end-io");
       
       //no need to propagate if we are on the final step, we just
@@ -862,16 +862,16 @@ int main(int argn,char* args[]) {
                continue;   // Refinement failed and we're bailing out
 
             // Calculate new dt limits since we might break CFL when refining
-            phiprof::Timer computeDt {"compute-dt"};
+            phiprof::Timer computeDtimer {"compute-dt"};
             calculateSpatialTranslation(mpiGrid,0.0);
             calculateAcceleration(mpiGrid,0.0);      
          }
          balanceLoad(mpiGrid, sysBoundaryContainer);
          addTimedBarrier("barrier-end-load-balance");
-         phiprof::Timer shrink {"Shrink_to_fit"};
+         phiprof::Timer shrinkTimer {"Shrink_to_fit"};
          // * shrink to fit after LB * //
          shrink_to_fit_grid_data(mpiGrid);
-         shrink.stop();
+         shrinkTimer.stop();
          logFile << "(LB): ... done!"  << endl << writeVerbose;
          P::prepareForRebalance = false;
 
@@ -901,7 +901,7 @@ int main(int argn,char* args[]) {
          computeNewTimeStep(mpiGrid, technicalGrid, newDt, dtIsChanged);
          addTimedBarrier("barrier-check-dt");
          if(dtIsChanged) {
-            phiprof::Timer updateDt {"update-dt"};
+            phiprof::Timer updateDtimer {"update-dt"};
             //propagate velocity space back to real-time
             if( P::propagateVlasovAcceleration ) {
                // Back half dt to real time, forward by new half dt
@@ -915,7 +915,7 @@ int main(int argn,char* args[]) {
             P::dt=newDt;
             
             logFile <<" dt changed to "<<P::dt <<"s, distribution function was half-stepped to real-time and back"<<endl<<writeVerbose;
-            updateDt.stop();
+            updateDtimer.stop();
             continue; //
             addTimedBarrier("barrier-new-dt-set");
          }
@@ -933,26 +933,26 @@ int main(int argn,char* args[]) {
          }
       }
       
-      phiprof::Timer propagate {"Propagate"};
+      phiprof::Timer propagateTimer {"Propagate"};
       //Propagate the state of simulation forward in time by dt:
       
-      phiprof::Timer spatialSpace {"Spatial-space"};
+      phiprof::Timer spatialSpaceTimer {"Spatial-space"};
       if( P::propagateVlasovTranslation) {
          calculateSpatialTranslation(mpiGrid,P::dt);
       } else {
          calculateSpatialTranslation(mpiGrid,0.0);
       }
-      spatialSpace.stop(computedCells, "Cells");
+      spatialSpaceTimer.stop(computedCells, "Cells");
       
       // Apply boundary conditions
       if (P::propagateVlasovTranslation || P::propagateVlasovAcceleration ) {
-         phiprof::Timer t {"Update system boundaries (Vlasov post-translation)"};
+         phiprof::Timer timer {"Update system boundaries (Vlasov post-translation)"};
          sysBoundaryContainer.applySysBoundaryVlasovConditions(mpiGrid, P::t+0.5*P::dt, false);
-         t.stop();
+         timer.stop();
          addTimedBarrier("barrier-boundary-conditions");
       }
       
-      phiprof::Timer moments {"Compute interp moments"};
+      phiprof::Timer momentsTimer {"Compute interp moments"};
       calculateInterpolatedVelocityMoments(
          mpiGrid,
          CellParams::RHOM_DT2,
@@ -964,19 +964,19 @@ int main(int argn,char* args[]) {
          CellParams::P_22_DT2,
          CellParams::P_33_DT2
       );
-      moments.stop();
+      momentsTimer.stop();
       
       // Propagate fields forward in time by dt. This needs to be done before the
       // moments for t + dt are computed (field uses t and t+0.5dt)
       if (P::propagateField) {
-         phiprof::Timer propagate {"Propagate Fields"};
+         phiprof::Timer propagateTimer {"Propagate Fields"};
 
-         phiprof::Timer couplingIn {"fsgrid-coupling-in"};
+         phiprof::Timer couplingInTimer {"fsgrid-coupling-in"};
          // Copy moments over into the fsgrid.
          //setupTechnicalFsGrid(mpiGrid, cells, technicalGrid);
          feedMomentsIntoFsGrid(mpiGrid, cells, momentsGrid, technicalGrid, false);
          feedMomentsIntoFsGrid(mpiGrid, cells, momentsDt2Grid, technicalGrid, true);
-         couplingIn.stop();
+         couplingInTimer.stop();
          
          propagateFields(
             perBGrid,
@@ -997,13 +997,13 @@ int main(int argn,char* args[]) {
             P::fieldSolverSubcycles
          );
 
-         phiprof::Timer getFields {"getFieldsFromFsGrid"};
+         phiprof::Timer getFieldsTimer {"getFieldsFromFsGrid"};
          // Copy results back from fsgrid.
          volGrid.updateGhostCells();
          technicalGrid.updateGhostCells();
          getFieldsFromFsGrid(volGrid, BgBGrid, EGradPeGrid, technicalGrid, mpiGrid, cells);
-         getFields.stop();
-         propagate.stop(cells.size(),"SpatialCells");
+         getFieldsTimer.stop();
+         propagateTimer.stop(cells.size(),"SpatialCells");
          addTimedBarrier("barrier-after-field-solver");
       }
       
@@ -1045,7 +1045,7 @@ int main(int argn,char* args[]) {
          }
       }
       
-      phiprof::Timer vspace {"Velocity-space"};
+      phiprof::Timer vspaceTimer {"Velocity-space"};
       if ( P::propagateVlasovAcceleration ) {
          calculateAcceleration(mpiGrid,P::dt);
          addTimedBarrier("barrier-after-ad just-blocks");
@@ -1053,17 +1053,17 @@ int main(int argn,char* args[]) {
          //zero step to set up moments _v
          calculateAcceleration(mpiGrid, 0.0);
       }
-      vspace.stop(computedCells, "Cells");
+      vspaceTimer.stop(computedCells, "Cells");
       addTimedBarrier("barrier-after-acceleration");
       
       if (P::propagateVlasovTranslation || P::propagateVlasovAcceleration ) {
-         phiprof::Timer t {"Update system boundaries (Vlasov post-acceleration)"};
+         phiprof::Timer timer {"Update system boundaries (Vlasov post-acceleration)"};
          sysBoundaryContainer.applySysBoundaryVlasovConditions(mpiGrid, P::t+0.5*P::dt, true);
-         t.stop();
+         timer.stop();
          addTimedBarrier("barrier-boundary-conditions");
       }
       
-      moments.start();
+      momentsTimer.start();
       // *here we compute rho and rho_v for timestep t + dt, so next
       // timestep * //
       calculateInterpolatedVelocityMoments(
@@ -1077,13 +1077,13 @@ int main(int argn,char* args[]) {
          CellParams::P_22,
          CellParams::P_33
       );
-      moments.stop();
+      momentsTimer.stop();
 
-      propagate.stop(computedCells,"Cells");
+      propagateTimer.stop(computedCells,"Cells");
       
-      phiprof::Timer endStep {"Project endTimeStep"};
+      phiprof::Timer endStepTimer {"Project endTimeStep"};
       project->hook(hook::END_OF_TIME_STEP, mpiGrid, perBGrid);
-      endStep.stop();
+      endStepTimer.stop();
 
       // Check timestep
       if (P::dt < P::bailout_min_dt) {
@@ -1101,8 +1101,8 @@ int main(int argn,char* args[]) {
 
    double after = MPI_Wtime();
 
-   simulation.stop();
-   phiprof::Timer finalization {"Finalization"};
+   simulationTimer.stop();
+   phiprof::Timer finalizationTimer {"Finalization"};
    if (P::propagateField ) { 
       finalizeFieldPropagator();
    }
@@ -1127,8 +1127,8 @@ int main(int argn,char* args[]) {
       logFile << writeVerbose;
    }
    
-   finalization.stop();
-   main.stop();
+   finalizationTimer.stop();
+   mainTimer.stop();
    
    phiprof::print(MPI_COMM_WORLD,"phiprof");
    

--- a/vlasovsolver/cpu_acc_semilag.cpp
+++ b/vlasovsolver/cpu_acc_semilag.cpp
@@ -91,12 +91,12 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
    vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = spatial_cell->get_velocity_blocks(popID);
 
    // compute transform, forward in time and backward in time
-   phiprof::Timer transform {"compute-transform"};
+   phiprof::Timer transformTimer {"compute-transform"};
 
    //compute the transform performed in this acceleration
    Transform<Real,3,Affine> fwd_transform= compute_acceleration_transformation(spatial_cell,popID,dt);
    Transform<Real,3,Affine> bwd_transform= fwd_transform.inverse();
-   transform.stop();
+   transformTimer.stop();
 
    const uint8_t refLevel = 0;
    Real intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk;
@@ -107,25 +107,25 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
    switch(map_order){
       case 0: {
          //Map order XYZ
-         phiprof::Timer intersections {intersections_id};
+         phiprof::Timer intersectionsTimer {intersections_id};
          compute_intersections_1st(vmesh,bwd_transform, fwd_transform, 0, refLevel,
                                    intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk);
          compute_intersections_2nd(vmesh,bwd_transform, fwd_transform, 1, refLevel,
                                    intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk);
          compute_intersections_3rd(vmesh,bwd_transform, fwd_transform, 2, refLevel,
                                    intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk);
-         intersections.stop();
-         phiprof::Timer mapping {mapping_id};
+         intersectionsTimer.stop();
+         phiprof::Timer mappingTimer {mapping_id};
          map_1d(spatial_cell, popID, intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk,0); // map along x
          map_1d(spatial_cell, popID, intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk,1); // map along y
          map_1d(spatial_cell, popID, intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk,2); // map along z
-         mapping.stop();
+         mappingTimer.stop();
          break;
       }
          
       case 1: {
          //Map order YZX
-         phiprof::Timer intersections{intersections_id};
+         phiprof::Timer intersectionsTimer{intersections_id};
          compute_intersections_1st(vmesh, bwd_transform, fwd_transform, 1, refLevel,
                                    intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk);
          compute_intersections_2nd(vmesh, bwd_transform, fwd_transform, 2, refLevel,
@@ -133,17 +133,17 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
          compute_intersections_3rd(vmesh, bwd_transform, fwd_transform, 0, refLevel,
                                    intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk);
       
-         intersections.stop();
-         phiprof::Timer mapping {mapping_id};
+         intersectionsTimer.stop();
+         phiprof::Timer mappingTimer {mapping_id};
          map_1d(spatial_cell, popID, intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk,1); // map along y
          map_1d(spatial_cell, popID, intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk,2); // map along z
          map_1d(spatial_cell, popID, intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk,0); // map along x
-         mapping.stop();
+         mappingTimer.stop();
          break;
       }
 
       case 2: {
-         phiprof::Timer intersections{intersections_id};
+         phiprof::Timer intersectionsTimer{intersections_id};
          //Map order Z X Y
          compute_intersections_1st(vmesh, bwd_transform, fwd_transform, 2, refLevel,
                                    intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk);
@@ -151,12 +151,12 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
                                    intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk);
          compute_intersections_3rd(vmesh, bwd_transform, fwd_transform, 1, refLevel,
                                    intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk);
-         intersections.stop();
-         phiprof::Timer mapping {mapping_id};
+         intersectionsTimer.stop();
+         phiprof::Timer mappingTimer {mapping_id};
          map_1d(spatial_cell, popID, intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk,2); // map along z
          map_1d(spatial_cell, popID, intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk,0); // map along x
          map_1d(spatial_cell, popID, intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk,1); // map along y
-         mapping.stop();
+         mappingTimer.stop();
          break;
       }
    }

--- a/vlasovsolver/cpu_acc_semilag.cpp
+++ b/vlasovsolver/cpu_acc_semilag.cpp
@@ -91,12 +91,12 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
    vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = spatial_cell->get_velocity_blocks(popID);
 
    // compute transform, forward in time and backward in time
-   phiprof::Timer transformTimer {"compute-transform"};
+   phiprof::Timer transform {"compute-transform"};
 
    //compute the transform performed in this acceleration
    Transform<Real,3,Affine> fwd_transform= compute_acceleration_transformation(spatial_cell,popID,dt);
    Transform<Real,3,Affine> bwd_transform= fwd_transform.inverse();
-   transformTimer.stop();
+   transform.stop();
 
    const uint8_t refLevel = 0;
    Real intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk;
@@ -107,25 +107,25 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
    switch(map_order){
       case 0: {
          //Map order XYZ
-         phiprof::Timer intersectionsTimer {intersections_id};
+         phiprof::Timer intersections {intersections_id};
          compute_intersections_1st(vmesh,bwd_transform, fwd_transform, 0, refLevel,
                                    intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk);
          compute_intersections_2nd(vmesh,bwd_transform, fwd_transform, 1, refLevel,
                                    intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk);
          compute_intersections_3rd(vmesh,bwd_transform, fwd_transform, 2, refLevel,
                                    intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk);
-         intersectionsTimer.stop();
-         phiprof::Timer mappingTimer {mapping_id};
+         intersections.stop();
+         phiprof::Timer mapping {mapping_id};
          map_1d(spatial_cell, popID, intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk,0); // map along x
          map_1d(spatial_cell, popID, intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk,1); // map along y
          map_1d(spatial_cell, popID, intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk,2); // map along z
-         mappingTimer.stop();
+         mapping.stop();
          break;
       }
          
       case 1: {
          //Map order YZX
-         phiprof::Timer intersectionsTimer{intersections_id};
+         phiprof::Timer intersections{intersections_id};
          compute_intersections_1st(vmesh, bwd_transform, fwd_transform, 1, refLevel,
                                    intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk);
          compute_intersections_2nd(vmesh, bwd_transform, fwd_transform, 2, refLevel,
@@ -133,17 +133,17 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
          compute_intersections_3rd(vmesh, bwd_transform, fwd_transform, 0, refLevel,
                                    intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk);
       
-         intersectionsTimer.stop();
-         phiprof::Timer mappingTimer {mapping_id};
+         intersections.stop();
+         phiprof::Timer mapping {mapping_id};
          map_1d(spatial_cell, popID, intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk,1); // map along y
          map_1d(spatial_cell, popID, intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk,2); // map along z
          map_1d(spatial_cell, popID, intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk,0); // map along x
-         mappingTimer.stop();
+         mapping.stop();
          break;
       }
 
       case 2: {
-         phiprof::Timer intersectionsTimer{intersections_id};
+         phiprof::Timer intersections{intersections_id};
          //Map order Z X Y
          compute_intersections_1st(vmesh, bwd_transform, fwd_transform, 2, refLevel,
                                    intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk);
@@ -151,12 +151,12 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell,
                                    intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk);
          compute_intersections_3rd(vmesh, bwd_transform, fwd_transform, 1, refLevel,
                                    intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk);
-         intersectionsTimer.stop();
-         phiprof::Timer mappingTimer {mapping_id};
+         intersections.stop();
+         phiprof::Timer mapping {mapping_id};
          map_1d(spatial_cell, popID, intersection_z,intersection_z_di,intersection_z_dj,intersection_z_dk,2); // map along z
          map_1d(spatial_cell, popID, intersection_x,intersection_x_di,intersection_x_dj,intersection_x_dk,0); // map along x
          map_1d(spatial_cell, popID, intersection_y,intersection_y_di,intersection_y_dj,intersection_y_dk,1); // map along y
-         mappingTimer.stop();
+         mapping.stop();
          break;
       }
    }

--- a/vlasovsolver/cpu_moments.cpp
+++ b/vlasovsolver/cpu_moments.cpp
@@ -155,7 +155,7 @@ void calculateMoments_R(
         const std::vector<CellID>& cells,
         const bool& computeSecond) {
  
-    phiprof::Timer moments {"compute-moments-n"};
+    phiprof::Timer momentsTimer {"compute-moments-n"};
     creal HALF = 0.5;
 
     for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
@@ -302,7 +302,7 @@ void calculateMoments_V(
         const std::vector<CellID>& cells,
         const bool& computeSecond) {
  
-   phiprof::Timer moments {"Compute _V moments"};
+   phiprof::Timer momentsTimer {"Compute _V moments"};
    
    // Loop over all particle species
    for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {

--- a/vlasovsolver/cpu_moments.cpp
+++ b/vlasovsolver/cpu_moments.cpp
@@ -155,7 +155,7 @@ void calculateMoments_R(
         const std::vector<CellID>& cells,
         const bool& computeSecond) {
  
-    phiprof::start("compute-moments-n");
+    phiprof::Timer moments {"compute-moments-n"};
     creal HALF = 0.5;
 
     for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
@@ -243,7 +243,6 @@ void calculateMoments_R(
 
    // Compute second moments only if requested.
    if (computeSecond == false) {
-      phiprof::stop("compute-moments-n");
       return;
    }
 
@@ -288,7 +287,6 @@ void calculateMoments_R(
       } // for-loop over spatial cells
    } // for-loop over particle species
 
-   phiprof::stop("compute-moments-n");
 }
 
 /** Calculate zeroth, first, and (possibly) second bulk velocity moments for the 
@@ -304,7 +302,7 @@ void calculateMoments_V(
         const std::vector<CellID>& cells,
         const bool& computeSecond) {
  
-   phiprof::start("Compute _V moments");
+   phiprof::Timer moments {"Compute _V moments"};
    
    // Loop over all particle species
    for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
@@ -374,7 +372,6 @@ void calculateMoments_V(
 
    // Compute second moments only if requested
    if (computeSecond == false) {
-      phiprof::stop("Compute _V moments");
       return;
    }
 
@@ -420,6 +417,4 @@ void calculateMoments_V(
          
       } // for-loop over spatial cells
    } // for-loop over particle species
-
-   phiprof::stop("Compute _V moments");
 }

--- a/vlasovsolver/cpu_moments.cpp
+++ b/vlasovsolver/cpu_moments.cpp
@@ -155,7 +155,7 @@ void calculateMoments_R(
         const std::vector<CellID>& cells,
         const bool& computeSecond) {
  
-    phiprof::Timer momentsTimer {"compute-moments-n"};
+    phiprof::Timer moments {"compute-moments-n"};
     creal HALF = 0.5;
 
     for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
@@ -302,7 +302,7 @@ void calculateMoments_V(
         const std::vector<CellID>& cells,
         const bool& computeSecond) {
  
-   phiprof::Timer momentsTimer {"Compute _V moments"};
+   phiprof::Timer moments {"Compute _V moments"};
    
    // Loop over all particle species
    for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {

--- a/vlasovsolver/cpu_trans_map.cpp
+++ b/vlasovsolver/cpu_trans_map.cpp
@@ -437,9 +437,8 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
 
    const Realv i_dz=1.0/dz;
    
-   int t1 = phiprof::initializeTimer("mapping");
-   int t2 = phiprof::initializeTimer("store");
-   
+   int mapping_id {phiprof::initializeTimer("mapping")};
+   int store_id {phiprof::initializeTimer("store")};
    
 #pragma omp parallel 
    {
@@ -452,7 +451,7 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
 #pragma omp for schedule(guided)
       for(uint blocki = 0; blocki < unionOfBlocks.size(); blocki++){
          vmesh::GlobalID blockGID = unionOfBlocks[blocki];
-         phiprof::start(t1);
+         phiprof::Timer mapping {mapping_id};
          
          for(uint celli = 0; celli < allCellsPointer.size(); celli++){
             allCellsBlockLocalID[celli] = allCellsPointer[celli]->get_velocity_block_local_id(blockGID, popID);
@@ -577,8 +576,8 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
             }
          }
       
-         phiprof::stop(t1);
-         phiprof::start(t2);
+         mapping.stop();
+         phiprof::Timer store {store_id};
                
          //reset blocks in all non-sysboundary spatial cells for this block id
          for(uint celli = 0; celli < allCellsPointer.size(); celli++){
@@ -620,7 +619,7 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
             }
          
          }
-         phiprof::stop(t2);
+         store.stop();
 
       
       } //loop over set of blocks on process

--- a/vlasovsolver/cpu_trans_map.cpp
+++ b/vlasovsolver/cpu_trans_map.cpp
@@ -451,7 +451,7 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
 #pragma omp for schedule(guided)
       for(uint blocki = 0; blocki < unionOfBlocks.size(); blocki++){
          vmesh::GlobalID blockGID = unionOfBlocks[blocki];
-         phiprof::Timer mappingTimer {mapping_id};
+         phiprof::Timer mapping {mapping_id};
          
          for(uint celli = 0; celli < allCellsPointer.size(); celli++){
             allCellsBlockLocalID[celli] = allCellsPointer[celli]->get_velocity_block_local_id(blockGID, popID);
@@ -576,8 +576,8 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
             }
          }
       
-         mappingTimer.stop();
-         phiprof::Timer storeTimer {store_id};
+         mapping.stop();
+         phiprof::Timer store {store_id};
                
          //reset blocks in all non-sysboundary spatial cells for this block id
          for(uint celli = 0; celli < allCellsPointer.size(); celli++){
@@ -619,7 +619,7 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
             }
          
          }
-         storeTimer.stop();
+         store.stop();
 
       
       } //loop over set of blocks on process

--- a/vlasovsolver/cpu_trans_map.cpp
+++ b/vlasovsolver/cpu_trans_map.cpp
@@ -451,7 +451,7 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
 #pragma omp for schedule(guided)
       for(uint blocki = 0; blocki < unionOfBlocks.size(); blocki++){
          vmesh::GlobalID blockGID = unionOfBlocks[blocki];
-         phiprof::Timer mapping {mapping_id};
+         phiprof::Timer mappingTimer {mapping_id};
          
          for(uint celli = 0; celli < allCellsPointer.size(); celli++){
             allCellsBlockLocalID[celli] = allCellsPointer[celli]->get_velocity_block_local_id(blockGID, popID);
@@ -576,8 +576,8 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
             }
          }
       
-         mapping.stop();
-         phiprof::Timer store {store_id};
+         mappingTimer.stop();
+         phiprof::Timer storeTimer {store_id};
                
          //reset blocks in all non-sysboundary spatial cells for this block id
          for(uint celli = 0; celli < allCellsPointer.size(); celli++){
@@ -619,7 +619,7 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
             }
          
          }
-         store.stop();
+         storeTimer.stop();
 
       
       } //loop over set of blocks on process

--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -1372,11 +1372,13 @@ void prepareSeedIdsAndPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Ge
    phiprof::Timer checkGhostsTimer {"check_ghost_cells"};
    // Check refinement of two ghost cells on each end of each pencil
    check_ghost_cells(mpiGrid,DimensionPencils[dimension],dimension);
-   phiprof::stop("check_ghost_cells");
+   checkGhostsTimer.stop();
 
    // ****************************************************************************
 
-   if(printPencils) printPencilsFunc(DimensionPencils[dimension],dimension,myRank);
+   if(printPencils) {
+      printPencilsFunc(DimensionPencils[dimension],dimension,myRank);
+   }
    buildPencilsTimer.stop();
 }
 

--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -1325,12 +1325,12 @@ void prepareSeedIdsAndPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Ge
       }
    }
 
-   phiprof::Timer getSeeds {"getSeedIds"};
+   phiprof::Timer getSeedsTimer {"getSeedIds"};
    vector<CellID> seedIds;
    getSeedIds(mpiGrid, localPropagatedCells, dimension, seedIds);
-   getSeeds.stop();
+   getSeedsTimer.stop();
 
-   phiprof::Timer buildPencils {"buildPencils"};
+   phiprof::Timer buildPencilsTimer {"buildPencils"};
    // Output vectors for ready pencils
    //setOfPencils pencils;
 
@@ -1369,7 +1369,7 @@ void prepareSeedIdsAndPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Ge
       }
    }
 
-   phiprof::Timer checkGhosts {"check_ghost_cells"};
+   phiprof::Timer checkGhostsTimer {"check_ghost_cells"};
    // Check refinement of two ghost cells on each end of each pencil
    check_ghost_cells(mpiGrid,DimensionPencils[dimension],dimension);
    phiprof::stop("check_ghost_cells");
@@ -1377,7 +1377,7 @@ void prepareSeedIdsAndPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Ge
    // ****************************************************************************
 
    if(printPencils) printPencilsFunc(DimensionPencils[dimension],dimension,myRank);
-   buildPencils.stop();
+   buildPencilsTimer.stop();
 }
 
 /* Map velocity blocks in all local cells forward by one time step in one spatial dimension.
@@ -1400,7 +1400,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
                       const Realv dt,
                       const uint popID) {
    
-   phiprof::Timer setup {"setup"};
+   phiprof::Timer setupTimer {"setup"};
 
    uint cell_indices_to_id[3]; /*< used when computing id of target cell in block*/
    unsigned char  cellid_transpose[WID3]; /*< defines the transpose for the solver internal (transposed) id: i + j*WID + k*WID2 to actual one*/
@@ -1488,7 +1488,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
    // Get a pointer to the velocity mesh of the first spatial cell
    const vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh = allCellsPointer[0]->get_velocity_mesh(popID);
    
-   phiprof::Timer buildBlockList {"buildBlockList"};
+   phiprof::Timer buildBlockListimer {"buildBlockList"};
    // Get a unique sorted list of blockids that are in any of the
    // propagated cells. First use set for this, then add to vector (may not
    // be the most nice way to do this and in any case we could do it along
@@ -1518,7 +1518,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
    
    unionOfBlocks.insert(unionOfBlocks.end(), unionOfBlocksSet.begin(), unionOfBlocksSet.end());
    
-   buildBlockList.stop();
+   buildBlockListimer.stop();
    // ****************************************************************************
    
    // Assuming 1 neighbor in the target array because of the CFL condition
@@ -1527,12 +1527,12 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
    
    // Compute spatial neighbors for target cells.
    // For targets we need the local cells, plus a padding of 1 cell at both ends
-   phiprof::Timer computeTargets {"computeSpatialTargetCellsForPencils"};
+   phiprof::Timer computeTargetsTimer {"computeSpatialTargetCellsForPencils"};
    std::vector<SpatialCell*> targetCells(DimensionPencils[dimension].sumOfLengths + DimensionPencils[dimension].N * 2 * nTargetNeighborsPerPencil );
    computeSpatialTargetCellsForPencilsWithFaces(mpiGrid, DimensionPencils[dimension], dimension, targetCells.data());
-   computeTargets.stop();
+   computeTargetsTimer.stop();
    
-   setup.stop();
+   setupTimer.stop();
    
    int mappingId {phiprof::initializeTimer("mapping")};
    int storeId {phiprof::initializeTimer("store")};
@@ -1582,7 +1582,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
          // Get global id of the velocity block
          vmesh::GlobalID blockGID = unionOfBlocks[blocki];
 
-            phiprof::Timer mapping {mappingId};
+            phiprof::Timer mappingTimer {mappingId};
             
             // Loop over pencils
             uint totalTargetLength = 0;
@@ -1635,8 +1635,8 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
                
             } // Closes loop over pencils. SourceVecData gets implicitly deallocated here.
 
-            mapping.stop();
-            phiprof::Timer store {storeId};
+            mappingTimer.stop();
+            phiprof::Timer storeTimer {storeId};
             
             // reset blocks in all non-sysboundary neighbor spatial cells for this block id
             // At this point the block data is saved in targetBlockData so we can reset the spatial cells
@@ -1709,7 +1709,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
                
             } // closes loop over pencils
 
-            store.stop();
+            storeTimer.stop();
       } // Closes loop over blocks
    } // closes pragma omp parallel
 

--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -1325,12 +1325,12 @@ void prepareSeedIdsAndPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Ge
       }
    }
 
-   phiprof::Timer getSeedsTimer {"getSeedIds"};
+   phiprof::Timer getSeeds {"getSeedIds"};
    vector<CellID> seedIds;
    getSeedIds(mpiGrid, localPropagatedCells, dimension, seedIds);
-   getSeedsTimer.stop();
+   getSeeds.stop();
 
-   phiprof::Timer buildPencilsTimer {"buildPencils"};
+   phiprof::Timer buildPencils {"buildPencils"};
    // Output vectors for ready pencils
    //setOfPencils pencils;
 
@@ -1369,7 +1369,7 @@ void prepareSeedIdsAndPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Ge
       }
    }
 
-   phiprof::Timer checkGhostsTimer {"check_ghost_cells"};
+   phiprof::Timer checkGhosts {"check_ghost_cells"};
    // Check refinement of two ghost cells on each end of each pencil
    check_ghost_cells(mpiGrid,DimensionPencils[dimension],dimension);
    phiprof::stop("check_ghost_cells");
@@ -1377,7 +1377,7 @@ void prepareSeedIdsAndPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Ge
    // ****************************************************************************
 
    if(printPencils) printPencilsFunc(DimensionPencils[dimension],dimension,myRank);
-   buildPencilsTimer.stop();
+   buildPencils.stop();
 }
 
 /* Map velocity blocks in all local cells forward by one time step in one spatial dimension.
@@ -1400,7 +1400,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
                       const Realv dt,
                       const uint popID) {
    
-   phiprof::Timer setupTimer {"setup"};
+   phiprof::Timer setup {"setup"};
 
    uint cell_indices_to_id[3]; /*< used when computing id of target cell in block*/
    unsigned char  cellid_transpose[WID3]; /*< defines the transpose for the solver internal (transposed) id: i + j*WID + k*WID2 to actual one*/
@@ -1488,7 +1488,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
    // Get a pointer to the velocity mesh of the first spatial cell
    const vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh = allCellsPointer[0]->get_velocity_mesh(popID);
    
-   phiprof::Timer buildBlockListimer {"buildBlockList"};
+   phiprof::Timer buildBlockList {"buildBlockList"};
    // Get a unique sorted list of blockids that are in any of the
    // propagated cells. First use set for this, then add to vector (may not
    // be the most nice way to do this and in any case we could do it along
@@ -1518,7 +1518,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
    
    unionOfBlocks.insert(unionOfBlocks.end(), unionOfBlocksSet.begin(), unionOfBlocksSet.end());
    
-   buildBlockListimer.stop();
+   buildBlockList.stop();
    // ****************************************************************************
    
    // Assuming 1 neighbor in the target array because of the CFL condition
@@ -1527,12 +1527,12 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
    
    // Compute spatial neighbors for target cells.
    // For targets we need the local cells, plus a padding of 1 cell at both ends
-   phiprof::Timer computeTargetsTimer {"computeSpatialTargetCellsForPencils"};
+   phiprof::Timer computeTargets {"computeSpatialTargetCellsForPencils"};
    std::vector<SpatialCell*> targetCells(DimensionPencils[dimension].sumOfLengths + DimensionPencils[dimension].N * 2 * nTargetNeighborsPerPencil );
    computeSpatialTargetCellsForPencilsWithFaces(mpiGrid, DimensionPencils[dimension], dimension, targetCells.data());
-   computeTargetsTimer.stop();
+   computeTargets.stop();
    
-   setupTimer.stop();
+   setup.stop();
    
    int mappingId {phiprof::initializeTimer("mapping")};
    int storeId {phiprof::initializeTimer("store")};
@@ -1582,7 +1582,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
          // Get global id of the velocity block
          vmesh::GlobalID blockGID = unionOfBlocks[blocki];
 
-            phiprof::Timer mappingTimer {mappingId};
+            phiprof::Timer mapping {mappingId};
             
             // Loop over pencils
             uint totalTargetLength = 0;
@@ -1635,8 +1635,8 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
                
             } // Closes loop over pencils. SourceVecData gets implicitly deallocated here.
 
-            mappingTimer.stop();
-            phiprof::Timer storeTimer {storeId};
+            mapping.stop();
+            phiprof::Timer store {storeId};
             
             // reset blocks in all non-sysboundary neighbor spatial cells for this block id
             // At this point the block data is saved in targetBlockData so we can reset the spatial cells
@@ -1709,7 +1709,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
                
             } // closes loop over pencils
 
-            storeTimer.stop();
+            store.stop();
       } // Closes loop over blocks
    } // closes pragma omp parallel
 

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -77,7 +77,6 @@ void calculateSpatialTranslation(
         Real &time
 ) {
 
-    int trans_timer;
     bool localTargetGridGenerated = false;
     bool AMRtranslationActive = false;
     if (P::amrMaxSpatialRefLevel > 0) AMRtranslationActive = true;
@@ -94,12 +93,12 @@ void calculateSpatialTranslation(
     // ------------- SLICE - map dist function in Z --------------- //
    if(P::zcells_ini > 1){
 
-      phiprof::Timer transTimer_timer {"transfer-stencil-data-z", {"MPI"}};
+      phiprof::Timer transTimer {"transfer-stencil-data-z", {"MPI"}};
       //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(2);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,AMRtranslationActive);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
-      trans_timer.stop();
+      transTimer.stop();
 
       // bt=phiprof::initializeTimer("barrier-trans-pre-trans_map_1d-z","Barriers","MPI");
       // phiprof::start(bt);
@@ -116,11 +115,11 @@ void calculateSpatialTranslation(
       computeTimer.stop();
       time += MPI_Wtime() - t1;
 
-      phiprof::Timer btimer {"barrier-trans-pre-update_remote-z", {"Barriers","MPI"}};
+      phiprof::Timer btTimer {"barrier-trans-pre-update_remote-z", {"Barriers","MPI"}};
       MPI_Barrier(MPI_COMM_WORLD);
-      btimer.stop();
+      btTimer.stop();
 
-      phiprof::Timer updateTimer_remote {"update_remote-z", {"MPI"}};
+      phiprof::Timer updateRemoteTimer {"update_remote-z", {"MPI"}};
       if(P::amrMaxSpatialRefLevel == 0) {
          update_remote_mapping_contribution(mpiGrid, 2,+1,popID);
          update_remote_mapping_contribution(mpiGrid, 2,-1,popID);
@@ -128,7 +127,7 @@ void calculateSpatialTranslation(
          update_remote_mapping_contribution_amr(mpiGrid, 2,+1,popID);
          update_remote_mapping_contribution_amr(mpiGrid, 2,-1,popID);
       }
-      update_remoteTimer.stop();
+      updateRemoteTimer.stop();
 
    }
 
@@ -139,12 +138,12 @@ void calculateSpatialTranslation(
    // ------------- SLICE - map dist function in X --------------- //
    if(P::xcells_ini > 1){
       
-      phiprof::Timer transTimer_timer {"transfer-stencil-data-x", {"MPI"}};
+      phiprof::Timer transTimer {"transfer-stencil-data-x", {"MPI"}};
       //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(0);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,AMRtranslationActive);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
-      trans_timer.stop();
+      transTimer.stop();
       
       // bt=phiprof::initializeTimer("barrier-trans-pre-trans_map_1d-x","Barriers","MPI");
       // phiprof::start(bt);
@@ -161,11 +160,11 @@ void calculateSpatialTranslation(
       computeTimer.stop();
       time += MPI_Wtime() - t1;
 
-      phiprof::Timer btimer {"barrier-trans-pre-update_remote-x", {"Barriers","MPI"}};
+      phiprof::Timer btTimer {"barrier-trans-pre-update_remote-x", {"Barriers","MPI"}};
       MPI_Barrier(MPI_COMM_WORLD);
-      btimer.stop();
+      btTimer.stop();
 
-      phiprof::Timer updateTimer_remote {"update_remote-x", {"MPI"}};
+      phiprof::Timer updateRemoteTimer {"update_remote-x", {"MPI"}};
       if(P::amrMaxSpatialRefLevel == 0) {
          update_remote_mapping_contribution(mpiGrid, 0,+1,popID);
          update_remote_mapping_contribution(mpiGrid, 0,-1,popID);
@@ -173,7 +172,7 @@ void calculateSpatialTranslation(
          update_remote_mapping_contribution_amr(mpiGrid, 0,+1,popID);
          update_remote_mapping_contribution_amr(mpiGrid, 0,-1,popID);
       }
-      update_remoteTimer.stop();
+      updateRemoteTimer.stop();
    }
 
    phiprof::Timer btyTimer {"barrier-trans-pre-y", {"Barriers","MPI"}};
@@ -183,12 +182,12 @@ void calculateSpatialTranslation(
    // ------------- SLICE - map dist function in Y --------------- //
    if(P::ycells_ini > 1) {
       
-      phiprof::Timer transTimer_timer {"transfer-stencil-data-y", {"MPI"}};
+      phiprof::Timer transTimer {"transfer-stencil-data-y", {"MPI"}};
       //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(1);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,AMRtranslationActive);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
-      trans_timer.stop();
+      transTimer.stop();
       
       // bt=phiprof::initializeTimer("barrier-trans-pre-trans_map_1d-y","Barriers","MPI");
       // phiprof::start(bt);
@@ -205,9 +204,9 @@ void calculateSpatialTranslation(
       computeTimer.stop();
       time += MPI_Wtime() - t1;
       
-      phiprof::Timer btimer {"barrier-trans-pre-update_remote-y", {"Barriers","MPI"}};
+      phiprof::Timer btTimer {"barrier-trans-pre-update_remote-y", {"Barriers","MPI"}};
       MPI_Barrier(MPI_COMM_WORLD);
-      btimer.stop();
+      btTimer.stop();
 
       phiprof::Timer updateRemoteTimer {"update_remote-y", {"MPI"}};
       if(P::amrMaxSpatialRefLevel == 0) {
@@ -243,7 +242,7 @@ void calculateSpatialTranslation(
         creal dt) {
    typedef Parameters P;
    
-   phiprof::Timer semilgaTimer {"semilag-trans"};
+   phiprof::Timer semilagTimer {"semilag-trans"};
    
    double t1 = MPI_Wtime();
 
@@ -402,9 +401,9 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
       #endif
          
       uint map_order=rndInt%3;
-      phiprof::Timer semilagTimer_acc {"cell-semilag-acc"};
+      phiprof::Timer semilagAccTimer {"cell-semilag-acc"};
       cpu_accelerate_cell(mpiGrid[cellID],popID,map_order,subcycleDt);
-      semilag_accTimer.stop();
+      semilagAccTimer.stop();
    }
 
    //global adjust after each subcycle to keep number of blocks managable. Even the ones not

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -258,6 +258,7 @@ void calculateSpatialTranslation(
    // In both cases go to the end of this function and calculate the moments.
    if (dt == 0.0) {
       calculateMoments_R(mpiGrid,localCells,true);
+      return;
    }
    
    phiprof::Timer computeTimer {"compute_cell_lists"};

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -87,14 +87,14 @@ void calculateSpatialTranslation(
     int myRank;
     MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
    
-   phiprof::Timer btzTimer {"barrier-trans-pre-z", {"Barriers","MPI"}};
+   phiprof::Timer btz {"barrier-trans-pre-z", {"Barriers","MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   btzTimer.stop();
+   btz.stop();
  
     // ------------- SLICE - map dist function in Z --------------- //
    if(P::zcells_ini > 1){
 
-      phiprof::Timer transTimer_timer {"transfer-stencil-data-z", {"MPI"}};
+      phiprof::Timer trans_timer {"transfer-stencil-data-z", {"MPI"}};
       //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(2);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,AMRtranslationActive);
@@ -107,20 +107,20 @@ void calculateSpatialTranslation(
       // phiprof::stop(bt);
 
       t1 = MPI_Wtime();
-      phiprof::Timer computeTimer {"compute-mapping-z"};
+      phiprof::Timer compute {"compute-mapping-z"};
       if(P::amrMaxSpatialRefLevel == 0) {
          trans_map_1d(mpiGrid,local_propagated_cells, remoteTargetCellsz, 2, dt,popID); // map along z//
       } else {
          trans_map_1d_amr(mpiGrid,local_propagated_cells, remoteTargetCellsz, nPencils, 2, dt,popID); // map along z//
       }
-      computeTimer.stop();
+      compute.stop();
       time += MPI_Wtime() - t1;
 
-      phiprof::Timer btimer {"barrier-trans-pre-update_remote-z", {"Barriers","MPI"}};
+      phiprof::Timer bt {"barrier-trans-pre-update_remote-z", {"Barriers","MPI"}};
       MPI_Barrier(MPI_COMM_WORLD);
-      btimer.stop();
+      bt.stop();
 
-      phiprof::Timer updateTimer_remote {"update_remote-z", {"MPI"}};
+      phiprof::Timer update_remote {"update_remote-z", {"MPI"}};
       if(P::amrMaxSpatialRefLevel == 0) {
          update_remote_mapping_contribution(mpiGrid, 2,+1,popID);
          update_remote_mapping_contribution(mpiGrid, 2,-1,popID);
@@ -128,18 +128,18 @@ void calculateSpatialTranslation(
          update_remote_mapping_contribution_amr(mpiGrid, 2,+1,popID);
          update_remote_mapping_contribution_amr(mpiGrid, 2,-1,popID);
       }
-      update_remoteTimer.stop();
+      update_remote.stop();
 
    }
 
-   phiprof::Timer btxTimer {"barrier-trans-pre-x", {"Barriers","MPI"}};
+   phiprof::Timer btx {"barrier-trans-pre-x", {"Barriers","MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   btxTimer.stop();
+   btx.stop();
    
    // ------------- SLICE - map dist function in X --------------- //
    if(P::xcells_ini > 1){
       
-      phiprof::Timer transTimer_timer {"transfer-stencil-data-x", {"MPI"}};
+      phiprof::Timer trans_timer {"transfer-stencil-data-x", {"MPI"}};
       //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(0);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,AMRtranslationActive);
@@ -152,20 +152,20 @@ void calculateSpatialTranslation(
       // phiprof::stop(bt);
 
       t1 = MPI_Wtime();
-      phiprof::Timer computeTimer {"compute-mapping-x"};
+      phiprof::Timer compute {"compute-mapping-x"};
       if(P::amrMaxSpatialRefLevel == 0) {
          trans_map_1d(mpiGrid,local_propagated_cells, remoteTargetCellsx, 0,dt,popID); // map along x//
       } else {
          trans_map_1d_amr(mpiGrid,local_propagated_cells, remoteTargetCellsx, nPencils, 0,dt,popID); // map along x//
       }
-      computeTimer.stop();
+      compute.stop();
       time += MPI_Wtime() - t1;
 
-      phiprof::Timer btimer {"barrier-trans-pre-update_remote-x", {"Barriers","MPI"}};
+      phiprof::Timer bt {"barrier-trans-pre-update_remote-x", {"Barriers","MPI"}};
       MPI_Barrier(MPI_COMM_WORLD);
-      btimer.stop();
+      bt.stop();
 
-      phiprof::Timer updateTimer_remote {"update_remote-x", {"MPI"}};
+      phiprof::Timer update_remote {"update_remote-x", {"MPI"}};
       if(P::amrMaxSpatialRefLevel == 0) {
          update_remote_mapping_contribution(mpiGrid, 0,+1,popID);
          update_remote_mapping_contribution(mpiGrid, 0,-1,popID);
@@ -173,17 +173,17 @@ void calculateSpatialTranslation(
          update_remote_mapping_contribution_amr(mpiGrid, 0,+1,popID);
          update_remote_mapping_contribution_amr(mpiGrid, 0,-1,popID);
       }
-      update_remoteTimer.stop();
+      update_remote.stop();
    }
 
-   phiprof::Timer btyTimer {"barrier-trans-pre-y", {"Barriers","MPI"}};
+   phiprof::Timer bty {"barrier-trans-pre-y", {"Barriers","MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   btyTimer.stop();
+   bty.stop();
 
    // ------------- SLICE - map dist function in Y --------------- //
    if(P::ycells_ini > 1) {
       
-      phiprof::Timer transTimer_timer {"transfer-stencil-data-y", {"MPI"}};
+      phiprof::Timer trans_timer {"transfer-stencil-data-y", {"MPI"}};
       //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(1);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,AMRtranslationActive);
@@ -196,20 +196,20 @@ void calculateSpatialTranslation(
       // phiprof::stop(bt);
 
       t1 = MPI_Wtime();
-      phiprof::Timer computeTimer {"compute-mapping-y"};
+      phiprof::Timer compute {"compute-mapping-y"};
       if(P::amrMaxSpatialRefLevel == 0) {
          trans_map_1d(mpiGrid,local_propagated_cells, remoteTargetCellsy, 1,dt,popID); // map along y//
       } else {
          trans_map_1d_amr(mpiGrid,local_propagated_cells, remoteTargetCellsy, nPencils, 1,dt,popID); // map along y//      
       }
-      computeTimer.stop();
+      compute.stop();
       time += MPI_Wtime() - t1;
       
-      phiprof::Timer btimer {"barrier-trans-pre-update_remote-y", {"Barriers","MPI"}};
+      phiprof::Timer bt {"barrier-trans-pre-update_remote-y", {"Barriers","MPI"}};
       MPI_Barrier(MPI_COMM_WORLD);
-      btimer.stop();
+      bt.stop();
 
-      phiprof::Timer updateRemoteTimer {"update_remote-y", {"MPI"}};
+      phiprof::Timer updateRemote {"update_remote-y", {"MPI"}};
       if(P::amrMaxSpatialRefLevel == 0) {
          update_remote_mapping_contribution(mpiGrid, 1,+1,popID);
          update_remote_mapping_contribution(mpiGrid, 1,-1,popID);
@@ -217,12 +217,12 @@ void calculateSpatialTranslation(
          update_remote_mapping_contribution_amr(mpiGrid, 1,+1,popID);
          update_remote_mapping_contribution_amr(mpiGrid, 1,-1,popID);
       }
-      updateRemoteTimer.stop();
+      updateRemote.stop();
    }
 
-   phiprof::Timer btpostimer {"barrier-trans-post-trans",{"Barriers","MPI"}};
+   phiprof::Timer btpost {"barrier-trans-post-trans",{"Barriers","MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   btpostimer.stop();
+   btpost.stop();
 
    // MPI_Barrier(MPI_COMM_WORLD);
    // bailout(true, "", __FILE__, __LINE__);
@@ -243,7 +243,7 @@ void calculateSpatialTranslation(
         creal dt) {
    typedef Parameters P;
    
-   phiprof::Timer semilgaTimer {"semilag-trans"};
+   phiprof::Timer semilga {"semilag-trans"};
    
    double t1 = MPI_Wtime();
 
@@ -262,7 +262,7 @@ void calculateSpatialTranslation(
       calculateMoments_R(mpiGrid,localCells,true);
    }
    
-   phiprof::Timer computeTimer {"compute_cell_lists"};
+   phiprof::Timer compute {"compute_cell_lists"};
    remoteTargetCellsx = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_TARGET_X_NEIGHBORHOOD_ID);
    remoteTargetCellsy = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_TARGET_Y_NEIGHBORHOOD_ID);
    remoteTargetCellsz = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_TARGET_Z_NEIGHBORHOOD_ID);
@@ -288,12 +288,12 @@ void calculateSpatialTranslation(
          nPencils.push_back(0);
       }
    }
-   computeTimer.stop();
+   compute.stop();
    
    // Translate all particle species
    for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
       string profName = "translate "+getObjectWrapper().particleSpecies[popID].name;
-      phiprof::Timer timer {profName};
+      phiprof::Timer t {profName};
       SpatialCell::setCommunicatedSpecies(popID);
       //      std::cout << "I am at line " << __LINE__ << " of " << __FILE__ << std::endl;
       calculateSpatialTranslation(
@@ -402,9 +402,9 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
       #endif
          
       uint map_order=rndInt%3;
-      phiprof::Timer semilagTimer_acc {"cell-semilag-acc"};
+      phiprof::Timer semilag_acc {"cell-semilag-acc"};
       cpu_accelerate_cell(mpiGrid[cellID],popID,map_order,subcycleDt);
-      semilag_accTimer.stop();
+      semilag_acc.stop();
    }
 
    //global adjust after each subcycle to keep number of blocks managable. Even the ones not

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -87,14 +87,14 @@ void calculateSpatialTranslation(
     int myRank;
     MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
    
-   phiprof::Timer btz {"barrier-trans-pre-z", {"Barriers","MPI"}};
+   phiprof::Timer btzTimer {"barrier-trans-pre-z", {"Barriers","MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   btz.stop();
+   btzTimer.stop();
  
     // ------------- SLICE - map dist function in Z --------------- //
    if(P::zcells_ini > 1){
 
-      phiprof::Timer trans_timer {"transfer-stencil-data-z", {"MPI"}};
+      phiprof::Timer transTimer_timer {"transfer-stencil-data-z", {"MPI"}};
       //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(2);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,AMRtranslationActive);
@@ -107,20 +107,20 @@ void calculateSpatialTranslation(
       // phiprof::stop(bt);
 
       t1 = MPI_Wtime();
-      phiprof::Timer compute {"compute-mapping-z"};
+      phiprof::Timer computeTimer {"compute-mapping-z"};
       if(P::amrMaxSpatialRefLevel == 0) {
          trans_map_1d(mpiGrid,local_propagated_cells, remoteTargetCellsz, 2, dt,popID); // map along z//
       } else {
          trans_map_1d_amr(mpiGrid,local_propagated_cells, remoteTargetCellsz, nPencils, 2, dt,popID); // map along z//
       }
-      compute.stop();
+      computeTimer.stop();
       time += MPI_Wtime() - t1;
 
-      phiprof::Timer bt {"barrier-trans-pre-update_remote-z", {"Barriers","MPI"}};
+      phiprof::Timer btimer {"barrier-trans-pre-update_remote-z", {"Barriers","MPI"}};
       MPI_Barrier(MPI_COMM_WORLD);
-      bt.stop();
+      btimer.stop();
 
-      phiprof::Timer update_remote {"update_remote-z", {"MPI"}};
+      phiprof::Timer updateTimer_remote {"update_remote-z", {"MPI"}};
       if(P::amrMaxSpatialRefLevel == 0) {
          update_remote_mapping_contribution(mpiGrid, 2,+1,popID);
          update_remote_mapping_contribution(mpiGrid, 2,-1,popID);
@@ -128,18 +128,18 @@ void calculateSpatialTranslation(
          update_remote_mapping_contribution_amr(mpiGrid, 2,+1,popID);
          update_remote_mapping_contribution_amr(mpiGrid, 2,-1,popID);
       }
-      update_remote.stop();
+      update_remoteTimer.stop();
 
    }
 
-   phiprof::Timer btx {"barrier-trans-pre-x", {"Barriers","MPI"}};
+   phiprof::Timer btxTimer {"barrier-trans-pre-x", {"Barriers","MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   btx.stop();
+   btxTimer.stop();
    
    // ------------- SLICE - map dist function in X --------------- //
    if(P::xcells_ini > 1){
       
-      phiprof::Timer trans_timer {"transfer-stencil-data-x", {"MPI"}};
+      phiprof::Timer transTimer_timer {"transfer-stencil-data-x", {"MPI"}};
       //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(0);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,AMRtranslationActive);
@@ -152,20 +152,20 @@ void calculateSpatialTranslation(
       // phiprof::stop(bt);
 
       t1 = MPI_Wtime();
-      phiprof::Timer compute {"compute-mapping-x"};
+      phiprof::Timer computeTimer {"compute-mapping-x"};
       if(P::amrMaxSpatialRefLevel == 0) {
          trans_map_1d(mpiGrid,local_propagated_cells, remoteTargetCellsx, 0,dt,popID); // map along x//
       } else {
          trans_map_1d_amr(mpiGrid,local_propagated_cells, remoteTargetCellsx, nPencils, 0,dt,popID); // map along x//
       }
-      compute.stop();
+      computeTimer.stop();
       time += MPI_Wtime() - t1;
 
-      phiprof::Timer bt {"barrier-trans-pre-update_remote-x", {"Barriers","MPI"}};
+      phiprof::Timer btimer {"barrier-trans-pre-update_remote-x", {"Barriers","MPI"}};
       MPI_Barrier(MPI_COMM_WORLD);
-      bt.stop();
+      btimer.stop();
 
-      phiprof::Timer update_remote {"update_remote-x", {"MPI"}};
+      phiprof::Timer updateTimer_remote {"update_remote-x", {"MPI"}};
       if(P::amrMaxSpatialRefLevel == 0) {
          update_remote_mapping_contribution(mpiGrid, 0,+1,popID);
          update_remote_mapping_contribution(mpiGrid, 0,-1,popID);
@@ -173,17 +173,17 @@ void calculateSpatialTranslation(
          update_remote_mapping_contribution_amr(mpiGrid, 0,+1,popID);
          update_remote_mapping_contribution_amr(mpiGrid, 0,-1,popID);
       }
-      update_remote.stop();
+      update_remoteTimer.stop();
    }
 
-   phiprof::Timer bty {"barrier-trans-pre-y", {"Barriers","MPI"}};
+   phiprof::Timer btyTimer {"barrier-trans-pre-y", {"Barriers","MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   bty.stop();
+   btyTimer.stop();
 
    // ------------- SLICE - map dist function in Y --------------- //
    if(P::ycells_ini > 1) {
       
-      phiprof::Timer trans_timer {"transfer-stencil-data-y", {"MPI"}};
+      phiprof::Timer transTimer_timer {"transfer-stencil-data-y", {"MPI"}};
       //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(1);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,AMRtranslationActive);
@@ -196,20 +196,20 @@ void calculateSpatialTranslation(
       // phiprof::stop(bt);
 
       t1 = MPI_Wtime();
-      phiprof::Timer compute {"compute-mapping-y"};
+      phiprof::Timer computeTimer {"compute-mapping-y"};
       if(P::amrMaxSpatialRefLevel == 0) {
          trans_map_1d(mpiGrid,local_propagated_cells, remoteTargetCellsy, 1,dt,popID); // map along y//
       } else {
          trans_map_1d_amr(mpiGrid,local_propagated_cells, remoteTargetCellsy, nPencils, 1,dt,popID); // map along y//      
       }
-      compute.stop();
+      computeTimer.stop();
       time += MPI_Wtime() - t1;
       
-      phiprof::Timer bt {"barrier-trans-pre-update_remote-y", {"Barriers","MPI"}};
+      phiprof::Timer btimer {"barrier-trans-pre-update_remote-y", {"Barriers","MPI"}};
       MPI_Barrier(MPI_COMM_WORLD);
-      bt.stop();
+      btimer.stop();
 
-      phiprof::Timer updateRemote {"update_remote-y", {"MPI"}};
+      phiprof::Timer updateRemoteTimer {"update_remote-y", {"MPI"}};
       if(P::amrMaxSpatialRefLevel == 0) {
          update_remote_mapping_contribution(mpiGrid, 1,+1,popID);
          update_remote_mapping_contribution(mpiGrid, 1,-1,popID);
@@ -217,12 +217,12 @@ void calculateSpatialTranslation(
          update_remote_mapping_contribution_amr(mpiGrid, 1,+1,popID);
          update_remote_mapping_contribution_amr(mpiGrid, 1,-1,popID);
       }
-      updateRemote.stop();
+      updateRemoteTimer.stop();
    }
 
-   phiprof::Timer btpost {"barrier-trans-post-trans",{"Barriers","MPI"}};
+   phiprof::Timer btpostimer {"barrier-trans-post-trans",{"Barriers","MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   btpost.stop();
+   btpostimer.stop();
 
    // MPI_Barrier(MPI_COMM_WORLD);
    // bailout(true, "", __FILE__, __LINE__);
@@ -243,7 +243,7 @@ void calculateSpatialTranslation(
         creal dt) {
    typedef Parameters P;
    
-   phiprof::Timer semilga {"semilag-trans"};
+   phiprof::Timer semilgaTimer {"semilag-trans"};
    
    double t1 = MPI_Wtime();
 
@@ -262,7 +262,7 @@ void calculateSpatialTranslation(
       calculateMoments_R(mpiGrid,localCells,true);
    }
    
-   phiprof::Timer compute {"compute_cell_lists"};
+   phiprof::Timer computeTimer {"compute_cell_lists"};
    remoteTargetCellsx = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_TARGET_X_NEIGHBORHOOD_ID);
    remoteTargetCellsy = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_TARGET_Y_NEIGHBORHOOD_ID);
    remoteTargetCellsz = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_TARGET_Z_NEIGHBORHOOD_ID);
@@ -288,12 +288,12 @@ void calculateSpatialTranslation(
          nPencils.push_back(0);
       }
    }
-   compute.stop();
+   computeTimer.stop();
    
    // Translate all particle species
    for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
       string profName = "translate "+getObjectWrapper().particleSpecies[popID].name;
-      phiprof::Timer t {profName};
+      phiprof::Timer timer {profName};
       SpatialCell::setCommunicatedSpecies(popID);
       //      std::cout << "I am at line " << __LINE__ << " of " << __FILE__ << std::endl;
       calculateSpatialTranslation(
@@ -402,9 +402,9 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
       #endif
          
       uint map_order=rndInt%3;
-      phiprof::Timer semilag_acc {"cell-semilag-acc"};
+      phiprof::Timer semilagTimer_acc {"cell-semilag-acc"};
       cpu_accelerate_cell(mpiGrid[cellID],popID,map_order,subcycleDt);
-      semilag_acc.stop();
+      semilag_accTimer.stop();
    }
 
    //global adjust after each subcycle to keep number of blocks managable. Even the ones not

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -87,21 +87,19 @@ void calculateSpatialTranslation(
     int myRank;
     MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
    
-   int bt=phiprof::initializeTimer("barrier-trans-pre-z","Barriers","MPI");
-   phiprof::start(bt);
+   phiprof::Timer btz {"barrier-trans-pre-z", {"Barriers","MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   phiprof::stop(bt);
+   btz.stop();
  
     // ------------- SLICE - map dist function in Z --------------- //
    if(P::zcells_ini > 1){
 
-      trans_timer=phiprof::initializeTimer("transfer-stencil-data-z","MPI");
-      phiprof::start(trans_timer);
+      phiprof::Timer trans_timer {"transfer-stencil-data-z", {"MPI"}};
       //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(2);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,AMRtranslationActive);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Z_NEIGHBORHOOD_ID);
-      phiprof::stop(trans_timer);
+      trans_timer.stop();
 
       // bt=phiprof::initializeTimer("barrier-trans-pre-trans_map_1d-z","Barriers","MPI");
       // phiprof::start(bt);
@@ -109,22 +107,20 @@ void calculateSpatialTranslation(
       // phiprof::stop(bt);
 
       t1 = MPI_Wtime();
-      phiprof::start("compute-mapping-z");
+      phiprof::Timer compute {"compute-mapping-z"};
       if(P::amrMaxSpatialRefLevel == 0) {
          trans_map_1d(mpiGrid,local_propagated_cells, remoteTargetCellsz, 2, dt,popID); // map along z//
       } else {
          trans_map_1d_amr(mpiGrid,local_propagated_cells, remoteTargetCellsz, nPencils, 2, dt,popID); // map along z//
       }
-      phiprof::stop("compute-mapping-z");
+      compute.stop();
       time += MPI_Wtime() - t1;
 
-      bt=phiprof::initializeTimer("barrier-trans-pre-update_remote-z","Barriers","MPI");
-      phiprof::start(bt);
+      phiprof::Timer bt {"barrier-trans-pre-update_remote-z", {"Barriers","MPI"}};
       MPI_Barrier(MPI_COMM_WORLD);
-      phiprof::stop(bt);
+      bt.stop();
 
-      trans_timer=phiprof::initializeTimer("update_remote-z","MPI");
-      phiprof::start("update_remote-z");
+      phiprof::Timer update_remote {"update_remote-z", {"MPI"}};
       if(P::amrMaxSpatialRefLevel == 0) {
          update_remote_mapping_contribution(mpiGrid, 2,+1,popID);
          update_remote_mapping_contribution(mpiGrid, 2,-1,popID);
@@ -132,25 +128,23 @@ void calculateSpatialTranslation(
          update_remote_mapping_contribution_amr(mpiGrid, 2,+1,popID);
          update_remote_mapping_contribution_amr(mpiGrid, 2,-1,popID);
       }
-      phiprof::stop("update_remote-z");
+      update_remote.stop();
 
    }
 
-   bt=phiprof::initializeTimer("barrier-trans-pre-x","Barriers","MPI");
-   phiprof::start(bt);
+   phiprof::Timer btx {"barrier-trans-pre-x", {"Barriers","MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   phiprof::stop(bt);
+   btx.stop();
    
    // ------------- SLICE - map dist function in X --------------- //
    if(P::xcells_ini > 1){
       
-      trans_timer=phiprof::initializeTimer("transfer-stencil-data-x","MPI");
-      phiprof::start(trans_timer);
+      phiprof::Timer trans_timer {"transfer-stencil-data-x", {"MPI"}};
       //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(0);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,AMRtranslationActive);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_X_NEIGHBORHOOD_ID);
-      phiprof::stop(trans_timer);
+      trans_timer.stop();
       
       // bt=phiprof::initializeTimer("barrier-trans-pre-trans_map_1d-x","Barriers","MPI");
       // phiprof::start(bt);
@@ -158,22 +152,20 @@ void calculateSpatialTranslation(
       // phiprof::stop(bt);
 
       t1 = MPI_Wtime();
-      phiprof::start("compute-mapping-x");
+      phiprof::Timer compute {"compute-mapping-x"};
       if(P::amrMaxSpatialRefLevel == 0) {
          trans_map_1d(mpiGrid,local_propagated_cells, remoteTargetCellsx, 0,dt,popID); // map along x//
       } else {
          trans_map_1d_amr(mpiGrid,local_propagated_cells, remoteTargetCellsx, nPencils, 0,dt,popID); // map along x//
       }
-      phiprof::stop("compute-mapping-x");
+      compute.stop();
       time += MPI_Wtime() - t1;
 
-      bt=phiprof::initializeTimer("barrier-trans-pre-update_remote-x","Barriers","MPI");
-      phiprof::start(bt);
+      phiprof::Timer bt {"barrier-trans-pre-update_remote-x", {"Barriers","MPI"}};
       MPI_Barrier(MPI_COMM_WORLD);
-      phiprof::stop(bt);
+      bt.stop();
 
-      trans_timer=phiprof::initializeTimer("update_remote-x","MPI");
-      phiprof::start("update_remote-x");
+      phiprof::Timer update_remote {"update_remote-x", {"MPI"}};
       if(P::amrMaxSpatialRefLevel == 0) {
          update_remote_mapping_contribution(mpiGrid, 0,+1,popID);
          update_remote_mapping_contribution(mpiGrid, 0,-1,popID);
@@ -181,25 +173,22 @@ void calculateSpatialTranslation(
          update_remote_mapping_contribution_amr(mpiGrid, 0,+1,popID);
          update_remote_mapping_contribution_amr(mpiGrid, 0,-1,popID);
       }
-      phiprof::stop("update_remote-x");
-
+      update_remote.stop();
    }
 
-   bt=phiprof::initializeTimer("barrier-trans-pre-y","Barriers","MPI");
-   phiprof::start(bt);
+   phiprof::Timer bty {"barrier-trans-pre-y", {"Barriers","MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   phiprof::stop(bt);
+   bty.stop();
 
    // ------------- SLICE - map dist function in Y --------------- //
    if(P::ycells_ini > 1) {
       
-      trans_timer=phiprof::initializeTimer("transfer-stencil-data-y","MPI");
-      phiprof::start(trans_timer);
+      phiprof::Timer trans_timer {"transfer-stencil-data-y", {"MPI"}};
       //updateRemoteVelocityBlockLists(mpiGrid,popID,VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
       SpatialCell::set_mpi_transfer_direction(1);
       SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA,false,AMRtranslationActive);
       mpiGrid.update_copies_of_remote_neighbors(VLASOV_SOLVER_Y_NEIGHBORHOOD_ID);
-      phiprof::stop(trans_timer);
+      trans_timer.stop();
       
       // bt=phiprof::initializeTimer("barrier-trans-pre-trans_map_1d-y","Barriers","MPI");
       // phiprof::start(bt);
@@ -207,22 +196,20 @@ void calculateSpatialTranslation(
       // phiprof::stop(bt);
 
       t1 = MPI_Wtime();
-      phiprof::start("compute-mapping-y");
+      phiprof::Timer compute {"compute-mapping-y"};
       if(P::amrMaxSpatialRefLevel == 0) {
          trans_map_1d(mpiGrid,local_propagated_cells, remoteTargetCellsy, 1,dt,popID); // map along y//
       } else {
          trans_map_1d_amr(mpiGrid,local_propagated_cells, remoteTargetCellsy, nPencils, 1,dt,popID); // map along y//      
       }
-      phiprof::stop("compute-mapping-y");
+      compute.stop();
       time += MPI_Wtime() - t1;
       
-      bt=phiprof::initializeTimer("barrier-trans-pre-update_remote-y","Barriers","MPI");
-      phiprof::start(bt);
+      phiprof::Timer bt {"barrier-trans-pre-update_remote-y", {"Barriers","MPI"}};
       MPI_Barrier(MPI_COMM_WORLD);
-      phiprof::stop(bt);
+      bt.stop();
 
-      trans_timer=phiprof::initializeTimer("update_remote-y","MPI");
-      phiprof::start("update_remote-y");
+      phiprof::Timer updateRemote {"update_remote-y", {"MPI"}};
       if(P::amrMaxSpatialRefLevel == 0) {
          update_remote_mapping_contribution(mpiGrid, 1,+1,popID);
          update_remote_mapping_contribution(mpiGrid, 1,-1,popID);
@@ -230,14 +217,12 @@ void calculateSpatialTranslation(
          update_remote_mapping_contribution_amr(mpiGrid, 1,+1,popID);
          update_remote_mapping_contribution_amr(mpiGrid, 1,-1,popID);
       }
-      phiprof::stop("update_remote-y");
-     
+      updateRemote.stop();
    }
 
-   bt=phiprof::initializeTimer("barrier-trans-post-trans","Barriers","MPI");
-   phiprof::start(bt);
+   phiprof::Timer btpost {"barrier-trans-post-trans",{"Barriers","MPI"}};
    MPI_Barrier(MPI_COMM_WORLD);
-   phiprof::stop(bt);
+   btpost.stop();
 
    // MPI_Barrier(MPI_COMM_WORLD);
    // bailout(true, "", __FILE__, __LINE__);
@@ -258,7 +243,7 @@ void calculateSpatialTranslation(
         creal dt) {
    typedef Parameters P;
    
-   phiprof::start("semilag-trans");
+   phiprof::Timer semilga {"semilag-trans"};
    
    double t1 = MPI_Wtime();
 
@@ -273,9 +258,11 @@ void calculateSpatialTranslation(
    
    // If dt=0 we are either initializing or distribution functions are not translated. 
    // In both cases go to the end of this function and calculate the moments.
-   if (dt == 0.0) goto momentCalculation;
+   if (dt == 0.0) {
+      calculateMoments_R(mpiGrid,localCells,true);
+   }
    
-   phiprof::start("compute_cell_lists");
+   phiprof::Timer compute {"compute_cell_lists"};
    remoteTargetCellsx = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_TARGET_X_NEIGHBORHOOD_ID);
    remoteTargetCellsy = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_TARGET_Y_NEIGHBORHOOD_ID);
    remoteTargetCellsz = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_TARGET_Z_NEIGHBORHOOD_ID);
@@ -301,12 +288,12 @@ void calculateSpatialTranslation(
          nPencils.push_back(0);
       }
    }
-   phiprof::stop("compute_cell_lists");
+   compute.stop();
    
    // Translate all particle species
    for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
       string profName = "translate "+getObjectWrapper().particleSpecies[popID].name;
-      phiprof::start(profName);
+      phiprof::Timer t {profName};
       SpatialCell::setCommunicatedSpecies(popID);
       //      std::cout << "I am at line " << __LINE__ << " of " << __FILE__ << std::endl;
       calculateSpatialTranslation(
@@ -322,7 +309,6 @@ void calculateSpatialTranslation(
          popID,
          time
       );
-      phiprof::stop(profName);
    }
    
    if (Parameters::prepareForRebalance == true) {
@@ -348,10 +334,7 @@ void calculateSpatialTranslation(
    }
    
    // Mapping complete, update moments and maximum dt limits //
-momentCalculation:
    calculateMoments_R(mpiGrid,localCells,true);
-   
-   phiprof::stop("semilag-trans");
 }
 
 /*
@@ -419,9 +402,9 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
       #endif
          
       uint map_order=rndInt%3;
-      phiprof::start("cell-semilag-acc");
+      phiprof::Timer semilag_acc {"cell-semilag-acc"};
       cpu_accelerate_cell(mpiGrid[cellID],popID,map_order,subcycleDt);
-      phiprof::stop("cell-semilag-acc");
+      semilag_acc.stop();
    }
 
    //global adjust after each subcycle to keep number of blocks managable. Even the ones not
@@ -456,73 +439,70 @@ void calculateAcceleration(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
       for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
          adjustVelocityBlocks(mpiGrid, cells, true, popID);
       }
+   } else {
+      // Fairly ugly but no goto
+      phiprof::Timer timer {"semilag-acc"};
+      
+      // Accelerate all particle species
+      for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
+         int maxSubcycles=0;
+         int globalMaxSubcycles;
 
-      goto momentCalculation;
+         // Set active population
+         SpatialCell::setCommunicatedSpecies(popID);
+         
+         // Iterate through all local cells and collect cells to propagate.
+         // Ghost cells (spatial cells at the boundary of the simulation 
+         // volume) do not need to be propagated:
+         vector<CellID> propagatedCells;
+         for (size_t c=0; c<cells.size(); ++c) {
+            SpatialCell* SC = mpiGrid[cells[c]];
+            const vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh = SC->get_velocity_mesh(popID);
+            // disregard boundary cells, in preparation for acceleration
+            if (  (SC->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) ||
+                  // Include inflow-Maxwellian
+                  (P::vlasovAccelerateMaxwellianBoundaries && (SC->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN)) ) {
+               if (vmesh.size() != 0){
+                  //do not propagate spatial cells with no blocks
+                  propagatedCells.push_back(cells[c]);
+               }
+               //prepare for acceleration, updates max dt for each cell, it
+               //needs to be set to somthing sensible for _all_ cells, even if
+               //they are not propagated
+               prepareAccelerateCell(SC, popID);
+               //update max subcycles for all cells in this process
+               maxSubcycles = max((int)getAccelerationSubcycles(SC, dt, popID), maxSubcycles);
+               spatial_cell::Population& pop = SC->get_population(popID);
+               pop.ACCSUBCYCLES = getAccelerationSubcycles(SC, dt, popID);
+            }
+         }
+
+         // Compute global maximum for number of subcycles
+         MPI_Allreduce(&maxSubcycles, &globalMaxSubcycles, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+         
+         // substep global max times
+         for(uint step=0; step<(uint)globalMaxSubcycles; ++step) {
+            if(step > 0) {
+               // prune list of cells to propagate to only contained those which are now subcycled
+               vector<CellID> temp;
+               for (const auto& cell: propagatedCells) {
+                  if (step < getAccelerationSubcycles(mpiGrid[cell], dt, popID) ) {
+                     temp.push_back(cell);
+                  }
+               }
+               
+               propagatedCells.swap(temp);
+            }
+            // Accelerate population over one subcycle step
+            calculateAcceleration(popID,(uint)globalMaxSubcycles,step,mpiGrid,propagatedCells,dt);
+         } // for-loop over acceleration substeps
+         
+         // final adjust for all cells, also fixing remote cells.
+         adjustVelocityBlocks(mpiGrid, cells, true, popID);
+      } // for-loop over particle species
    }
-   phiprof::start("semilag-acc");
-    
-   // Accelerate all particle species
-    for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
-       int maxSubcycles=0;
-       int globalMaxSubcycles;
-
-       // Set active population
-       SpatialCell::setCommunicatedSpecies(popID);
-       
-       // Iterate through all local cells and collect cells to propagate.
-       // Ghost cells (spatial cells at the boundary of the simulation 
-       // volume) do not need to be propagated:
-       vector<CellID> propagatedCells;
-       for (size_t c=0; c<cells.size(); ++c) {
-          SpatialCell* SC = mpiGrid[cells[c]];
-          const vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh = SC->get_velocity_mesh(popID);
-          // disregard boundary cells, in preparation for acceleration
-          if (  (SC->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) ||
-                // Include inflow-Maxwellian
-                (P::vlasovAccelerateMaxwellianBoundaries && (SC->sysBoundaryFlag == sysboundarytype::SET_MAXWELLIAN)) ) {
-             if (vmesh.size() != 0){
-                //do not propagate spatial cells with no blocks
-                propagatedCells.push_back(cells[c]);
-             }
-             //prepare for acceleration, updates max dt for each cell, it
-             //needs to be set to somthing sensible for _all_ cells, even if
-             //they are not propagated
-             prepareAccelerateCell(SC, popID);
-             //update max subcycles for all cells in this process
-             maxSubcycles = max((int)getAccelerationSubcycles(SC, dt, popID), maxSubcycles);
-             spatial_cell::Population& pop = SC->get_population(popID);
-             pop.ACCSUBCYCLES = getAccelerationSubcycles(SC, dt, popID);
-          }
-       }
-
-       // Compute global maximum for number of subcycles
-       MPI_Allreduce(&maxSubcycles, &globalMaxSubcycles, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
-       
-       // substep global max times
-       for(uint step=0; step<(uint)globalMaxSubcycles; ++step) {
-          if(step > 0) {
-             // prune list of cells to propagate to only contained those which are now subcycled
-             vector<CellID> temp;
-             for (const auto& cell: propagatedCells) {
-                if (step < getAccelerationSubcycles(mpiGrid[cell], dt, popID) ) {
-                   temp.push_back(cell);
-                }
-             }
-             
-             propagatedCells.swap(temp);
-          }
-          // Accelerate population over one subcycle step
-          calculateAcceleration(popID,(uint)globalMaxSubcycles,step,mpiGrid,propagatedCells,dt);
-       } // for-loop over acceleration substeps
-       
-       // final adjust for all cells, also fixing remote cells.
-       adjustVelocityBlocks(mpiGrid, cells, true, popID);
-    } // for-loop over particle species
-
-    phiprof::stop("semilag-acc");
 
    // Recalculate "_V" velocity moments
-momentCalculation:
    calculateMoments_V(mpiGrid,cells,true);
 
    // Set CellParams::MAXVDT to be the minimum dt of all per-species values
@@ -581,7 +561,7 @@ void calculateInterpolatedVelocityMoments(
 
 void calculateInitialVelocityMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid) {
    const vector<CellID>& cells = getLocalCells();
-   phiprof::start("Calculate moments");
+   phiprof::Timer timer {"Calculate moments"};
 
    // Iterate through all local cells (incl. system boundary cells):
    #pragma omp parallel for
@@ -602,5 +582,4 @@ void calculateInitialVelocityMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_G
       SC->parameters[CellParams::P_22_DT2] = SC->parameters[CellParams::P_22];
       SC->parameters[CellParams::P_33_DT2] = SC->parameters[CellParams::P_33];
    } // for-loop over spatial cells
-   phiprof::stop("Calculate moments"); 
 }

--- a/vlasovsolver_amr/cpu_acc_map_amr.hpp
+++ b/vlasovsolver_amr/cpu_acc_map_amr.hpp
@@ -166,18 +166,18 @@ bool map_1d(SpatialCell* spatial_cell,Transform<Real,3,Affine>& fwd_transform,Tr
    // Successive calls (the inner loop below) of generateTargetMesh will then 
    // refine the already existing coarser blocks until every source block has 
    // a target block at the same (or higher) refinement level.
-   phiprof::start("mesh generation");
+   phiprof::Timer meshGen {"mesh generation"};
    for (uint8_t r=0; r<blocks.size(); ++r) {
       for (uint8_t rr=r; rr<blocks.size(); ++rr) {
          propagParams.refLevel = rr;
          generateTargetMesh(spatial_cell,blocks[rr],propagParams,r,vmesh);
       }
    }
-   phiprof::stop("mesh generation");
+   meshGen.stop();
 
-   phiprof::start("mapping");
+   phiprof::Timer mapping {"mapping"};
    map_1d(spatial_cell,propagParams,vmesh,blockContainer);
-   phiprof::stop("mapping");
+   mapping.stop();
 
    // Merge values from coarse blocks to refined blocks wherever the same domain 
    // is covered by overlapping blocks (at different refinement levels)
@@ -440,7 +440,7 @@ void map_1d(SpatialCell* spatial_cell,PropagParams& params,
             vmesh::GlobalID srcIndex[3];
             if (k_cell_src >= k_cell_src_max) {
                // Find the source block
-               phiprof::start("source block search");
+               phiprof::Timer search {"source block search"};
                srcIndex[params.i_mapped] = targetIndex[0];
                srcIndex[params.j_mapped] = targetIndex[1];
                srcIndex[params.k_mapped] = k_cell_src;
@@ -451,7 +451,6 @@ void map_1d(SpatialCell* spatial_cell,PropagParams& params,
 
                if (sourceGID == vmesh.invalidGlobalID()) {
                   ++k_cell_src;
-                  phiprof::stop("source block search");
                   continue;
                }
 
@@ -470,7 +469,6 @@ void map_1d(SpatialCell* spatial_cell,PropagParams& params,
 
                // Maximum k-index this source block contains
                k_cell_src_max = std::min(k_cell_src_max_global,k_block_src*(WID*srcRefMul) + WID*srcRefMul - 1);
-               phiprof::stop("source block search");
             }
 
             // Iterate over all source k-cells in this source block
@@ -483,7 +481,7 @@ void map_1d(SpatialCell* spatial_cell,PropagParams& params,
                   srcIndex[params.i_mapped] = targetIndex[0] + i*params.refMul;
                   srcIndex[params.j_mapped] = targetIndex[1] + j*params.refMul;
 
-                  phiprof::start("index computations");
+                  phiprof::Timer computations {"index computations"};
                   Real v_top = std::min(v_src_tops[j*WID+i],(Real)(k_block_src*(WID*srcRefMul)+(k_cell_bot+1)*srcRefMul));
                   Real v_bot = std::max(v_src_bots[j*WID+i],(Real)(k_block_src*(WID*srcRefMul)+(k_cell_bot  )*srcRefMul));
 
@@ -517,7 +515,7 @@ void map_1d(SpatialCell* spatial_cell,PropagParams& params,
                   trgtCellIndex[params.j_mapped] = j;
                   trgtCellIndex[params.k_mapped] = k;
                   const int trgtCell = vblock::index(trgtCellIndex[0],trgtCellIndex[1],trgtCellIndex[2]);
-                  phiprof::stop("index computations");
+                  computations.stop();
 
                   // ***** TODO: fancier integrations here ***** //
 

--- a/vlasovsolver_amr/cpu_acc_map_amr.hpp
+++ b/vlasovsolver_amr/cpu_acc_map_amr.hpp
@@ -166,18 +166,18 @@ bool map_1d(SpatialCell* spatial_cell,Transform<Real,3,Affine>& fwd_transform,Tr
    // Successive calls (the inner loop below) of generateTargetMesh will then 
    // refine the already existing coarser blocks until every source block has 
    // a target block at the same (or higher) refinement level.
-   phiprof::Timer meshGenTimer {"mesh generation"};
+   phiprof::Timer meshGen {"mesh generation"};
    for (uint8_t r=0; r<blocks.size(); ++r) {
       for (uint8_t rr=r; rr<blocks.size(); ++rr) {
          propagParams.refLevel = rr;
          generateTargetMesh(spatial_cell,blocks[rr],propagParams,r,vmesh);
       }
    }
-   meshGenTimer.stop();
+   meshGen.stop();
 
-   phiprof::Timer mappingTimer {"mapping"};
+   phiprof::Timer mapping {"mapping"};
    map_1d(spatial_cell,propagParams,vmesh,blockContainer);
-   mappingTimer.stop();
+   mapping.stop();
 
    // Merge values from coarse blocks to refined blocks wherever the same domain 
    // is covered by overlapping blocks (at different refinement levels)
@@ -440,7 +440,7 @@ void map_1d(SpatialCell* spatial_cell,PropagParams& params,
             vmesh::GlobalID srcIndex[3];
             if (k_cell_src >= k_cell_src_max) {
                // Find the source block
-               phiprof::Timer searchTimer {"source block search"};
+               phiprof::Timer search {"source block search"};
                srcIndex[params.i_mapped] = targetIndex[0];
                srcIndex[params.j_mapped] = targetIndex[1];
                srcIndex[params.k_mapped] = k_cell_src;
@@ -481,7 +481,7 @@ void map_1d(SpatialCell* spatial_cell,PropagParams& params,
                   srcIndex[params.i_mapped] = targetIndex[0] + i*params.refMul;
                   srcIndex[params.j_mapped] = targetIndex[1] + j*params.refMul;
 
-                  phiprof::Timer computationsTimer {"index computations"};
+                  phiprof::Timer computations {"index computations"};
                   Real v_top = std::min(v_src_tops[j*WID+i],(Real)(k_block_src*(WID*srcRefMul)+(k_cell_bot+1)*srcRefMul));
                   Real v_bot = std::max(v_src_bots[j*WID+i],(Real)(k_block_src*(WID*srcRefMul)+(k_cell_bot  )*srcRefMul));
 
@@ -515,7 +515,7 @@ void map_1d(SpatialCell* spatial_cell,PropagParams& params,
                   trgtCellIndex[params.j_mapped] = j;
                   trgtCellIndex[params.k_mapped] = k;
                   const int trgtCell = vblock::index(trgtCellIndex[0],trgtCellIndex[1],trgtCellIndex[2]);
-                  computationsTimer.stop();
+                  computations.stop();
 
                   // ***** TODO: fancier integrations here ***** //
 

--- a/vlasovsolver_amr/cpu_acc_map_amr.hpp
+++ b/vlasovsolver_amr/cpu_acc_map_amr.hpp
@@ -166,18 +166,18 @@ bool map_1d(SpatialCell* spatial_cell,Transform<Real,3,Affine>& fwd_transform,Tr
    // Successive calls (the inner loop below) of generateTargetMesh will then 
    // refine the already existing coarser blocks until every source block has 
    // a target block at the same (or higher) refinement level.
-   phiprof::Timer meshGen {"mesh generation"};
+   phiprof::Timer meshGenTimer {"mesh generation"};
    for (uint8_t r=0; r<blocks.size(); ++r) {
       for (uint8_t rr=r; rr<blocks.size(); ++rr) {
          propagParams.refLevel = rr;
          generateTargetMesh(spatial_cell,blocks[rr],propagParams,r,vmesh);
       }
    }
-   meshGen.stop();
+   meshGenTimer.stop();
 
-   phiprof::Timer mapping {"mapping"};
+   phiprof::Timer mappingTimer {"mapping"};
    map_1d(spatial_cell,propagParams,vmesh,blockContainer);
-   mapping.stop();
+   mappingTimer.stop();
 
    // Merge values from coarse blocks to refined blocks wherever the same domain 
    // is covered by overlapping blocks (at different refinement levels)
@@ -440,7 +440,7 @@ void map_1d(SpatialCell* spatial_cell,PropagParams& params,
             vmesh::GlobalID srcIndex[3];
             if (k_cell_src >= k_cell_src_max) {
                // Find the source block
-               phiprof::Timer search {"source block search"};
+               phiprof::Timer searchTimer {"source block search"};
                srcIndex[params.i_mapped] = targetIndex[0];
                srcIndex[params.j_mapped] = targetIndex[1];
                srcIndex[params.k_mapped] = k_cell_src;
@@ -481,7 +481,7 @@ void map_1d(SpatialCell* spatial_cell,PropagParams& params,
                   srcIndex[params.i_mapped] = targetIndex[0] + i*params.refMul;
                   srcIndex[params.j_mapped] = targetIndex[1] + j*params.refMul;
 
-                  phiprof::Timer computations {"index computations"};
+                  phiprof::Timer computationsTimer {"index computations"};
                   Real v_top = std::min(v_src_tops[j*WID+i],(Real)(k_block_src*(WID*srcRefMul)+(k_cell_bot+1)*srcRefMul));
                   Real v_bot = std::max(v_src_bots[j*WID+i],(Real)(k_block_src*(WID*srcRefMul)+(k_cell_bot  )*srcRefMul));
 
@@ -515,7 +515,7 @@ void map_1d(SpatialCell* spatial_cell,PropagParams& params,
                   trgtCellIndex[params.j_mapped] = j;
                   trgtCellIndex[params.k_mapped] = k;
                   const int trgtCell = vblock::index(trgtCellIndex[0],trgtCellIndex[1],trgtCellIndex[2]);
-                  computations.stop();
+                  computationsTimer.stop();
 
                   // ***** TODO: fancier integrations here ***** //
 

--- a/vlasovsolver_amr/cpu_acc_semilag.hpp
+++ b/vlasovsolver_amr/cpu_acc_semilag.hpp
@@ -61,12 +61,12 @@ using namespace Eigen;
 void cpu_accelerate_cell(SpatialCell* spatial_cell, uint map_order, const Real dt) {
    double t1=MPI_Wtime();
    /*compute transform, forward in time and backward in time*/
-   phiprof::Timer computeTransform {"compute-transform"};
+   phiprof::Timer computeTransformTimer {"compute-transform"};
 
    //compute the transform performed in this acceleration
    Transform<Real,3,Affine> fwd_transform= compute_acceleration_transformation(spatial_cell,dt);
    Transform<Real,3,Affine> bwd_transform= fwd_transform.inverse();
-   computeTransform.stop();
+   computeTransformTimer.stop();
 
    // NOTE: This is now in a debugging / testing state. The propagator 
    // only does one thing each time step. Currently this does

--- a/vlasovsolver_amr/cpu_acc_semilag.hpp
+++ b/vlasovsolver_amr/cpu_acc_semilag.hpp
@@ -61,12 +61,12 @@ using namespace Eigen;
 void cpu_accelerate_cell(SpatialCell* spatial_cell, uint map_order, const Real dt) {
    double t1=MPI_Wtime();
    /*compute transform, forward in time and backward in time*/
-   phiprof::Timer computeTransformTimer {"compute-transform"};
+   phiprof::Timer computeTransform {"compute-transform"};
 
    //compute the transform performed in this acceleration
    Transform<Real,3,Affine> fwd_transform= compute_acceleration_transformation(spatial_cell,dt);
    Transform<Real,3,Affine> bwd_transform= fwd_transform.inverse();
-   computeTransformTimer.stop();
+   computeTransform.stop();
 
    // NOTE: This is now in a debugging / testing state. The propagator 
    // only does one thing each time step. Currently this does

--- a/vlasovsolver_amr/cpu_acc_semilag.hpp
+++ b/vlasovsolver_amr/cpu_acc_semilag.hpp
@@ -61,12 +61,12 @@ using namespace Eigen;
 void cpu_accelerate_cell(SpatialCell* spatial_cell, uint map_order, const Real dt) {
    double t1=MPI_Wtime();
    /*compute transform, forward in time and backward in time*/
-   phiprof::start("compute-transform");
+   phiprof::Timer computeTransform {"compute-transform"};
 
    //compute the transform performed in this acceleration
    Transform<Real,3,Affine> fwd_transform= compute_acceleration_transformation(spatial_cell,dt);
    Transform<Real,3,Affine> bwd_transform= fwd_transform.inverse();
-   phiprof::stop("compute-transform");
+   computeTransform.stop();
 
    // NOTE: This is now in a debugging / testing state. The propagator 
    // only does one thing each time step. Currently this does
@@ -122,14 +122,13 @@ void cpu_accelerate_cell(SpatialCell* spatial_cell, uint map_order, const Real d
    
    // BEGIN TEST
    if (counter % 2 != 0) {
-      phiprof::start("mesh coarsening");
+      phiprof::Timer timer {"mesh coarsening"};
       vamr_ref_criteria::Base* refCriterion = getObjectWrapper().amrVelRefCriteria.create(Parameters::vamrVelRefCriterion);
       if (refCriterion != NULL) {
          refCriterion->initialize("");
          spatial_cell->coarsen_blocks(refCriterion);
          delete refCriterion;
       }
-      phiprof::stop("mesh coarsening");
    } else {
       ++dim;
       if (dim == 2) dim=0;


### PR DESCRIPTION
Replace all phiprof timer calls with timer objects as per https://github.com/fmihpc/phiprof/pull/30. Timers are closed by their destructor e.g. when going out of scope, making it easier to avoid bugs caused by dangling timers.

Some guidelines:
- Never use `phiprof::start(args)` or `phiprof::stop(label, args)`, use `phiprof::Timer t {args}` and `t.stop(args)` instead.
- Use `int id = phiprof::initialize(args)` outside a loop and `phiprof::Timer {id}` inside. Initialization is superfluous if done immediately before starting a timer.
- Since timers automatically stop when going out of scope, you may omit `t.stop()` before e.g. return.