### PR TITLE
Add nonMaxwellianity DRO

### DIFF
--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -48,7 +48,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       // Sidestep mixed case errors
       std::string lowercase = *it;
       for(auto& c : lowercase) c = tolower(c);
-      
+
       if(lowercase == "fg_b" || lowercase == "b") { // Bulk magnetic field at Yee-Lattice locations
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b",[](
                       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
@@ -82,7 +82,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
 	 }
 	 ));
          outputReducer->addMetadata(outputReducer->size()-1,"T","$\\mathrm{T}$","$B$","1.0");
-         continue;	 
+         continue;
       }
       if(lowercase == "fg_backgroundb" || lowercase == "backgroundb" || lowercase == "fg_b_background") { // Static (typically dipole) magnetic field part
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_background",[](
@@ -269,7 +269,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          continue;
       }
-      
+
       if(lowercase == "v" || lowercase == "vg_v") { // Overall effective bulk density defining the center-of-mass frame from all populations
          outputReducer->addOperator(new DRO::DataReductionOperatorCellParams("vg_v",CellParams::VX,3));
 	 outputReducer->addMetadata(outputReducer->size()-1,"m/s","$\\mathrm{m}\\,\\mathrm{s}^{-1}$","$V$","1.0");
@@ -447,6 +447,17 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             const std::string& pop = species.name;
             outputReducer->addOperator(new DRO::VariableHeatFluxVector(i));
             outputReducer->addMetadata(outputReducer->size()-1,"W/m^2","$\\mathrm{W}\\,\\mathrm{m}^{-2}$","$q_\\mathrm{"+pop+"}$","1.0");
+         }
+         continue;
+      }
+      if (lowercase == "populations_nonmaxwellianity" || lowercase == "populations_vg_nonmaxwellianity") {
+         // Per-population dimensionless non-maxwellianity parameter
+         for (unsigned int i = 0; i < getObjectWrapper().particleSpecies.size(); i++) {
+            species::Species& species = getObjectWrapper().particleSpecies[i];
+            const std::string& pop = species.name;
+            outputReducer->addOperator(new DRO::VariableNonMaxwellianity(i));
+            outputReducer->addMetadata(outputReducer->size() - 1, "", "",
+                                       "$\\tilde{\\epsilon}_\\mathrm{M," + pop + "}$", "1.0");
          }
          continue;
       }
@@ -2431,7 +2442,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
 	 outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$\\delta Z_\\mathrm{vg}$","1.0");
          continue;
       }
-      if(lowercase == "fg_gridcoordinates") { 
+      if(lowercase == "fg_gridcoordinates") {
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_x",[](
                       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
                       FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
@@ -2613,7 +2624,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "ig_latitude") {
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_latitude", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.nodes.size());
 
                      for(uint i=0; i<grid.nodes.size(); i++) {
@@ -2652,7 +2663,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "ig_cellarea") {
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereElement("ig_cellarea", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.elements.size());
 
                      for(uint i=0; i<grid.elements.size(); i++) {
@@ -2667,7 +2678,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "ig_b") {
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_b", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.nodes.size()*3);
 
                      for(uint i=0; i<grid.nodes.size(); i++) {
@@ -2685,7 +2696,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "ig_e") {
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereElement("ig_e", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.elements.size()*3);
 
                      for(uint i=0; i<grid.elements.size(); i++) {
@@ -2716,7 +2727,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "ig_inplanecurrent") {
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereElement("ig_inplanecurrent", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.elements.size()*3);
 
                      for(uint i=0; i<grid.elements.size(); i++) {
@@ -2758,14 +2769,14 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "ig_upmappedarea") {
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereElement("ig_upmappedarea", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.elements.size()*3);
 
                      for(uint i=0; i<grid.elements.size(); i++) {
                         std::array<Real, 3> area = grid.mappedElementArea(i);
-                        retval[3*i] = area[0]; 
-                        retval[3*i+1] = area[1]; 
-                        retval[3*i+2] = area[2]; 
+                        retval[3*i] = area[0];
+                        retval[3*i+1] = area[1];
+                        retval[3*i+2] = area[2];
                      }
 
                      return retval;
@@ -2949,7 +2960,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "ig_potential") {
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_potential", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.nodes.size());
 
                      for(uint i=0; i<grid.nodes.size(); i++) {
@@ -2986,7 +2997,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                      }));
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_p", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.nodes.size());
 
                      for(uint i=0; i<grid.nodes.size(); i++) {
@@ -2997,7 +3008,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                      }));
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_pp", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.nodes.size());
 
                      for(uint i=0; i<grid.nodes.size(); i++) {
@@ -3008,7 +3019,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                      }));
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_z", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.nodes.size());
 
                      for(uint i=0; i<grid.nodes.size(); i++) {
@@ -3019,7 +3030,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                      }));
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_zz", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.nodes.size());
 
                      for(uint i=0; i<grid.nodes.size(); i++) {
@@ -3034,7 +3045,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "ig_upmappednodecoords") {
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_upmappednodecoords", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.nodes.size()*3);
 
                      for(uint i=0; i<grid.nodes.size(); i++) {
@@ -3051,7 +3062,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "ig_upmappedb") {
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_upmappedb", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.nodes.size()*3);
 
                      for(uint i=0; i<grid.nodes.size(); i++) {
@@ -3069,13 +3080,13 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          FieldTracing::fieldTracingParameters.doTraceOpenClosed = true;
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_openclosed", [](
             SBC::SphericalTriGrid& grid)->std::vector<Real> {
-               
+
                std::vector<Real> retval(grid.nodes.size());
-               
+
                for(uint i=0; i<grid.nodes.size(); i++) {
                   retval[i] = (Real)grid.nodes[i].openFieldLine;
                }
-               
+
                return retval;
             }));
          continue;
@@ -3083,7 +3094,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(lowercase == "ig_fac") {
          outputReducer->addOperator(new DRO::DataReductionOperatorIonosphereNode("ig_fac", [](
                      SBC::SphericalTriGrid& grid)->std::vector<Real> {
-                  
+
                      std::vector<Real> retval(grid.nodes.size());
 
                      for(uint i=0; i<grid.nodes.size(); i++) {
@@ -3162,10 +3173,10 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
             FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
             FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
-               
+
                std::array<int32_t,3>& gridSize = technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
-               
+
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
@@ -3286,7 +3297,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
  */
 DataReducer::DataReducer() { }
 
-/** Destructor for class DataReducer. All stored DataReductionOperators 
+/** Destructor for class DataReducer. All stored DataReductionOperators
  * are deleted.
  */
 DataReducer::~DataReducer() {
@@ -3297,7 +3308,7 @@ DataReducer::~DataReducer() {
    }
 }
 
-/** Add a new DRO::DataReductionOperator which has been created with new operation. 
+/** Add a new DRO::DataReductionOperator which has been created with new operation.
  * DataReducer will take care of deleting it.
  * @return If true, the given DRO::DataReductionOperator was added successfully.
  */
@@ -3330,7 +3341,7 @@ bool DataReducer::getDataVectorInfo(const unsigned int& operatorID,std::string& 
    return operators[operatorID]->getDataVectorInfo(dataType,dataSize,vectorSize);
 }
 
-/** Add a metadata to the specified DRO::DataReductionOperator. 
+/** Add a metadata to the specified DRO::DataReductionOperator.
  * @param operatorID ID number of the DataReductionOperator to add metadata to
  * @param unit string with the physical unit of the DRO result
  * @param unitLaTeX LaTeX-formatted string with the physical unit of the DRO result
@@ -3388,7 +3399,7 @@ bool DataReducer::reduceDiagnostic(const SpatialCell* cell,const unsigned int& o
    // Tell the chosen operator which spatial cell we are counting:
    if (operatorID >= operators.size()) return false;
    if (operators[operatorID]->setSpatialCell(cell) == false) return false;
-   
+
    if (operators[operatorID]->reduceDiagnostic(cell,result) == false) return false;
    return true;
 }
@@ -3426,7 +3437,7 @@ bool DataReducer::writeFsGridData(
                       const std::string& meshName, const unsigned int operatorID,
                       vlsv::Writer& vlsvWriter,
                       const bool writeAsFloat) {
-   
+
    if (operatorID >= operators.size()) return false;
    DRO::DataReductionOperatorFsGrid* DROf = dynamic_cast<DRO::DataReductionOperatorFsGrid*>(operators[operatorID]);
    if(!DROf) {
@@ -3450,5 +3461,5 @@ bool DataReducer::writeIonosphereGridData(
    } else {
       return false;
    }
-   
+
 }

--- a/datareduction/datareductionoperator.h
+++ b/datareduction/datareductionoperator.h
@@ -37,24 +37,24 @@ using namespace spatial_cell;
 namespace DRO {
 
    /** DRO::DataReductionOperator defines a base class for reducing simulation data
-    * (six-dimensional distribution function) into more compact variables, e.g. 
+    * (six-dimensional distribution function) into more compact variables, e.g.
     * scalar fields, which can be written into file(s) and visualized.
-    * 
-    * The intention is that each DRO::DataReductionOperator stores the reduced data 
-    * into internal variables, whose values are written into a byte array when 
+    *
+    * The intention is that each DRO::DataReductionOperator stores the reduced data
+    * into internal variables, whose values are written into a byte array when
     * DRO::DataReductionOperator::appendReducedData is called.
-    * 
-    * If needed, a user can write his or her own DRO::DataReductionOperators, which 
+    *
+    * If needed, a user can write his or her own DRO::DataReductionOperators, which
     * are loaded when the simulation initializes.
     *
-    * Datareduction oeprators are not thread-safe, some of the more intensive ones are threaded within. 
+    * Datareduction oeprators are not thread-safe, some of the more intensive ones are threaded within.
     */
 
    class DataReductionOperator {
    public:
       DataReductionOperator();
       virtual ~DataReductionOperator();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const = 0;
       virtual bool getUnitMetadata(std::string& _unit,std::string& _unitLaTeX,std::string& _variableLaTeX,std::string& _unitConversion) {
 	_unit=unit;
@@ -75,13 +75,13 @@ namespace DRO {
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool reduceDiagnostic(const SpatialCell* cell,Real * result);
       virtual bool setSpatialCell(const SpatialCell* cell) = 0;
-      
+
    protected:
       std::string unit;
       std::string unitLaTeX;
       std::string variableLaTeX;
       std::string unitConversion;
-      
+
    };
 
    class DataReductionOperatorHasParameters: public DataReductionOperator {
@@ -147,7 +147,7 @@ namespace DRO {
          virtual bool reduceDiagnostic(const SpatialCell* cell,Real * result);
          virtual bool writeIonosphereData(SBC::SphericalTriGrid& grid, vlsv::Writer& vlsvWriter);
    };
-   
+
    // Generic (lambda-based) datareducer for ionosphere grid node-centered data
    class DataReductionOperatorIonosphereNode : public DataReductionOperator {
       public:
@@ -165,7 +165,7 @@ namespace DRO {
          virtual bool reduceDiagnostic(const SpatialCell* cell,Real * result);
          virtual bool writeIonosphereData(SBC::SphericalTriGrid& grid, vlsv::Writer& vlsvWriter);
    };
-   
+
    // Generic (lambda-based) datareducer for ionosphere grid node-centered int data
    class DataReductionOperatorIonosphereNodeInt : public DataReductionOperator {
    public:
@@ -173,7 +173,7 @@ namespace DRO {
    private:
       ReductionLambda lambda;
       std::string variableName;
-      
+
    public:
       DataReductionOperatorIonosphereNodeInt(const std::string& name, ReductionLambda l): DataReductionOperator(), lambda(l),variableName(name) {};
       virtual std::string getName() const;
@@ -206,13 +206,13 @@ namespace DRO {
    public:
       DataReductionOperatorCellParams(const std::string& name,const unsigned int parameterIndex,const unsigned int vectorSize);
       virtual ~DataReductionOperatorCellParams();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool reduceDiagnostic(const SpatialCell* cell,Real * result);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       uint _parameterIndex;
       uint vectorSize;
@@ -225,38 +225,38 @@ namespace DRO {
       DataReductionOperatorDerivatives(const std::string& name,const unsigned int parameterIndex,const unsigned int vectorSize);
       virtual bool setSpatialCell(const SpatialCell* cell);
    };
-   
+
    class DataReductionOperatorBVOLDerivatives: public DataReductionOperatorCellParams {
    public:
       DataReductionOperatorBVOLDerivatives(const std::string& name,const unsigned int parameterIndex,const unsigned int vectorSize);
       virtual bool setSpatialCell(const SpatialCell* cell);
    };
-   
+
    class MPIrank: public DataReductionOperator {
    public:
       MPIrank();
       virtual ~MPIrank();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       Real rank;
       int mpiRank;
    };
-   
+
    class BoundaryType: public DataReductionOperator {
    public:
       BoundaryType();
       virtual ~BoundaryType();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       int boundaryType;
    };
@@ -265,12 +265,12 @@ namespace DRO {
    public:
       BoundaryLayer();
       virtual ~BoundaryLayer();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       int boundaryLayer;
    };
@@ -279,138 +279,138 @@ namespace DRO {
    public:
       Blocks(cuint popID);
       virtual ~Blocks();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool reduceDiagnostic(const SpatialCell* cell,Real* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       uint nBlocks;
       uint popID;
       std::string popName;
    };
-   
+
    class VariableBVol: public DataReductionOperator {
    public:
       VariableBVol();
       virtual ~VariableBVol();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       Real B[3];
    };
 
-   
+
    class VariablePressureSolver: public DataReductionOperator {
    public:
       VariablePressureSolver();
       virtual ~VariablePressureSolver();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       Real Pressure;
    };
-   
+
    class VariablePTensorDiagonal: public DataReductionOperator {
    public:
       VariablePTensorDiagonal(cuint popID);
       virtual ~VariablePTensorDiagonal();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       Real averageVX, averageVY, averageVZ;
       Real PTensor[3];
       uint popID;
       std::string popName;
    };
-   
+
    class VariablePTensorOffDiagonal: public DataReductionOperator {
    public:
       VariablePTensorOffDiagonal(cuint popID);
       virtual ~VariablePTensorOffDiagonal();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       Real averageVX, averageVY, averageVZ;
       Real PTensor[3];
       uint popID;
       std::string popName;
    };
-   
+
    class DiagnosticFluxB: public DataReductionOperator {
    public:
       DiagnosticFluxB();
       virtual  ~DiagnosticFluxB();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceDiagnostic(const SpatialCell* cell,Real* result);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
-      
+
    };
-   
+
    class DiagnosticFluxE: public DataReductionOperator {
    public:
       DiagnosticFluxE();
       virtual  ~DiagnosticFluxE();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceDiagnostic(const SpatialCell* cell,Real* result);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
-      
+
    };
-   
+
    class MaxDistributionFunction: public DataReductionOperator {
    public:
       MaxDistributionFunction(cuint popID);
       virtual ~MaxDistributionFunction();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool reduceDiagnostic(const SpatialCell* cell,Real *buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       Real maxF;
       uint popID;
       std::string popName;
    };
-   
+
    class MinDistributionFunction: public DataReductionOperator {
    public:
       MinDistributionFunction(cuint popID);
       virtual ~MinDistributionFunction();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool reduceDiagnostic(const SpatialCell* cell,Real *buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       Real minF;
       uint popID;
@@ -421,12 +421,12 @@ namespace DRO {
    public:
       VariableRhoThermal(cuint popID);
       virtual ~VariableRhoThermal();
-     
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-     
+
    protected:
       Real RhoThermal;
       uint popID;
@@ -438,12 +438,12 @@ namespace DRO {
    public:
       VariableRhoNonthermal(cuint popID);
       virtual ~VariableRhoNonthermal();
-     
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-     
+
    protected:
       Real RhoNonthermal;
       uint popID;
@@ -455,12 +455,12 @@ namespace DRO {
    public:
       VariableVThermal(cuint popID);
       virtual ~VariableVThermal();
-     
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-     
+
    protected:
       Real VThermal[3];
       uint popID;
@@ -489,12 +489,12 @@ namespace DRO {
    public:
       VariablePTensorThermalDiagonal(cuint popID);
       virtual ~VariablePTensorThermalDiagonal();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       Real averageVX, averageVY, averageVZ;
       Real PTensor[3];
@@ -556,7 +556,7 @@ namespace DRO {
       std::string popName;
       bool doSkip;
    };
-   
+
    class VariableEffectiveSparsityThreshold: public DataReductionOperator {
    public:
       VariableEffectiveSparsityThreshold(cuint popID);
@@ -567,7 +567,7 @@ namespace DRO {
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool reduceDiagnostic(const spatial_cell::SpatialCell* cell,Real* result);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       uint popID;
       std::string popName;
@@ -592,19 +592,19 @@ namespace DRO {
       Real E1limit;
       Real E2limit;
    };
-   
+
    // Precipitation directional differential number flux (within loss cone)
    class VariablePrecipitationDiffFlux: public DataReductionOperatorHasParameters {
    public:
       VariablePrecipitationDiffFlux(cuint popID);
       virtual ~VariablePrecipitationDiffFlux();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
       virtual bool writeParameters(vlsv::Writer& vlsvWriter);
-      
+
    protected:
       uint popID;
       std::string popName;
@@ -619,13 +619,13 @@ namespace DRO {
    public:
       VariablePrecipitationLineDiffFlux(cuint popID);
       virtual ~VariablePrecipitationLineDiffFlux();
-      
+
       virtual bool getDataVectorInfo(std::string& dataType,unsigned int& dataSize,unsigned int& vectorSize) const;
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
       virtual bool writeParameters(vlsv::Writer& vlsvWriter);
-      
+
    protected:
       uint popID;
       std::string popName;
@@ -653,10 +653,34 @@ namespace DRO {
       virtual std::string getName() const;
       virtual bool reduceData(const SpatialCell* cell,char* buffer);
       virtual bool setSpatialCell(const SpatialCell* cell);
-      
+
    protected:
       Real averageVX, averageVY, averageVZ;
       Real HeatFlux[3];
+      uint popID;
+      std::string popName;
+   };
+
+   // Dimensionless non-maxwellianity parameter
+   class VariableNonMaxwellianity : public DataReductionOperator {
+   public:
+      VariableNonMaxwellianity(cuint popID);
+      virtual ~VariableNonMaxwellianity();
+
+      virtual bool getDataVectorInfo(std::string& dataType, unsigned int& dataSize, unsigned int& vectorSize) const;
+      virtual std::string getName() const;
+      virtual bool reduceData(const SpatialCell* cell, char* buffer);
+      virtual bool setSpatialCell(const SpatialCell* cell);
+
+   protected:
+      Real rho;
+      Real V0[3];
+      Real b_par[3];
+      Real b_perp1[3];
+      Real b_perp2[3];
+      Real T_par;
+      Real T_perp;
+      Real epsilon;
       uint popID;
       std::string popName;
    };

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -350,8 +350,9 @@ bool P::addParameters() {
                         "populations_vg_moments_thermal populations_vg_moments_nonthermal " +
                         "populations_vg_effectivesparsitythreshold populations_vg_rho_loss_adjust " +
                         "populations_vg_energydensity populations_vg_precipitationdifferentialflux " +
-                        "populations_vg_heatflux " +  
-                        "vg_maxdt_acceleration vg_maxdt_translation populations_vg_maxdt_acceleration "
+                        "populations_vg_heatflux " +
+                        "populations_vg_nonmaxwellianity " +
+                        "vg_maxdt_acceleration vg_maxdt_translation populations_vg_maxdt_acceleration " +
                         "populations_vg_maxdt_translation " +
                         "fg_maxdt_fieldsolver " + "vg_rank fg_rank fg_amr_level vg_loadbalance_weight " +
                         "vg_boundarytype fg_boundarytype vg_boundarylayer fg_boundarylayer " +
@@ -446,7 +447,7 @@ bool P::addParameters() {
    RP::add("AMR.box_center_z", "z coordinate of the center of the box that is refined (for testing)", 0.0);
    RP::add("AMR.transShortPencils", "if true, use one-cell pencils", false);
    RP::addComposing("AMR.filterpasses", string("AMR filter passes for each individual refinement level"));
-   
+
    RP::add("fieldtracing.fieldLineTracer", "Field line tracing method to use for coupling ionosphere and magnetosphere (options are: Euler, BS)", std::string("Euler"));
    RP::add("fieldtracing.tracer_max_allowed_error", "Maximum allowed error for the adaptive field line tracers ", 1000);
    RP::add("fieldtracing.tracer_max_attempts", "Maximum allowed attempts for the adaptive field line tracers", 100);
@@ -599,7 +600,7 @@ void Parameters::getParameters() {
    mpiioValues.clear();
    RP::get("io.restart_write_mpiio_hint_key", mpiioKeys);
    RP::get("io.restart_write_mpiio_hint_value", mpiioValues);
-   
+
    if (mpiioKeys.size() != mpiioValues.size()) {
       if (myRank == MASTER_RANK) {
          cerr << "WARNING the number of io.restart_write_mpiio_hint_key and io.restart_write_mpiio_hint_value do not "
@@ -616,7 +617,7 @@ void Parameters::getParameters() {
    mpiioValues.clear();
    RP::get("io.restart_read_mpiio_hint_key", mpiioKeys);
    RP::get("io.restart_read_mpiio_hint_value", mpiioValues);
-   
+
    if (mpiioKeys.size() != mpiioValues.size()) {
       if (myRank == MASTER_RANK) {
          cerr << "WARNING the number of io.restart_read_mpiio_hint_key and io.restart_read_mpiio_hint_value do not "
@@ -717,7 +718,7 @@ void Parameters::getParameters() {
          int maxPasses=g_sequence(P::amrMaxSpatialRefLevel-1);
          for (uint refLevel=0; refLevel<=P::amrMaxSpatialRefLevel; refLevel++){
             numPasses.push_back(maxPasses);
-            maxPasses/=2; 
+            maxPasses/=2;
          }
          //Overwrite passes for the highest refLevel. We do not want to filter there.
          numPasses[P::amrMaxSpatialRefLevel] = 0;
@@ -834,7 +835,7 @@ void Parameters::getParameters() {
    for (size_t s = 0; s < P::systemWriteName.size(); ++s) {
       P::systemWrites.push_back(0);
    }
-   
+
    RP::get("fieldtracing.fieldLineTracer", tracerString);
    RP::get("fieldtracing.tracer_max_allowed_error", FieldTracing::fieldTracingParameters.max_allowed_error);
    RP::get("fieldtracing.tracer_max_attempts", FieldTracing::fieldTracingParameters.max_field_tracer_attempts);
@@ -844,7 +845,7 @@ void Parameters::getParameters() {
    RP::get("fieldtracing.use_reconstruction_cache", FieldTracing::fieldTracingParameters.useCache);
    RP::get("fieldtracing.fluxrope_max_curvature_radii_to_trace", FieldTracing::fieldTracingParameters.fluxrope_max_curvature_radii_to_trace);
    RP::get("fieldtracing.fluxrope_max_curvature_radii_extent", FieldTracing::fieldTracingParameters.fluxrope_max_curvature_radii_extent);
-   
+
    if(tracerString == "Euler") {
       FieldTracing::fieldTracingParameters.tracingMethod = FieldTracing::Euler;
    } else if (tracerString == "ADPT_Euler") {

--- a/testpackage/tests/Flowthrough_trans_periodic/Flowthrough_trans_periodic.cfg
+++ b/testpackage/tests/Flowthrough_trans_periodic/Flowthrough_trans_periodic.cfg
@@ -26,7 +26,7 @@ output = populations_vg_v
 output = vg_boundarytype
 output = vg_rank
 output = populations_vg_blocks
-output = populations_vg_blocks
+output = populations_vg_nonmaxwellianity
 diagnostic = populations_vg_blocks
 
 [gridbuilder]


### PR DESCRIPTION
Originally coded by Vertti Tarvus. Used in the KHI runs and foreshock bubble run. The test for nonMaxwellianity output remains a future work.

The format changes are all about removing whitespaces.