### PR TITLE
Remove yet another unused variable varning in vspace memory calc.

### DIFF
--- a/spatial_cell.hpp
+++ b/spatial_cell.hpp
@@ -1603,7 +1603,6 @@ namespace spatial_cell {
     functions of the containers in spatial cell
     */
    inline uint64_t SpatialCell::get_cell_memory_size() {
-      const uint64_t VEL_BLOCK_SIZE = 2*WID3*sizeof(Realf) + BlockParams::N_VELOCITY_BLOCK_PARAMS*sizeof(Real);
       uint64_t size = 0;
       size += vmeshTemp.sizeInBytes();
       size += blockContainerTemp.sizeInBytes();


### PR DESCRIPTION
This is basically the same fix as #738, in a slightly different function.

This PR is part of my "remove one compiler warning per day" initiative