### PR TITLE
Squelch warning about IonosphereNodeInt datareducer diagnostic type.

### DIFF
--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -266,7 +266,7 @@ namespace DRO {
    bool DataReductionOperatorIonosphereNode::reduceDiagnostic(const SpatialCell* cell,Real * result) {
       return false;
    }
-   bool DataReductionOperatorIonosphereNodeInt::reduceDiagnostic(const SpatialCell* cell,int * result) {
+   bool DataReductionOperatorIonosphereNodeInt::reduceDiagnostic(const SpatialCell* cell,Real * result) {
       return false;
    }
    bool DataReductionOperatorIonosphereNode::setSpatialCell(const SpatialCell* cell) {

--- a/datareduction/datareductionoperator.h
+++ b/datareduction/datareductionoperator.h
@@ -180,7 +180,7 @@ namespace DRO {
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual bool setSpatialCell(const SpatialCell* cell);
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
-      virtual bool reduceDiagnostic(const SpatialCell* cell,int * result);
+      virtual bool reduceDiagnostic(const SpatialCell* cell,Real * result);
       virtual bool writeIonosphereData(SBC::SphericalTriGrid& grid, vlsv::Writer& vlsvWriter);
    };
 


### PR DESCRIPTION
The virtual function override wasn't working, because it expected an int* instead of a Real*. Which is fundamentally ok, because it was anyway replacing a no-op function by a no-op function.

But it's better to have the *correct* no-op doing nothing there.

Also, I like to reduce warnings. This PR is part of my "remove one compiler warning per day" initiative.