### PR TITLE
Bailout when fg cells are not cubic

### DIFF
--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -419,14 +419,16 @@ int main(int argn,char* args[]) {
       = {P::xmin, P::ymin, P::zmin};
 
    // Checking that spatial cells are cubic, otherwise field solver is incorrect (cf. derivatives in E, Hall term)
-   if ((abs((technicalGrid.DX - technicalGrid.DY) / technicalGrid.DX) > 0.001) ||
-       (abs((technicalGrid.DX - technicalGrid.DZ) / technicalGrid.DX) > 0.001) ||
-       (abs((technicalGrid.DY - technicalGrid.DZ) / technicalGrid.DY) > 0.001)) {
+   if ((abs((technicalGrid.DX - technicalGrid.DY) / technicalGrid.DX) >1e-3) ||
+       (abs((technicalGrid.DX - technicalGrid.DZ) / technicalGrid.DX) >1e-3) ||
+       (abs((technicalGrid.DY - technicalGrid.DZ) / technicalGrid.DY) >1e-3)) {
       if (myRank == MASTER_RANK) {
          std::cerr << "WARNING: Your spatial cells seem not to be cubic. However the field solver is assuming them to "
                       "be. Use at your own risk and responsibility!"
                    << std::endl;
       }
+      //Let's bailout if FsGrid cells are not cubic;
+      bailout(true,"Non-cubic FsGrid Cells. Check your cfg file!",__FILE__,__LINE__);
    }
    phiprof::stop("Init fieldsolver grids");
 


### PR DESCRIPTION
One way to not continue the run when fsgrid cells are not cubic.