### PR TITLE
Remove warning for unused variable in vspace memory size calculation.

### DIFF
--- a/spatial_cell.hpp
+++ b/spatial_cell.hpp
@@ -1627,7 +1627,6 @@ namespace spatial_cell {
     the size() functions of the containers in spatial cell
     */
    inline uint64_t SpatialCell::get_cell_memory_capacity() {
-      const uint64_t VEL_BLOCK_SIZE = 2*WID3*sizeof(Realf) + BlockParams::N_VELOCITY_BLOCK_PARAMS*sizeof(Real);
       uint64_t capacity = 0;
       
       capacity += vmeshTemp.capacityInBytes();


### PR DESCRIPTION
Apparently, this variable was an orphan from before implementation of multipop.

This PR is part of my "Remove one compiler warning per day" initiative.