### PR TITLE
CI: Don't upload testpackage_build.log anymore, get proper return val.

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -121,17 +121,17 @@ jobs:
     - name: Compile vlasiator (Testpackage build)
       run: |
         export VLASIATOR_ARCH=carrington_gcc_openmpi
-        srun -M carrington --job-name tp_compile --interactive --nodes=1 -n 1 -c 16 --mem=40G -p short -t 0:10:0 bash -c 'module purge; module load GCC/11.2.0; module load OpenMPI/4.1.1-GCC-11.2.0 ; module load PMIx/4.1.0-GCCcore-11.2.0; module load PAPI/6.0.0.1-GCCcore-11.2.0; export VLASIATOR_ARCH=carrington_gcc_openmpi; make -j 16 testpackage' 2>&1 | tee build.log
+        srun -M carrington --job-name tp_compile --interactive --nodes=1 -n 1 -c 16 --mem=40G -p short -t 0:10:0 bash -c 'module purge; module load GCC/11.2.0; module load OpenMPI/4.1.1-GCC-11.2.0 ; module load PMIx/4.1.0-GCCcore-11.2.0; module load PAPI/6.0.0.1-GCCcore-11.2.0; export VLASIATOR_ARCH=carrington_gcc_openmpi; make -j 16 testpackage'
     - name: Upload testpackage binary
       uses: actions/upload-artifact@v3
       with:
         name: vlasiator-testpackage
         path: vlasiator
-    - name: Upload build log
-      uses: actions/upload-artifact@v3
-      with:
-        name: Testpackage build log
-        path: build.log
+    #- name: Upload build log
+    #  uses: actions/upload-artifact@v3
+    #  with:
+    #    name: Testpackage build log
+    #    path: build.log
 
   build_tools:
     # Build vlsvdiff and vlsvextract for testepackage use


### PR DESCRIPTION
Before, the pipe catching the compilation output was causing the job to always return a green checkmark, even if the build failed for some reason.

The information in that build log is anyway captured as part of the github action, so there's no need to keep it around as an artefact.