### PR TITLE
Fix (potentially) uninitialized return value warning in setbyuser.

### DIFF
--- a/sysboundary/setbyuser.cpp
+++ b/sysboundary/setbyuser.cpp
@@ -388,7 +388,7 @@ namespace SBC {
          vector<Real> tempData;
          for (uint i=0; i<nParams; i++) {
             Real readParam;
-            int ret;
+            int ret = 0;
             if ( typeid( readParam ) == typeid(double) ) {
                ret = fscanf(fp,"%lf",&readParam);
             } else if( typeid( readParam ) == typeid(float) ) {


### PR DESCRIPTION
Found by clang's warnings output.

This PR is part of my "remove one compiler warning per day" initiative (which is starting to come to the end of its low-hanging-fruit stage).