### PR TITLE
Remove unneeded include of boost/lexical_cast in readparameters.

### DIFF
--- a/readparameters.h
+++ b/readparameters.h
@@ -23,7 +23,6 @@
 #ifndef READPARAMETERS_H
 #define READPARAMETERS_H
 
-#include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
 #include <fstream>
 #include <iomanip>


### PR DESCRIPTION
This must have been some leftover from the past. Anyway, it's good to reduce unneccessary dependencies.
(I actually found this when I tried to compile on my phone, it broke on all boost includes and I removed them one-by-one, until I noticed that I actually simply hadn't installed any boost package yet)