### PR TITLE
Update PAPI github url in CI build script.

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -58,7 +58,7 @@ jobs:
           cp version1/*.h $GITHUB_WORKSPACE/libraries/include
       - name: Build papi
         run: |
-          git clone https://bitbucket.org/icl/papi.git
+          git clone https://github.com/icl-utk-edu/papi
           cd papi/src
           ./configure --prefix=$GITHUB_WORKSPACE/libraries && make -j 4 CC=gcc && make install
           cd ../..


### PR DESCRIPTION
Since the old repository is now empty, this was breaking the CI build process.