### PR TITLE
Squelch more unused variable warnings.

### DIFF
--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -1426,7 +1426,9 @@ namespace DRO {
       const uint vectorSize = 3;
       //Input data into buffer
       const char* ptr = reinterpret_cast<const char*>(&PTensor);
-      for (uint i = 0; i < 3*sizeof(Real); ++i) buffer[i] = ptr[i];
+      for (uint i = 0; i < vectorSize*sizeof(Real); ++i) {
+         buffer[i] = ptr[i];
+      }
       return true;
    }
    
@@ -1466,7 +1468,9 @@ namespace DRO {
       const uint vectorSize = 3;
       //Input data into buffer
       const char* ptr = reinterpret_cast<const char*>(&PTensor);
-      for (uint i = 0; i < 3*sizeof(Real); ++i) buffer[i] = ptr[i];
+      for (uint i = 0; i < vectorSize*sizeof(Real); ++i) {
+         buffer[i] = ptr[i];
+      }
       return true;
    }
    

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -694,7 +694,7 @@ namespace projects {
       if (myRank == MASTER_RANK)
          std::cout << "Maximum refinement level is " << mpiGrid.mapping.get_maximum_refinement_level() << std::endl;
 
-      Real ibr2 {pow(ionosphereRadius + 2*P::dx_ini, 2)};
+      //Real ibr2 {pow(ionosphereRadius + 2*P::dx_ini, 2)};
 
       std::vector<CellID> cells {getLocalCells()};
       Real r_max2 {pow(P::refineRadius, 2)};
@@ -707,7 +707,6 @@ namespace projects {
          int refLevel {mpiGrid.get_refinement_level(id)};
          Real r2 {pow(xyz[0], 2) + pow(xyz[1], 2) + pow(xyz[2], 2)};
 
-         bool refine = false;
          const Real logDx {std::log2(P::dx_ini)};
          if (!canRefine(mpiGrid[id])) {
             // Skip refining, touching boundaries during runtime breaks everything

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -269,7 +269,6 @@ namespace SBC {
          }
 
          // Make it delaunay
-         int numAdjacentVertices = 0;
          std::vector<int> adjacentVertices;
          for(int i=0; i<(int)nearestSamples.size(); i++) {
             int k = nearestSamples[i];

--- a/sysboundary/setbyuser.cpp
+++ b/sysboundary/setbyuser.cpp
@@ -427,7 +427,6 @@ namespace SBC {
    bool SetByUser::generateTemplateCells(creal& t) {
       #pragma omp parallel for
       for(uint i=0; i<6; i++) {
-         int index;
          if(facesToProcess[i]) {
             generateTemplateCell(templateCells[i], templateB[i], i, t);
          }


### PR DESCRIPTION
These ones are pretty straightforward.

This PR is part of my "remove one compiler warning per day" initiative.