### PR TITLE
Enable compiler autovectorization diagnostics in CI.

### DIFF
--- a/MAKE/Makefile.github_actions
+++ b/MAKE/Makefile.github_actions
@@ -47,7 +47,7 @@ CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 #                         mpi.h in c++ on Cray
 
 FLAGS =
-CXXFLAGS += -I ${GITHUB_WORKSPACE}/libraries/include -I/usr/include/eigen3 -L ${GITHUB_WORKSPACE}/libraries/lib -march=native -O3 -std=c++17 -fopenmp -Wall -Wno-unused -fabi-version=0 -mavx -g -Wno-cast-function-type
+CXXFLAGS += -I ${GITHUB_WORKSPACE}/libraries/include -I/usr/include/eigen3 -L ${GITHUB_WORKSPACE}/libraries/lib -march=native -O3 -std=c++17 -fopenmp -Wall -Wno-unused -fabi-version=0 -mavx -g -Wno-cast-function-type -fopt-info-missed-vec -fopt-info-vec
 MATHFLAGS = #-ffast-math
 LDFLAGS = -L ${GITHUB_WORKSPACE}/libraries/lib -Wl,-rpath=${GITHUB_WORKSPACE}/libraries/lib -g
 LIB_MPI = -lgomp 


### PR DESCRIPTION
This PR is mostly to check whether the resulting flood of compiling outputs shows anything reasonable in the check annotations.