### PR TITLE
Print both relative and abso error variables in testpackage CI output

### DIFF
--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -173,7 +173,8 @@ for run in ${run_tests[*]}; do
    
    MAXERR=0.  # Absolute error
    MAXREL=0.  # Relative error
-   MAXVAR=""  # Variable with said error
+   MAXERRVAR=""  # Variable with max absolute error
+   MAXRELVAR=""  # Variable with max relative error
 
    variables=(${variable_names[$run]// / })
    indices=(${variable_components[$run]// / })
@@ -193,8 +194,12 @@ for run in ${run_tests[*]}; do
             # Check if we have a new maximum error
             if (( $( echo "$absoluteValue $MAXERR" | awk '{ if($1 > $2) print 1; else print 0 }' ) )); then
                MAXERR=$absoluteValue
+               MAXERRVAR=${variables[$i]}
+            fi
+            # ... or new max relative error
+            if (( $( echo "$relativeValue $MAXREL" | awk '{ if($1 > $2) print 1; else print 0 }' ) )); then
                MAXREL=$relativeValue
-               MAXVAR=${variables[$i]}
+               MAXRELVAR=${variables[$i]}
             fi
    
        elif [[ "${variables[$i]}" == "ig_"* ]]
@@ -211,8 +216,12 @@ for run in ${run_tests[*]}; do
             # Check if we have a new maximum error
             if (( $( echo "$absoluteValue $MAXERR" | awk '{ if($1 > $2) print 1; else print 0 }' ) )); then
                MAXERR=$absoluteValue
+               MAXERRVAR=${variables[$i]}
+            fi
+            # ... or new max relative error
+            if (( $( echo "$relativeValue $MAXREL" | awk '{ if($1 > $2) print 1; else print 0 }' ) )); then
                MAXREL=$relativeValue
-               MAXVAR=${variables[$i]}
+               MAXRELVAR=${variables[$i]}
             fi
    
        elif [ ! "${variables[$i]}" == "proton" ]
@@ -229,8 +238,12 @@ for run in ${run_tests[*]}; do
             # Check if we have a new maximum error
             if (( $( echo "$absoluteValue $MAXERR" | awk '{ if($1 > $2) print 1; else print 0 }' ) )); then
                MAXERR=$absoluteValue
+               MAXERRVAR=${variables[$i]}
+            fi
+            # ... or new max relative error
+            if (( $( echo "$relativeValue $MAXREL" | awk '{ if($1 > $2) print 1; else print 0 }' ) )); then
                MAXREL=$relativeValue
-               MAXVAR=${variables[$i]}
+               MAXRELVAR=${variables[$i]}
             fi
    
        elif [ "${variables[$i]}" == "proton" ]
@@ -245,19 +258,21 @@ for run in ${run_tests[*]}; do
        # so we save the variables to temp files
        echo $MAXERR > $RUNNER_TEMP/MAXERR.txt
        echo $MAXREL > $RUNNER_TEMP/MAXREL.txt
-       echo $MAXVAR > $RUNNER_TEMP/MAXVAR.txt
+       echo $MAXERRVAR > $RUNNER_TEMP/MAXERRVAR.txt
+       echo $MAXRELVAR > $RUNNER_TEMP/MAXRELVAR.txt
        echo $speedup > $RUNNER_TEMP/speedup.txt
    done 2>&1 1>&3 3>&- | tee -a $GITHUB_WORKSPACE/stderr.txt; } 3>&1 1>&2 | tee -a $GITHUB_WORKSPACE/stdout.txt
 
    # Recover error variables
    MAXERR=`cat $RUNNER_TEMP/MAXERR.txt`
+   MAXERRVAR=`cat $RUNNER_TEMP/MAXERRVAR.txt`
    MAXREL=`cat $RUNNER_TEMP/MAXREL.txt`
-   MAXVAR=`cat $RUNNER_TEMP/MAXVAR.txt`
+   MAXRELVAR=`cat $RUNNER_TEMP/MAXRELVAR.txt`
    speedup=`cat $RUNNER_TEMP/speedup.txt`
 
    # Output CI step annotation
    if (( $( echo "$MAXERR 0." | awk '{ if($1 > $2) print 1; else print 0 }' ) )); then
-      echo -e "<details><summary>:large_orange_diamond: ${test_name[$run]}: Nonzero diffs: : \`$MAXVAR\` has absolute error $MAXERR, relative error $MAXREL. Speedup: $speedup</summary>\n" >> $GITHUB_STEP_SUMMARY
+      echo -e "<details><summary>:large_orange_diamond: ${test_name[$run]}: Nonzero diffs: : \`$MAXERRVAR\` has absolute error $MAXERR, \`$MAXRELVAR\` has relative error $MAXREL. Speedup: $speedup</summary>\n" >> $GITHUB_STEP_SUMMARY
       NONZEROTESTS=$((NONZEROTESTS+1))
    else 
       echo -e "<details><summary>:heavy_check_mark: ${test_name[$run]}: Ran with zero diffs. Speedup: $speedup</summary>\n" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Before, only the maximum absolute error determined which variable would be lifted to the tests' one-line status.