### PR TITLE
Remove (you guessed it) some more unused variable warnings.

### DIFF
--- a/projects/Shocktest/Shocktest.cpp
+++ b/projects/Shocktest/Shocktest.cpp
@@ -212,7 +212,7 @@ namespace projects {
                   Bxavg = Byavg = Bzavg = 0.0;
                   if(this->nSpaceSamples > 1) {
                      Real d_x = perBGrid.DX / (this->nSpaceSamples - 1);
-                     Real d_z = perBGrid.DZ / (this->nSpaceSamples - 1);
+                     //Real d_z = perBGrid.DZ / (this->nSpaceSamples - 1);
                      for (uint i=0; i<this->nSpaceSamples; ++i) {
                         for (uint k=0; k<this->nSpaceSamples; ++k) {
                            Bxavg += ((xyz[0] + i * d_x) < 0.0) ? this->Bx[this->LEFT] : this->Bx[this->RIGHT];

--- a/spatial_cell.cpp
+++ b/spatial_cell.cpp
@@ -575,7 +575,6 @@ namespace spatial_cell {
 
       std::vector<MPI_Aint> displacements;
       std::vector<int> block_lengths;
-      vmesh::LocalID block_index = 0;
 
       // create datatype for actual data if we are in the first two 
       // layers around a boundary, or if we send for the whole system
@@ -884,7 +883,6 @@ namespace spatial_cell {
       }
       
       // Iterate over all octants, each octant corresponds to a different child:
-      bool removeBlock = false;
       for (int k_oct=0; k_oct<2; ++k_oct) for (int j_oct=0; j_oct<2; ++j_oct) for (int i_oct=0; i_oct<2; ++i_oct) {
          // Copy data belonging to the octant to a temporary array:
          Realf array[WID3];

--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -1592,7 +1592,6 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
                
                int L = DimensionPencils[dimension].lengthOfPencils[pencili];
                uint targetLength = L + 2 * nTargetNeighborsPerPencil;
-               uint sourceLength = L + 2 * VLASOV_STENCIL_WIDTH;
                               
                // load data(=> sourcedata) / (proper xy reconstruction in future)
                bool pencil_has_data = copy_trans_block_data_amr(pencilSourceCells[pencili].data(), blockGID, L, pencilSourceVecData[pencili].data(),
@@ -1726,7 +1725,6 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
 int get_sibling_index(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, const CellID& cellid) {
 
    const int NO_SIBLINGS = 0;
-   const int ERROR = -1;
    
    if(mpiGrid.get_refinement_level(cellid) == 0) {
       return NO_SIBLINGS;


### PR DESCRIPTION
If you weigh a harddisk containing the code, it has probably become lighter by a measurable amount already!

This PR is part of my "remove one compiler warning per day" - initiative