### PR TITLE
Squelch warning about unused IMFdelAx in vectordipole.cpp

### DIFF
--- a/backgroundfield/vectordipole.cpp
+++ b/backgroundfield/vectordipole.cpp
@@ -262,15 +262,15 @@ double VectorDipole::operator()( double x, double y, double z, coordinate compon
       //delAx[2] = (-3./(r2*r2*r1))*(q[1]*r[2]-q[2]*r[1])*r[2] +q[1]/(r2*r1);
 
       // Calculate del IMFAx, del IMFAy, del IMFAz
+      //double IMFdelAx[3]; // Unused, since always zero
+      //IMFdelAx[0] = 0.;
+      //IMFdelAx[1] = -0.5*IMF[2];
+      //IMFdelAx[2] =  0.5*IMF[1];
       double IMFdelAy[3];
-      double IMFdelAx[3];
-      double IMFdelAz[3];
-      IMFdelAx[0] = 0.;
-      IMFdelAx[1] = -0.5*IMF[2];
-      IMFdelAx[2] =  0.5*IMF[1];
       IMFdelAy[0] =  0.5*IMF[2];
       IMFdelAy[1] = 0.0;
       IMFdelAy[2] = -0.5*IMF[0];
+      double IMFdelAz[3];
       IMFdelAz[0] = -0.5*IMF[1];
       IMFdelAz[1] =  0.5*IMF[0];
       IMFdelAz[2] = 0.0;


### PR DESCRIPTION
We don't need this variable anyway, as long as our solar wind flows parallel to x.

This PR is part of my "remove one compiler warning per day" initiative.