### PR TITLE
Fix generate_version

### DIFF
--- a/generate_version.sh
+++ b/generate_version.sh
@@ -69,7 +69,7 @@ git status | sed 's/\"/\\"/g' | sed 's/\\\"/\\"/g'  |gawk '{printf("%s\"%s\"%s\n
 echo "    cout << endl << \"----------- git diff ---------- \"<<endl;" >>version.cpp
 
 echo "    const char diff_data[] = {" >> version.cpp
-DIFF=$(git diff `git diff --name-only |grep -v generate_version.sh` | xxd -i)
+DIFF=$(git diff `git diff --name-only |grep -v generate_version.sh` | xxd -i | sed "s/0x/\'\\\\x/g;s/,/\',/g")\'
 if [[ -n $DIFF ]]; then
    echo -n $DIFF >> version.cpp
    echo "    ,0 };" >> version.cpp
@@ -123,7 +123,7 @@ git status | sed 's/\"/\\"/g' | sed 's/\\\"/\\"/g'  |gawk '{printf("%s\"%s\"%s\n
 echo "   versionInfo+=\"----------- git diff ---------- \";" >>version.cpp
 
 echo "    const char diff_data[] = {" >> version.cpp
-DIFF=$(git diff `git diff --name-only |grep -v generate_version.sh` | xxd -i)
+DIFF=$(git diff `git diff --name-only |grep -v generate_version.sh` | xxd -i | sed "s/0x/\'\\\\x/g;s/,/\',/g")\'
 if [[ -n $DIFF ]]; then
    echo -n $DIFF >> version.cpp
    echo "    ,0 };" >> version.cpp

--- a/generate_version.sh
+++ b/generate_version.sh
@@ -69,7 +69,7 @@ git status | sed 's/\"/\\"/g' | sed 's/\\\"/\\"/g'  |gawk '{printf("%s\"%s\"%s\n
 echo "    cout << endl << \"----------- git diff ---------- \"<<endl;" >>version.cpp
 
 echo "    const char diff_data[] = {" >> version.cpp
-DIFF=$(git diff `git diff --name-only |grep -v generate_version.sh` | xxd -i | sed "s/0x/\'\\\\x/g;s/,/\',/g")\'
+DIFF=$(git diff `git diff --name-only |grep -v generate_version.sh` | xxd -i | sed "s/0x\([0-9a-f]\{2\}\)/'\\\\x\1'/g")
 if [[ -n $DIFF ]]; then
    echo -n $DIFF >> version.cpp
    echo "    ,0 };" >> version.cpp
@@ -123,7 +123,7 @@ git status | sed 's/\"/\\"/g' | sed 's/\\\"/\\"/g'  |gawk '{printf("%s\"%s\"%s\n
 echo "   versionInfo+=\"----------- git diff ---------- \";" >>version.cpp
 
 echo "    const char diff_data[] = {" >> version.cpp
-DIFF=$(git diff `git diff --name-only |grep -v generate_version.sh` | xxd -i | sed "s/0x/\'\\\\x/g;s/,/\',/g")\'
+DIFF=$(git diff `git diff --name-only |grep -v generate_version.sh` | xxd -i | sed "s/0x\([0-9a-f]\{2\}\)/'\\\\x\1'/g")
 if [[ -n $DIFF ]]; then
    echo -n $DIFF >> version.cpp
    echo "    ,0 };" >> version.cpp


### PR DESCRIPTION
Changes hex codes in `generate_version.sh` (and by proxy `version.cpp`) to character literals instead of integers. This fixes an error where non-ascii characters in the diff cause a failure to compile, as any one-byte character literal can be converted to `char`, but integers > 128 emit a narrowing conversion error.