### PR TITLE
Remove two unused variables from vlasovmover.cpp

### DIFF
--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -78,7 +78,6 @@ void calculateSpatialTranslation(
 ) {
 
     int trans_timer;
-    bool localTargetGridGenerated = false;
     bool AMRtranslationActive = false;
     if (P::amrMaxSpatialRefLevel > 0) AMRtranslationActive = true;
 
@@ -260,7 +259,7 @@ void calculateSpatialTranslation(
    
    phiprof::start("semilag-trans");
    
-   double t1 = MPI_Wtime();
+   //double t1 = MPI_Wtime();
 
    const vector<CellID>& localCells = getLocalCells();
    vector<CellID> remoteTargetCellsx;


### PR DESCRIPTION
(One is commented out, because some other commented-out timing code
 might depend on it)

This PR is part of my "remove one compiler warning per day" initiative