### PR TITLE
Remove "#pragma ivdep" warnings by replacing with "#pragma omp simd"

### DIFF
--- a/vlasovsolver/cpu_1d_pqm.hpp
+++ b/vlasovsolver/cpu_1d_pqm.hpp
@@ -99,11 +99,7 @@ inline void filter_pqm_monotonicity(Vec *values, uint k, Vec &fv_l, Vec &fv_r, V
       //todo store and then load data to avoid inserts (is it beneficial...?)
       
 //serialized the handling of inflexion points, these do not happen for smooth regions
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#pragma ivdep
-#pragma GCC diagnostic pop
-#pragma GCC ivdep                     
+#pragma omp simd
       for(uint i = 0;i < VECL; i++) {
          if(fixInflexion[i]){
             //need to collapse, at least one inflexion point has wrong

--- a/vlasovsolver/cpu_acc_map.cpp
+++ b/vlasovsolver/cpu_acc_map.cpp
@@ -571,11 +571,7 @@ bool map_1d(SpatialCell* spatial_cell,
                   else{
                      // total value of integrand
                      const Vec target_density = target_density_r - target_density_l;                  
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#pragma ivdep
-#pragma GCC diagnostic pop
-#pragma GCC ivdep                     
+#pragma omp simd
                      for (int target_i=0; target_i < VECL; ++target_i) {
                         // do the conversion from Realv to Realf here, faster than doing it in accumulation
                         const Realf tval = target_density[target_i];

--- a/vlasovsolver/cpu_trans_map.cpp
+++ b/vlasovsolver/cpu_trans_map.cpp
@@ -559,11 +559,7 @@ bool trans_map_1d(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
                for (uint k=0; k<WID; ++k) {
                   for(uint planeVector = 0; planeVector < VEC_PER_PLANE; planeVector++){
                      targetVecValues[i_trans_pt_blockv(planeVector, k, b)].store(vector);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#pragma ivdep
-#pragma GCC diagnostic pop
-#pragma GCC ivdep
+#pragma omp simd
                      for(uint i = 0; i< VECL; i++){
                         // store data, when reading data from data we swap
                         // dimensions 


### PR DESCRIPTION
Hooray for this thing actually being standardized in OpenMP 4!

Compare, for example https://blog.rwth-aachen.de/hpc_import_20210107/attachments/28344675/30867475.pdf

(This might warrant a specific performance check, to see that it actually produces code of the same speed)

This PR is part of my "remove one compiler warning per day" initiative.