### PR TITLE
Remove outdated warning about hardcoded meshName in ioread.

### DIFF
--- a/ioread.cpp
+++ b/ioread.cpp
@@ -1058,7 +1058,8 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    bool success=true;
    int myRank,processes;
 
-#warning Spatial grid name hard-coded here
+   // Note: Spatial grid name hard-coded here.
+   // But so are the other mesh names below.
    const string meshName = "SpatialGrid";
    
    // Attempt to open VLSV file for reading:


### PR DESCRIPTION
While technically correct, we are anyway hardcoding the other mesh names in the corresponding fsgrid and ionosphere loading routines, too. That warning basically had only historical value anymore.

This PR is part of my "remove one compiler warning per day" initiative.