### PR TITLE
Remove an unused variable from cpu_acc_map

### DIFF
--- a/vlasovsolver/cpu_acc_map.cpp
+++ b/vlasovsolver/cpu_acc_map.cpp
@@ -434,10 +434,6 @@ bool map_1d(SpatialCell* spatial_cell,
                i_indices * cell_indices_to_id[0] +
                j_indices * cell_indices_to_id[1];
        
-            const int target_block_index_common =
-               block_indices_begin[0] * block_indices_to_id[0] +
-               block_indices_begin[1] * block_indices_to_id[1];
-       
             /* 
                intersection_min is the intersection z coordinate (z after
                swaps that is) of the lowest possible z plane for each i,j
@@ -526,8 +522,6 @@ bool map_1d(SpatialCell* spatial_cell,
                   const int blockK = gk/WID;
                   const int gk_mod_WID = (gk - blockK * WID);
 
-                  //the block of the Lagrangian cell to which we map
-                  //const int target_block(target_block_index_common + blockK * block_indices_to_id[2]);
                   
                   //cell indices in the target block  (TODO: to be replaced by
                   //compile time generated scatter write operation)


### PR DESCRIPTION
This PR is part of my "remove one compiler warning per day"-initiative