### PR TITLE
Squelch a bunch of unused variables in ioread and iowrite

### DIFF
--- a/ioread.cpp
+++ b/ioread.cpp
@@ -228,8 +228,6 @@ bool readNBlocks(vlsv::ParallelReader& file,const std::string& meshName,
    // Read mesh bounding box to all processes, the info in bbox contains 
    // the number of spatial cells in the mesh.
    // (This is *not* the physical coordinate bounding box.)
-   uint64_t bbox[6];
-   uint64_t* bbox_ptr = bbox;
    list<pair<string,string> > attribsIn;
    map<string,string> attribsOut;
    attribsIn.push_back(make_pair("mesh",meshName));
@@ -320,7 +318,6 @@ bool _readBlockData(
 ) {   
    uint64_t arraySize;
    uint64_t avgVectorSize;
-   uint64_t cellParamsVectorSize;
    vlsv::datatype::type dataType;
    uint64_t byteSize;
    list<pair<string,string> > avgAttribs;

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -475,7 +475,6 @@ bool writeCommonGridData(
    // Writes parameters and cell ids into the VLSV file
    int myRank;
    MPI_Comm_rank(comm, &myRank);
-   const int masterProcessId = 0;
    //Write local cells into array as a variable:
    //Note: This needs to be done separately from the array MESH
    const short unsigned int vectorSize = 1;
@@ -1308,7 +1307,6 @@ bool writeGrid(
    const int& stripe,
    const bool writeGhosts
 ) {
-   double allStart = MPI_Wtime();
    bool success = true;
    int myRank;
    phiprof::initializeTimer("Barrier-entering-writegrid","MPI","Barrier");
@@ -1556,7 +1554,6 @@ bool writeRestart(
    const int& stripe) 
 {
    // Writes a restart
-   double allStart = MPI_Wtime();
    bool success = true;
    int myRank;
    


### PR DESCRIPTION
These were apparently all still leftovers from previous methods of handling things, or from copy'n'pasting a bit to overzealously from other parts of the code.

This PR is part of my "Remove one compiler warning per day" initiative.