### PR TITLE
Remove projections from ionosphere and conductingsphere perturbed B computations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ DEPS_VLSVMOVER_VAMR = vlasovsolver_amr/vlasovmover.cpp vlasovsolver_amr/cpu_acc_
 
 OBJS = 	version.o memoryallocation.o backgroundfield.o quadr.o dipole.o linedipole.o vectordipole.o constantfield.o integratefunction.o \
 	datareducer.o datareductionoperator.o dro_populations.o vamr_refinement_criteria.o\
-	donotcompute.o ionosphere.o conductingsphere.o outflow.o setbyuser.o setmaxwellian.o\
+	donotcompute.o ionosphere.o copysphere.o outflow.o setbyuser.o setmaxwellian.o\
 	fieldtracing.o \
 	sysboundary.o sysboundarycondition.o particle_species.o\
 	project.o projectTriAxisSearch.o read_gaussian_population.o\

--- a/common.h
+++ b/common.h
@@ -446,7 +446,7 @@ namespace sysboundarytype {
       IONOSPHERE,       /*!< Ionospheric current model */
       OUTFLOW,          /*!< No fixed conditions on the fields and distribution function. */
       SET_MAXWELLIAN,   /*!< Set Maxwellian boundary condition, i.e. set fields and distribution function. */
-      CONDUCTINGSPHERE, /*!< A perfectly conducting sphere as the simple inner boundary */
+      COPYSPHERE,       /*!< A sphere with copy-condition for perturbed B as the simple inner boundary */
       N_SYSBOUNDARY_CONDITIONS
    };
 }

--- a/fieldsolver/ldz_magnetic_field.cpp
+++ b/fieldsolver/ldz_magnetic_field.cpp
@@ -192,36 +192,6 @@ void propagateSysBoundaryMagneticField(
    }
 }
 
-/*! \brief Low-level magnetic field projection function.
- *
- * Projects the magnetic field according to the system boundary conditions.
- *
- * \param perBGrid fsGrid holding the perturbed B quantities at runge-kutta t=0
- * \param perBDt2Grid fsGrid holding the perturbed B quantities at runge-kutta t=0.5
- * \param technicalGrid fsGrid holding technical information (such as boundary types)
- * \param i,j,k fsGrid cell coordinates for the current cell
- * \param sysBoundaries System boundary conditions existing
- * \param RKCase Element in the enum defining the Runge-Kutta method steps
- *
- * \sa propagateMagneticFieldSimple propagateMagneticField
- */
-void SysBoundaryMagneticFieldProjection(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-   cint i,
-   cint j,
-   cint k,
-   SysBoundary& sysBoundaries,
-   cint& RKCase
-) {
-   if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-      sysBoundaries.getSysBoundary(technicalGrid.get(i,j,k)->sysBoundaryFlag)->fieldSolverBoundaryCondMagneticFieldProjection(perBGrid, technicalGrid, i, j, k);
-   } else {
-      sysBoundaries.getSysBoundary(technicalGrid.get(i,j,k)->sysBoundaryFlag)->fieldSolverBoundaryCondMagneticFieldProjection(perBDt2Grid, technicalGrid, i, j, k);
-   }
-}
-
 /*! \brief High-level magnetic field propagation function.
  * 
  * Propagates the magnetic field and applies the field boundary conditions defined in project.h where needed.
@@ -335,24 +305,6 @@ void propagateMagneticFieldSimple(
                for (uint component = 0; component < 3; component++) {
                   propagateSysBoundaryMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, technicalGrid, i, j, k, sysBoundaries, dt, RKCase, component);
                }
-            }
-         }
-      }
-   }
-   phiprof::stop(timer,N_cells,"Spatial Cells");
-
-   // Projection of magnetic field to normal of boundary, if necessary
-   timer=phiprof::initializeTimer("Compute system boundary cells");
-   phiprof::start(timer);
-   #pragma omp parallel for collapse(3)
-   for (int k=0; k<gridDims[2]; k++) {
-      for (int j=0; j<gridDims[1]; j++) {
-         for (int i=0; i<gridDims[0]; i++) {
-            if (technicalGrid.get(i,j,k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY &&
-                ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
-                 (technicalGrid.get(i,j,k)->sysBoundaryLayer == 1))
-               ) {
-               SysBoundaryMagneticFieldProjection(perBGrid, perBDt2Grid, technicalGrid, i, j, k, sysBoundaries, RKCase);
             }
          }
       }

--- a/mini-apps/ionosphereSolverTests/Makefile
+++ b/mini-apps/ionosphereSolverTests/Makefile
@@ -18,7 +18,7 @@ clean:
 ionosphere.o: ../../sysboundary/ionosphere.h ../../sysboundary/ionosphere.cpp ../../backgroundfield/backgroundfield.h ../../projects/project.h
 	${CMP} ${CXXFLAGS} ${FLAGS} ${MATHFLAGS} -c ../../sysboundary/ionosphere.cpp ${INC_DCCRG} ${INC_FSGRID} ${INC_ZOLTAN} ${INC_BOOST} ${INC_EIGEN} ${INC_VECTORCLASS} ${INC_PROFILE} ${INC_JEMALLOC} -Wno-comment
 
-sysboundarycondition.o: ../../sysboundary/sysboundarycondition.h ../../sysboundary/sysboundarycondition.cpp ../../sysboundary/donotcompute.h ../../sysboundary/donotcompute.cpp ../../sysboundary/ionosphere.h ../../sysboundary/ionosphere.cpp ../../sysboundary/conductingsphere.h ../../sysboundary/conductingsphere.cpp ../../sysboundary/outflow.h ../../sysboundary/outflow.cpp ../../sysboundary/setmaxwellian.h ../../sysboundary/setmaxwellian.cpp ../../sysboundary/setbyuser.h ../../sysboundary/setbyuser.cpp
+sysboundarycondition.o: ../../sysboundary/sysboundarycondition.h ../../sysboundary/sysboundarycondition.cpp ../../sysboundary/donotcompute.h ../../sysboundary/donotcompute.cpp ../../sysboundary/ionosphere.h ../../sysboundary/ionosphere.cpp ../../sysboundary/copysphere.h ../../sysboundary/copysphere.cpp ../../sysboundary/outflow.h ../../sysboundary/outflow.cpp ../../sysboundary/setmaxwellian.h ../../sysboundary/setmaxwellian.cpp ../../sysboundary/setbyuser.h ../../sysboundary/setbyuser.cpp
 	${CMP} ${CXXFLAGS} ${FLAGS} ${MATHFLAGS} -c ../../sysboundary/sysboundarycondition.cpp ${INC_DCCRG} ${INC_FSGRID} ${INC_ZOLTAN} ${INC_BOOST} ${INC_EIGEN} ${INC_PROFILE} ${INC_JEMALLOC}
 
 parameters.o: ../../parameters.h ../../parameters.cpp ../../readparameters.h

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -119,13 +119,13 @@ namespace projects {
 
       RP::get("Magnetosphere.dipoleType", this->dipoleType);
 
-      /** Read inner boundary parameters from either ionospheric or conductingsphere sysboundary condition */
-      if (sysBoundaryContainer.existSysBoundary("Conductingsphere")) {
-         RP::get("conductingsphere.radius", this->ionosphereRadius);
-         RP::get("conductingsphere.centerX", this->center[0]);
-         RP::get("conductingsphere.centerY", this->center[1]);
-         RP::get("conductingsphere.centerZ", this->center[2]);
-         RP::get("conductingsphere.geometry", this->ionosphereGeometry);
+      /** Read inner boundary parameters from either ionospheric or copysphere sysboundary condition */
+      if (sysBoundaryContainer.existSysBoundary("Copysphere")) {
+         RP::get("copysphere.radius", this->ionosphereRadius);
+         RP::get("copysphere.centerX", this->center[0]);
+         RP::get("copysphere.centerY", this->center[1]);
+         RP::get("copysphere.centerZ", this->center[2]);
+         RP::get("copysphere.geometry", this->ionosphereGeometry);
       } else if (sysBoundaryContainer.existSysBoundary("Ionosphere")) {
          RP::get("ionosphere.radius", this->ionosphereRadius);
          RP::get("ionosphere.centerX", this->center[0]);
@@ -134,7 +134,7 @@ namespace projects {
          RP::get("ionosphere.geometry", this->ionosphereGeometry);
       } else {
          if(myRank == MASTER_RANK) {
-            std::cerr<<"Warning in initializing Magnetosphere: Could not find inner boundary (ionosphere or conductingsphere)!"<<std::endl;
+            std::cerr<<"Warning in initializing Magnetosphere: Could not find inner boundary (ionosphere or copysphere)!"<<std::endl;
          }
       }
       if(ionosphereRadius < 1000.) {
@@ -183,13 +183,13 @@ namespace projects {
          RP::get(pop + "_Magnetosphere.nSpaceSamples", sP.nSpaceSamples);
          RP::get(pop + "_Magnetosphere.nVelocitySamples", sP.nVelocitySamples);
 
-         /** Read inner boundary parameters from either ionospheric or conductingsphere sysboundary condition */
-         if (sysBoundaryContainer.existSysBoundary("Conductingsphere")) {
-            RP::get(pop + "_conductingsphere.rho", sP.ionosphereRho);
-            RP::get(pop + "_conductingsphere.T", sP.ionosphereT);
-            RP::get(pop + "_conductingsphere.VX0", sP.ionosphereV0[0]);
-            RP::get(pop + "_conductingsphere.VY0", sP.ionosphereV0[1]);
-            RP::get(pop + "_conductingsphere.VZ0", sP.ionosphereV0[2]);
+         /** Read inner boundary parameters from either ionospheric or copysphere sysboundary condition */
+         if (sysBoundaryContainer.existSysBoundary("Copysphere")) {
+            RP::get(pop + "_copysphere.rho", sP.ionosphereRho);
+            RP::get(pop + "_copysphere.T", sP.ionosphereT);
+            RP::get(pop + "_copysphere.VX0", sP.ionosphereV0[0]);
+            RP::get(pop + "_copysphere.VY0", sP.ionosphereV0[1]);
+            RP::get(pop + "_copysphere.VZ0", sP.ionosphereV0[2]);
          } else if (sysBoundaryContainer.existSysBoundary("Ionosphere")) {
             RP::get(pop + "_ionosphere.rho", sP.ionosphereRho);
             RP::get(pop + "_ionosphere.T", sP.ionosphereT);
@@ -215,20 +215,20 @@ namespace projects {
          }
          if(sP.taperOuterRadius > 0 && sP.taperOuterRadius <= this->ionosphereRadius) {
             if(myRank == MASTER_RANK) {
-               cerr << "Error: " << pop << "_Magnetosphere.taperOuterRadius is non-zero yet smaller than ionosphere.radius / conductingsphere.radius! Aborting." << endl;
+               cerr << "Error: " << pop << "_Magnetosphere.taperOuterRadius is non-zero yet smaller than ionosphere.radius / copysphere.radius! Aborting." << endl;
             }
             abort();
          }
          if(sP.taperInnerRadius == 0 && sP.taperOuterRadius > 0) {
             if(myRank == MASTER_RANK) {
-               cerr << "Warning: " << pop << "_Magnetosphere.taperInnerRadius is zero (default), now setting this to the same value as ionosphere.radius / conductingsphere.radius, that is " << this->ionosphereRadius << ". Set/change " << pop << "_Magnetosphere.taperInnerRadius if this is not the expected behavior." << endl;
+               cerr << "Warning: " << pop << "_Magnetosphere.taperInnerRadius is zero (default), now setting this to the same value as ionosphere.radius / copysphere.radius, that is " << this->ionosphereRadius << ". Set/change " << pop << "_Magnetosphere.taperInnerRadius if this is not the expected behavior." << endl;
             }
             sP.taperInnerRadius = this->ionosphereRadius;
          }
          if(sP.ionosphereT == 0) {
             if(myRank == MASTER_RANK) {
-               if (sysBoundaryContainer.existSysBoundary("Conductingsphere")) {
-                  cerr << "Warning: " << pop << "_conductingsphere.T is zero (default), now setting to the same value as " << pop << "_Magnetosphere.T, that is " << sP.T << ". Set/change " << pop << "_conductingsphere.T if this is not the expected behavior." << endl;
+               if (sysBoundaryContainer.existSysBoundary("Copysphere")) {
+                  cerr << "Warning: " << pop << "_copysphere.T is zero (default), now setting to the same value as " << pop << "_Magnetosphere.T, that is " << sP.T << ". Set/change " << pop << "_copysphere.T if this is not the expected behavior." << endl;
                } else if (sysBoundaryContainer.existSysBoundary("Ionosphere")) {
                   cerr << "Warning: " << pop << "_ionosphere.T is zero (default), now setting to the same value as " << pop << "_Magnetosphere.T, that is " << sP.T << ". Set/change " << pop << "_ionosphere.T if this is not the expected behavior." << endl;
                }
@@ -237,8 +237,8 @@ namespace projects {
          }
          if(sP.ionosphereRho == 0) {
             if(myRank == MASTER_RANK) {
-               if (sysBoundaryContainer.existSysBoundary("Conductingsphere")) {
-                  cerr << "Warning: " << pop << "_conductingsphere.rho is zero (default), now setting to the same value as " << pop << "_Magnetosphere.rho, that is " << sP.rho << ". Set/change " << pop << "_conductingsphere.rho if this is not the expected behavior." << endl;
+               if (sysBoundaryContainer.existSysBoundary("Copysphere")) {
+                  cerr << "Warning: " << pop << "_copysphere.rho is zero (default), now setting to the same value as " << pop << "_Magnetosphere.rho, that is " << sP.rho << ". Set/change " << pop << "_copysphere.rho if this is not the expected behavior." << endl;
                } else if (sysBoundaryContainer.existSysBoundary("Ionosphere")) {
                   cerr << "Warning: " << pop << "_ionosphere.rho is zero (default), now setting to the same value as " << pop << "_Magnetosphere.rho, that is " << sP.rho << ". Set/change " << pop << "_ionosphere.rho if this is not the expected behavior." << endl;
                }

--- a/samples/Magnetosphere3D/Magnetosphere3D.cfg
+++ b/samples/Magnetosphere3D/Magnetosphere3D.cfg
@@ -99,7 +99,7 @@ refine_L3tailwidth = 8.0e7
 refine_L3tailxmin = -30.0e7
 refine_L3tailxmax = -5.0e7
 
-[conductingsphere]
+[copysphere]
 centerX = 0.0
 centerY = 0.0
 centerZ = 0.0
@@ -121,7 +121,7 @@ taperOuterRadius = 1e8
 nSpaceSamples = 1
 nVelocitySamples = 1
 
-[proton_conductingsphere]
+[proton_copysphere]
 # increased temperature and density close to inner boundary to add load balance challenge
 T = 1.5e6
 rho = 3.0e6
@@ -179,7 +179,7 @@ periodic_y = no
 periodic_z = no
 boundary = Outflow
 boundary = Maxwellian
-boundary = Conductingsphere
+boundary = Copysphere
 
 [outflow]
 precedence = 3

--- a/sysboundary/conductingsphere.cpp
+++ b/sysboundary/conductingsphere.cpp
@@ -664,28 +664,6 @@ namespace SBC {
       cint j,
       cint k
    ) {
-      // Projection of B-field to normal direction
-      Real BdotN = 0;
-      std::array<Real, 3> normalDirection = fieldSolverGetNormalDirection(technicalGrid, i, j, k);
-      for(uint component=0; component<3; component++) {
-         BdotN += bGrid.get(i,j,k)->at(fsgrids::bfield::PERBX+component) * normalDirection[component];
-      }
-      // Apply to any components that were not solved
-      if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
-          ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BX) != compute::BX))
-         ) {
-         bGrid.get(i,j,k)->at(fsgrids::bfield::PERBX) = BdotN*normalDirection[0];
-      }
-      if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
-          ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BY) != compute::BY))
-         ) {
-         bGrid.get(i,j,k)->at(fsgrids::bfield::PERBY) = BdotN*normalDirection[1];
-      }
-      if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
-          ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BZ) != compute::BZ))
-         ) {
-         bGrid.get(i,j,k)->at(fsgrids::bfield::PERBZ) = BdotN*normalDirection[2];
-      }
    }
 
    void Conductingsphere::fieldSolverBoundaryCondElectricField(

--- a/sysboundary/conductingsphere.cpp
+++ b/sysboundary/conductingsphere.cpp
@@ -653,19 +653,6 @@ namespace SBC {
       }
    }
 
-   /*! We want here to
-    *
-    * -- Retain only the boundary-normal projection of perturbed face B
-    */
-   void Conductingsphere::fieldSolverBoundaryCondMagneticFieldProjection(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      cint i,
-      cint j,
-      cint k
-   ) {
-   }
-
    void Conductingsphere::fieldSolverBoundaryCondElectricField(
       FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
       cint i,

--- a/sysboundary/conductingsphere.h
+++ b/sysboundary/conductingsphere.h
@@ -83,13 +83,6 @@ namespace SBC {
          creal& dt,
          cuint& component
       );
-      virtual void fieldSolverBoundaryCondMagneticFieldProjection(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-         cint i,
-         cint j,
-         cint k
-      );
       virtual void fieldSolverBoundaryCondElectricField(
          FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
          cint i,

--- a/sysboundary/copysphere.cpp
+++ b/sysboundary/copysphere.cpp
@@ -20,14 +20,14 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-/*!\file conductingsphere.cpp
- * \brief Implementation of the class SysBoundaryCondition::Conductingsphere to handle cells classified as sysboundarytype::CONDUCTINGSPHERE.
+/*!\file copysphere.cpp
+ * \brief Implementation of the class SysBoundaryCondition::Copysphere to handle cells classified as sysboundarytype::COPYSPHERE.
  */
 
 #include <cstdlib>
 #include <iostream>
 
-#include "conductingsphere.h"
+#include "copysphere.h"
 #include "../projects/project.h"
 #include "../projects/projects_common.h"
 #include "../vlasovmover.h"
@@ -40,50 +40,50 @@
 
 
 #ifndef NDEBUG
-   #define DEBUG_CONDUCTINGSPHERE
+   #define DEBUG_COPYSPHERE
 #endif
 #ifdef DEBUG_SYSBOUNDARY
-   #define DEBUG_CONDUCTINGSPHERE
+   #define DEBUG_COPYSPHERE
 #endif
 
 namespace SBC {
-   Conductingsphere::Conductingsphere(): SysBoundaryCondition() { }
+   Copysphere::Copysphere(): SysBoundaryCondition() { }
    
-   Conductingsphere::~Conductingsphere() { }
+   Copysphere::~Copysphere() { }
    
-   void Conductingsphere::addParameters() {
-      Readparameters::add("conductingsphere.centerX", "X coordinate of conductingsphere center (m)", 0.0);
-      Readparameters::add("conductingsphere.centerY", "Y coordinate of conductingsphere center (m)", 0.0);
-      Readparameters::add("conductingsphere.centerZ", "Z coordinate of conductingsphere center (m)", 0.0);
-      Readparameters::add("conductingsphere.radius", "Radius of conductingsphere (m).", 1.0e7);
-      Readparameters::add("conductingsphere.geometry", "Select the geometry of the conductingsphere, 0: inf-norm (diamond), 1: 1-norm (square), 2: 2-norm (circle, DEFAULT), 3: 2-norm cylinder aligned with y-axis, use with polar plane/line dipole.", 2);
-      Readparameters::add("conductingsphere.precedence", "Precedence value of the conductingsphere system boundary condition (integer), the higher the stronger.", 2);
-      Readparameters::add("conductingsphere.reapplyUponRestart", "If 0 (default), keep going with the state existing in the restart file. If 1, calls again applyInitialState. Can be used to change boundary condition behaviour during a run.", 0);
+   void Copysphere::addParameters() {
+      Readparameters::add("copysphere.centerX", "X coordinate of copysphere center (m)", 0.0);
+      Readparameters::add("copysphere.centerY", "Y coordinate of copysphere center (m)", 0.0);
+      Readparameters::add("copysphere.centerZ", "Z coordinate of copysphere center (m)", 0.0);
+      Readparameters::add("copysphere.radius", "Radius of copysphere (m).", 1.0e7);
+      Readparameters::add("copysphere.geometry", "Select the geometry of the copysphere, 0: inf-norm (diamond), 1: 1-norm (square), 2: 2-norm (circle, DEFAULT), 3: 2-norm cylinder aligned with y-axis, use with polar plane/line dipole.", 2);
+      Readparameters::add("copysphere.precedence", "Precedence value of the copysphere system boundary condition (integer), the higher the stronger.", 2);
+      Readparameters::add("copysphere.reapplyUponRestart", "If 0 (default), keep going with the state existing in the restart file. If 1, calls again applyInitialState. Can be used to change boundary condition behaviour during a run.", 0);
 
       // Per-population parameters
       for(uint i=0; i< getObjectWrapper().particleSpecies.size(); i++) {
          const std::string& pop = getObjectWrapper().particleSpecies[i].name;
          
-         Readparameters::add(pop + "_conductingsphere.rho", "Number density of the conductingsphere (m^-3)", 0.0);
-         Readparameters::add(pop + "_conductingsphere.T", "Temperature of the conductingsphere (K)", 0.0);
-         Readparameters::add(pop + "_conductingsphere.VX0", "Bulk velocity of conductospheric distribution function in X direction (m/s)", 0.0);
-         Readparameters::add(pop + "_conductingsphere.VY0", "Bulk velocity of conductospheric distribution function in X direction (m/s)", 0.0);
-         Readparameters::add(pop + "_conductingsphere.VZ0", "Bulk velocity of conductospheric distribution function in X direction (m/s)", 0.0);
-         Readparameters::add(pop + "_conductingsphere.fluffiness", "Inertia of boundary smoothing when copying neighbour's moments and velocity distributions (0=completely constant boundaries, 1=neighbours are interpolated immediately).", 0);
+         Readparameters::add(pop + "_copysphere.rho", "Number density of the copysphere (m^-3)", 0.0);
+         Readparameters::add(pop + "_copysphere.T", "Temperature of the copysphere (K)", 0.0);
+         Readparameters::add(pop + "_copysphere.VX0", "Bulk velocity of conductospheric distribution function in X direction (m/s)", 0.0);
+         Readparameters::add(pop + "_copysphere.VY0", "Bulk velocity of conductospheric distribution function in X direction (m/s)", 0.0);
+         Readparameters::add(pop + "_copysphere.VZ0", "Bulk velocity of conductospheric distribution function in X direction (m/s)", 0.0);
+         Readparameters::add(pop + "_copysphere.fluffiness", "Inertia of boundary smoothing when copying neighbour's moments and velocity distributions (0=completely constant boundaries, 1=neighbours are interpolated immediately).", 0);
       }
    }
    
-   void Conductingsphere::getParameters() {
+   void Copysphere::getParameters() {
 
-      Readparameters::get("conductingsphere.centerX", this->center[0]);
-      Readparameters::get("conductingsphere.centerY", this->center[1]);
-      Readparameters::get("conductingsphere.centerZ", this->center[2]);
-      Readparameters::get("conductingsphere.radius", this->radius);
+      Readparameters::get("copysphere.centerX", this->center[0]);
+      Readparameters::get("copysphere.centerY", this->center[1]);
+      Readparameters::get("copysphere.centerZ", this->center[2]);
+      Readparameters::get("copysphere.radius", this->radius);
       FieldTracing::fieldTracingParameters.innerBoundaryRadius = this->radius;
-      Readparameters::get("conductingsphere.geometry", this->geometry);
-      Readparameters::get("conductingsphere.precedence", this->precedence);
+      Readparameters::get("copysphere.geometry", this->geometry);
+      Readparameters::get("copysphere.precedence", this->precedence);
       uint reapply;
-      Readparameters::get("conductingsphere.reapplyUponRestart",reapply);
+      Readparameters::get("copysphere.reapplyUponRestart",reapply);
       this->applyUponRestart = false;
       if(reapply == 1) {
          this->applyUponRestart = true;
@@ -91,14 +91,14 @@ namespace SBC {
 
       for(uint i=0; i< getObjectWrapper().particleSpecies.size(); i++) {
         const std::string& pop = getObjectWrapper().particleSpecies[i].name;
-        ConductingsphereSpeciesParameters sP;
+        CopysphereSpeciesParameters sP;
 
-        Readparameters::get(pop + "_conductingsphere.rho", sP.rho);
-        Readparameters::get(pop + "_conductingsphere.VX0", sP.V0[0]);
-        Readparameters::get(pop + "_conductingsphere.VY0", sP.V0[1]);
-        Readparameters::get(pop + "_conductingsphere.VZ0", sP.V0[2]);
-        Readparameters::get(pop + "_conductingsphere.fluffiness", sP.fluffiness);
-        Readparameters::get(pop + "_conductingsphere.T", sP.T);
+        Readparameters::get(pop + "_copysphere.rho", sP.rho);
+        Readparameters::get(pop + "_copysphere.VX0", sP.V0[0]);
+        Readparameters::get(pop + "_copysphere.VY0", sP.V0[1]);
+        Readparameters::get(pop + "_copysphere.VZ0", sP.V0[2]);
+        Readparameters::get(pop + "_copysphere.fluffiness", sP.fluffiness);
+        Readparameters::get(pop + "_copysphere.T", sP.T);
         Readparameters::get(pop + "_Magnetosphere.nSpaceSamples", sP.nSpaceSamples);
         Readparameters::get(pop + "_Magnetosphere.nVelocitySamples", sP.nVelocitySamples);
 
@@ -115,7 +115,7 @@ namespace SBC {
       }
    }
    
-   bool Conductingsphere::initSysBoundary(
+   bool Copysphere::initSysBoundary(
       creal& t,
       Project &project
    ) {
@@ -151,14 +151,14 @@ namespace SBC {
          r = sqrt((x-center[0])*(x-center[0]) + (z-center[2])*(z-center[2]));
          break;
       default:
-         std::cerr << __FILE__ << ":" << __LINE__ << ":" << "conductingsphere.geometry has to be 0, 1 or 2." << std::endl;
+         std::cerr << __FILE__ << ":" << __LINE__ << ":" << "copysphere.geometry has to be 0, 1 or 2." << std::endl;
          abort();
       }
 
       return r;
    }
    
-   bool Conductingsphere::assignSysBoundary(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
+   bool Copysphere::assignSysBoundary(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                                       FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid) {
       const vector<CellID>& cells = getLocalCells();
       for(uint i=0; i<cells.size(); i++) {
@@ -182,7 +182,7 @@ namespace SBC {
       return true;
    }
 
-   bool Conductingsphere::applyInitialState(
+   bool Copysphere::applyInitialState(
       const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
       FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
@@ -200,13 +200,13 @@ namespace SBC {
       return true;
    }
 
-   std::array<Real, 3> Conductingsphere::fieldSolverGetNormalDirection(
+   std::array<Real, 3> Copysphere::fieldSolverGetNormalDirection(
       FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
       cint i,
       cint j,
       cint k
    ) {
-      phiprof::start("Conductingsphere::fieldSolverGetNormalDirection");
+      phiprof::start("Copysphere::fieldSolverGetNormalDirection");
       std::array<Real, 3> normalDirection{{ 0.0, 0.0, 0.0 }};
       
       static creal DIAG2 = 1.0 / sqrt(2.0);
@@ -229,7 +229,7 @@ namespace SBC {
          if (Parameters::ycells_ini == 1) {
             if (Parameters::zcells_ini == 1) {
                // X,Y,Z
-               std::cerr << __FILE__ << ":" << __LINE__ << ":" << "What do you expect to do with a single-cell simulation of conductingsphere boundary type? Stop kidding." << std::endl;
+               std::cerr << __FILE__ << ":" << __LINE__ << ":" << "What do you expect to do with a single-cell simulation of copysphere boundary type? Stop kidding." << std::endl;
                abort();
                // end of X,Y,Z
             } else {
@@ -277,7 +277,7 @@ namespace SBC {
                   normalDirection[2] = z / length;
                   break;
                default:
-                  std::cerr << __FILE__ << ":" << __LINE__ << ":" << "conductingsphere.geometry has to be 0, 1 or 2 with this grid shape." << std::endl;
+                  std::cerr << __FILE__ << ":" << __LINE__ << ":" << "copysphere.geometry has to be 0, 1 or 2 with this grid shape." << std::endl;
                   abort();
             }
             // end of X
@@ -324,7 +324,7 @@ namespace SBC {
                   normalDirection[2] = z / length;
                   break;
                default:
-                  std::cerr << __FILE__ << ":" << __LINE__ << ":" << "conductingsphere.geometry has to be 0, 1, 2 or 3 with this grid shape." << std::endl;
+                  std::cerr << __FILE__ << ":" << __LINE__ << ":" << "copysphere.geometry has to be 0, 1, 2 or 3 with this grid shape." << std::endl;
                   abort();
             }
             // end of Y
@@ -365,7 +365,7 @@ namespace SBC {
                normalDirection[1] = y / length;
                break;
             default:
-               std::cerr << __FILE__ << ":" << __LINE__ << ":" << "conductingsphere.geometry has to be 0, 1 or 2 with this grid shape." << std::endl;
+               std::cerr << __FILE__ << ":" << __LINE__ << ":" << "copysphere.geometry has to be 0, 1 or 2 with this grid shape." << std::endl;
                abort();
          }
          // end of Z
@@ -463,13 +463,13 @@ namespace SBC {
                normalDirection[2] = z / length;
                break;
             default:
-               std::cerr << __FILE__ << ":" << __LINE__ << ":" << "conductingsphere.geometry has to be 0, 1, 2 or 3 with this grid shape." << std::endl;
+               std::cerr << __FILE__ << ":" << __LINE__ << ":" << "copysphere.geometry has to be 0, 1, 2 or 3 with this grid shape." << std::endl;
                abort();
          }
          // end of 3D
       }
       
-      phiprof::stop("Conductingsphere::fieldSolverGetNormalDirection");
+      phiprof::stop("Copysphere::fieldSolverGetNormalDirection");
       return normalDirection;
    }
    
@@ -479,7 +479,7 @@ namespace SBC {
     * 
     * -- Retain only the normal components of perturbed face B
     */
-   Real Conductingsphere::fieldSolverBoundaryCondMagneticField(
+   Real Copysphere::fieldSolverBoundaryCondMagneticField(
       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
       FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
       cint i,
@@ -629,7 +629,7 @@ namespace SBC {
                   return retval / nCells;
                }
             default:
-               cerr << "ERROR: conductingsphere boundary tried to copy nonsensical magnetic field component " << component << endl;
+               cerr << "ERROR: copysphere boundary tried to copy nonsensical magnetic field component " << component << endl;
                return 0.0;
          }
       } else { // L2 cells
@@ -653,7 +653,7 @@ namespace SBC {
       }
    }
 
-   void Conductingsphere::fieldSolverBoundaryCondElectricField(
+   void Copysphere::fieldSolverBoundaryCondElectricField(
       FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
       cint i,
       cint j,
@@ -663,7 +663,7 @@ namespace SBC {
       EGrid.get(i,j,k)->at(fsgrids::efield::EX+component) = 0.0;
    }
    
-   void Conductingsphere::fieldSolverBoundaryCondHallElectricField(
+   void Copysphere::fieldSolverBoundaryCondHallElectricField(
       FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
       cint i,
       cint j,
@@ -695,7 +695,7 @@ namespace SBC {
       }
    }
    
-   void Conductingsphere::fieldSolverBoundaryCondGradPeElectricField(
+   void Copysphere::fieldSolverBoundaryCondGradPeElectricField(
       FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
       cint i,
       cint j,
@@ -705,7 +705,7 @@ namespace SBC {
       EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EXGRADPE+component) = 0.0;
    }
    
-   void Conductingsphere::fieldSolverBoundaryCondDerivatives(
+   void Copysphere::fieldSolverBoundaryCondDerivatives(
       FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
       FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
       cint i,
@@ -718,33 +718,33 @@ namespace SBC {
       return;
    }
    
-   void Conductingsphere::fieldSolverBoundaryCondBVOLDerivatives(
+   void Copysphere::fieldSolverBoundaryCondBVOLDerivatives(
       FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, 2> & volGrid,
       cint i,
       cint j,
       cint k,
       cuint& component
    ) {
-      // FIXME This should be OK as the BVOL derivatives are only used for Lorentz force JXB, which is not applied on the conducting sphere cells.
+      // FIXME This should be OK as the BVOL derivatives are only used for Lorentz force JXB, which is not applied on the copy sphere cells.
       this->setCellBVOLDerivativesToZero(volGrid, i, j, k, component);
    }
    
-   void Conductingsphere::vlasovBoundaryCondition(
+   void Copysphere::vlasovBoundaryCondition(
       const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
       const CellID& cellID,
       const uint popID,
       const bool calculate_V_moments
    ) {
-      phiprof::start("vlasovBoundaryCondition (Conductingsphere)");
+      phiprof::start("vlasovBoundaryCondition (Copysphere)");
       this->vlasovBoundaryFluffyCopyFromAllCloseNbrs(mpiGrid, cellID, popID, calculate_V_moments, this->speciesParams[popID].fluffiness);
-      phiprof::stop("vlasovBoundaryCondition (Conductingsphere)");
+      phiprof::stop("vlasovBoundaryCondition (Copysphere)");
    }
 
    /**
     * NOTE: This function must initialize all particle species!
     * @param project
     */
-   void Conductingsphere::generateTemplateCell(Project &project) {
+   void Copysphere::generateTemplateCell(Project &project) {
       // WARNING not 0.0 here or the dipole() function fails miserably.
       templateCell.sysBoundaryFlag = this->getIndex();
       templateCell.sysBoundaryLayer = 1;
@@ -757,7 +757,7 @@ namespace SBC {
       
       // Loop over particle species
       for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
-         const ConductingsphereSpeciesParameters& sP = this->speciesParams[popID];
+         const CopysphereSpeciesParameters& sP = this->speciesParams[popID];
          const vector<vmesh::GlobalID> blocksToInitialize = findBlocksToInitialize(templateCell,popID);
          Realf* data = templateCell.get_data(popID);
          
@@ -840,13 +840,13 @@ namespace SBC {
       templateCell.parameters[CellParams::P_33_V] = templateCell.parameters[CellParams::P_33];
    }
    
-   Real Conductingsphere::shiftedMaxwellianDistribution(
+   Real Copysphere::shiftedMaxwellianDistribution(
       const uint popID,
       creal& vx, creal& vy, creal& vz
    ) {
       
       const Real MASS = getObjectWrapper().particleSpecies[popID].mass;
-      const ConductingsphereSpeciesParameters& sP = this->speciesParams[popID];
+      const CopysphereSpeciesParameters& sP = this->speciesParams[popID];
 
       return sP.rho * pow(MASS /
       (2.0 * M_PI * physicalconstants::K_B * sP.T), 1.5) *
@@ -854,7 +854,7 @@ namespace SBC {
       (2.0 * physicalconstants::K_B * sP.T));
    }
 
-   std::vector<vmesh::GlobalID> Conductingsphere::findBlocksToInitialize(spatial_cell::SpatialCell& cell,const uint popID) {
+   std::vector<vmesh::GlobalID> Copysphere::findBlocksToInitialize(spatial_cell::SpatialCell& cell,const uint popID) {
       vector<vmesh::GlobalID> blocksToInitialize;
       bool search = true;
       uint counter = 0;
@@ -905,12 +905,12 @@ namespace SBC {
       return blocksToInitialize;
    }
 
-   void Conductingsphere::setCellFromTemplate(SpatialCell* cell,const uint popID) {
+   void Copysphere::setCellFromTemplate(SpatialCell* cell,const uint popID) {
       copyCellData(&templateCell,cell,false,popID,true); // copy also vdf, _V
       copyCellData(&templateCell,cell,true,popID,false); // don't copy vdf again but copy _R now
    }
 
-   std::string Conductingsphere::getName() const {return "Conductingsphere";}
+   std::string Copysphere::getName() const {return "Copysphere";}
    
-   uint Conductingsphere::getIndex() const {return sysboundarytype::CONDUCTINGSPHERE;}
+   uint Copysphere::getIndex() const {return sysboundarytype::COPYSPHERE;}
 }

--- a/sysboundary/copysphere.cpp
+++ b/sysboundary/copysphere.cpp
@@ -66,9 +66,9 @@ namespace SBC {
          
          Readparameters::add(pop + "_copysphere.rho", "Number density of the copysphere (m^-3)", 0.0);
          Readparameters::add(pop + "_copysphere.T", "Temperature of the copysphere (K)", 0.0);
-         Readparameters::add(pop + "_copysphere.VX0", "Bulk velocity of conductospheric distribution function in X direction (m/s)", 0.0);
-         Readparameters::add(pop + "_copysphere.VY0", "Bulk velocity of conductospheric distribution function in X direction (m/s)", 0.0);
-         Readparameters::add(pop + "_copysphere.VZ0", "Bulk velocity of conductospheric distribution function in X direction (m/s)", 0.0);
+         Readparameters::add(pop + "_copysphere.VX0", "Bulk velocity of copyspheric distribution function in X direction (m/s)", 0.0);
+         Readparameters::add(pop + "_copysphere.VY0", "Bulk velocity of copyspheric distribution function in X direction (m/s)", 0.0);
+         Readparameters::add(pop + "_copysphere.VZ0", "Bulk velocity of copyspheric distribution function in X direction (m/s)", 0.0);
          Readparameters::add(pop + "_copysphere.fluffiness", "Inertia of boundary smoothing when copying neighbour's moments and velocity distributions (0=completely constant boundaries, 1=neighbours are interpolated immediately).", 0);
       }
    }

--- a/sysboundary/copysphere.h
+++ b/sysboundary/copysphere.h
@@ -20,8 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef CONDUCTINGSPHERE_H
-#define CONDUCTINGSPHERE_H
+#ifndef COPYSPHERE_H
+#define COPYSPHERE_H
 
 #include <vector>
 #include "../definitions.h"
@@ -34,7 +34,7 @@ using namespace std;
 
 namespace SBC {
 
-   struct ConductingsphereSpeciesParameters {
+   struct CopysphereSpeciesParameters {
       Real rho;
       Real V0[3];
       Real T;
@@ -43,21 +43,21 @@ namespace SBC {
       uint nVelocitySamples;
    };
 
-   /*!\brief Conductingsphere is a class applying an ionosphere-ish boundary conditions.
+   /*!\brief Copysphere is a class applying an ionosphere-ish boundary conditions.
     * 
-    * Conductingsphere is a class handling cells tagged as sysboundarytype::CONDUCTINGSPHERE by this system boundary condition. It applies perfectly conducting boundary conditions.
+    * Copysphere is a class handling cells tagged as sysboundarytype::COPYSPHERE by this system boundary condition. It applies copy boundary conditions to perturbed magnetic field.
     * 
     * These consist in:
     * - Do nothing for the distribution (keep the initial state constant in time);
-    * - Keep only the normal perturbed B component and null out the other perturbed components (perfect conductor behavior);
+    * - Copy the closest neighbors' perturbed B and average it;
     * - Null out the electric fields.
     *
     * For 3D magnetospheric simulations, you might be interesting in trying the ionosphere boundary instead!
     */
-   class Conductingsphere: public SysBoundaryCondition {
+   class Copysphere: public SysBoundaryCondition {
    public:
-      Conductingsphere();
-      virtual ~Conductingsphere();
+      Copysphere();
+      virtual ~Copysphere();
       
       static void addParameters();
       virtual void getParameters();
@@ -147,11 +147,11 @@ namespace SBC {
          cint k
       );
       
-      Real center[3]; /*!< Coordinates of the centre of the conducting sphere. */
-      Real radius; /*!< Radius of the conducting sphere. */
-      uint geometry; /*!< Geometry of the conducting sphere, 0: inf-norm (diamond), 1: 1-norm (square), 2: 2-norm (circle, DEFAULT), 3: polar-plane cylinder with line dipole. */
+      Real center[3]; /*!< Coordinates of the centre of the copy sphere. */
+      Real radius; /*!< Radius of the copy sphere. */
+      uint geometry; /*!< Geometry of the copy sphere, 0: inf-norm (diamond), 1: 1-norm (square), 2: 2-norm (circle, DEFAULT), 3: polar-plane cylinder with line dipole. */
 
-      std::vector<ConductingsphereSpeciesParameters> speciesParams;
+      std::vector<CopysphereSpeciesParameters> speciesParams;
       Real T;
       Real rho;
       Real VX0;

--- a/sysboundary/donotcompute.h
+++ b/sysboundary/donotcompute.h
@@ -69,13 +69,6 @@ namespace SBC {
          creal& dt,
          cuint& component
       ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondMagneticField called!" << std::endl; return 0.;}
-      virtual void fieldSolverBoundaryCondMagneticFieldProjection(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-         cint i,
-         cint j,
-         cint k
-      ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondMagneticFieldProjection called!" << std::endl;}
       virtual void fieldSolverBoundaryCondElectricField(
          FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
          cint i,

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -2972,19 +2972,6 @@ namespace SBC {
       }
    }
 
-   /*! We want here to
-    *
-    * -- Retain only the boundary-normal projection of perturbed face B
-    */
-   void Ionosphere::fieldSolverBoundaryCondMagneticFieldProjection(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      cint i,
-      cint j,
-      cint k
-   ) {
-   }
-
    void Ionosphere::fieldSolverBoundaryCondElectricField(
       FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
       cint i,

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -2382,7 +2382,7 @@ namespace SBC {
          cerr << "*                                               *" << endl;
          cerr << "* Most likely, your config file needs to be up- *" << endl;
          cerr << "* dated, changing all mentions of \"ionosphere\"  *" << endl;
-         cerr << "* to \"conductingsphere\".                        *" << endl;
+         cerr << "* to \"copysphere\".                        *" << endl;
          cerr << "*                                               *" << endl;
          cerr << "* This simulation will now crash in the friend- *" << endl;
          cerr << "* liest way possible.                           *" << endl;

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -2983,28 +2983,6 @@ namespace SBC {
       cint j,
       cint k
    ) {
-      // Projection of B-field to normal direction
-      Real BdotN = 0;
-      std::array<Real, 3> normalDirection = fieldSolverGetNormalDirection(technicalGrid, i, j, k);
-      for(uint component=0; component<3; component++) {
-         BdotN += bGrid.get(i,j,k)->at(fsgrids::bfield::PERBX+component) * normalDirection[component];
-      }
-      // Apply to any components that were not solved
-      if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
-          ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BX) != compute::BX))
-         ) {
-         bGrid.get(i,j,k)->at(fsgrids::bfield::PERBX) = BdotN*normalDirection[0];
-      }
-      if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
-          ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BY) != compute::BY))
-         ) {
-         bGrid.get(i,j,k)->at(fsgrids::bfield::PERBY) = BdotN*normalDirection[1];
-      }
-      if ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 2) ||
-          ((technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) && ((technicalGrid.get(i,j,k)->SOLVE & compute::BZ) != compute::BZ))
-         ) {
-         bGrid.get(i,j,k)->at(fsgrids::bfield::PERBZ) = BdotN*normalDirection[2];
-      }
    }
 
    void Ionosphere::fieldSolverBoundaryCondElectricField(

--- a/sysboundary/ionosphere.h
+++ b/sysboundary/ionosphere.h
@@ -315,7 +315,7 @@ namespace SBC {
     * 
     * These consist in:
     * - Do nothing for the distribution (keep the initial state constant in time);
-    * - Keep only the normal perturbed B component and null out the other perturbed components (perfect conductor behavior);
+    * - Copy the closest neighbors' perturbed B and average it;
     * - Null out the electric fields.
     */
    class Ionosphere: public SysBoundaryCondition {

--- a/sysboundary/ionosphere.h
+++ b/sysboundary/ionosphere.h
@@ -347,13 +347,6 @@ namespace SBC {
          creal& dt,
          cuint& component
       );
-      virtual void fieldSolverBoundaryCondMagneticFieldProjection(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-         cint i,
-         cint j,
-         cint k
-      );
       virtual void fieldSolverBoundaryCondElectricField(
          FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
          cint i,

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -247,14 +247,6 @@ namespace SBC {
       }
    }
 
-   void Outflow::fieldSolverBoundaryCondMagneticFieldProjection(
-      FsGrid< array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      cint i,
-      cint j,
-      cint k
-   ) {
-   }
    void Outflow::fieldSolverBoundaryCondElectricField(
       FsGrid< array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
       cint i,

--- a/sysboundary/outflow.h
+++ b/sysboundary/outflow.h
@@ -78,13 +78,6 @@ namespace SBC {
          creal& dt,
          cuint& component
       );
-      virtual void fieldSolverBoundaryCondMagneticFieldProjection(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-         cint i,
-         cint j,
-         cint k
-      );
       virtual void fieldSolverBoundaryCondElectricField(
          FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
          cint i,

--- a/sysboundary/setbyuser.cpp
+++ b/sysboundary/setbyuser.cpp
@@ -93,15 +93,6 @@ namespace SBC {
       return success;
    }
    
-   void SetByUser::fieldSolverBoundaryCondMagneticFieldProjection(
-      FsGrid< array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      cint i,
-      cint j,
-      cint k
-   ) {
-   }
-
    Real SetByUser::fieldSolverBoundaryCondMagneticField(
       FsGrid< array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
       FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,

--- a/sysboundary/setbyuser.h
+++ b/sysboundary/setbyuser.h
@@ -83,13 +83,6 @@ namespace SBC {
          creal& dt,
          cuint& component
       );
-      virtual void fieldSolverBoundaryCondMagneticFieldProjection(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-         cint i,
-         cint j,
-         cint k
-      );
       virtual void fieldSolverBoundaryCondElectricField(
          FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
          cint i,

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -33,7 +33,7 @@
 
 #include "donotcompute.h"
 #include "ionosphere.h"
-#include "conductingsphere.h"
+#include "copysphere.h"
 #include "outflow.h"
 #include "setmaxwellian.h"
 #include "sysboundary.h"
@@ -81,7 +81,7 @@ void SysBoundary::addParameters() {
    Readparameters::addComposing(
        "boundaries.boundary",
        "List of boundary condition (BC) types to be used. Each boundary condition to be used has to be on a new line "
-       "boundary = YYY. Available options are: Outflow, Ionosphere, Conductingsphere, Maxwellian, User.");
+       "boundary = YYY. Available options are: Outflow, Ionosphere, Copysphere, Maxwellian, User.");
    Readparameters::add("boundaries.periodic_x", "Set the grid periodicity in x-direction. 'yes'(default)/'no'.", "yes");
    Readparameters::add("boundaries.periodic_y", "Set the grid periodicity in y-direction. 'yes'(default)/'no'.", "yes");
    Readparameters::add("boundaries.periodic_z", "Set the grid periodicity in z-direction. 'yes'(default)/'no'.", "yes");
@@ -89,7 +89,7 @@ void SysBoundary::addParameters() {
    // call static addParameter functions in all bc's
    SBC::DoNotCompute::addParameters();
    SBC::Ionosphere::addParameters();
-   SBC::Conductingsphere::addParameters();
+   SBC::Copysphere::addParameters();
    SBC::Outflow::addParameters();
    SBC::SetMaxwellian::addParameters();
 }
@@ -262,16 +262,16 @@ bool SysBoundary::initSysBoundaries(Project& project, creal& t) {
             success = false;
          }
          isThisDynamic = isThisDynamic | this->getSysBoundary(sysboundarytype::IONOSPHERE)->isDynamic();
-      } else if(*it == "Conductingsphere") {
-         if(this->addSysBoundary(new SBC::Conductingsphere, project, t) == false) {
-            if(myRank == MASTER_RANK) cerr << "Error in adding Conductingsphere boundary." << endl;
+      } else if(*it == "Copysphere") {
+         if(this->addSysBoundary(new SBC::Copysphere, project, t) == false) {
+            if(myRank == MASTER_RANK) cerr << "Error in adding Copysphere boundary." << endl;
             success = false;
          }
          if(this->addSysBoundary(new SBC::DoNotCompute, project, t) == false) {
-            if(myRank == MASTER_RANK) cerr << "Error in adding DoNotCompute boundary (for Conductingsphere)." << endl;
+            if(myRank == MASTER_RANK) cerr << "Error in adding DoNotCompute boundary (for Copysphere)." << endl;
             success = false;
          }
-         isThisDynamic = isThisDynamic | this->getSysBoundary(sysboundarytype::CONDUCTINGSPHERE)->isDynamic();
+         isThisDynamic = isThisDynamic | this->getSysBoundary(sysboundarytype::COPYSPHERE)->isDynamic();
       } else if (*it == "Maxwellian") {
          if (!this->addSysBoundary(new SBC::SetMaxwellian, project, t)) {
             if (myRank == MASTER_RANK) {
@@ -378,7 +378,7 @@ bool SysBoundary::checkRefinement(dccrg::Dccrg<spatial_cell::SpatialCell, dccrg:
    for (auto cellId : local_cells) {
       SpatialCell* cell = mpiGrid[cellId];
       if (cell) {
-         if (cell->sysBoundaryFlag == sysboundarytype::IONOSPHERE || cell->sysBoundaryFlag == sysboundarytype::CONDUCTINGSPHERE) {
+         if (cell->sysBoundaryFlag == sysboundarytype::IONOSPHERE || cell->sysBoundaryFlag == sysboundarytype::COPYSPHERE) {
             innerBoundaryCells.insert(cellId);
             innerBoundaryRefLvl = mpiGrid.get_refinement_level(cellId);
             if (cell->sysBoundaryLayer == 1) {
@@ -656,7 +656,7 @@ bool SysBoundary::classifyCells(dccrg::Dccrg<spatial_cell::SpatialCell, dccrg::C
          for (int z = 0; z < localSize[2]; ++z) {
             if (technicalGrid.get(x,y,z)->sysBoundaryLayer == 0 && (
                 technicalGrid.get(x,y,z)->sysBoundaryFlag == sysboundarytype::IONOSPHERE || 
-                technicalGrid.get(x,y,z)->sysBoundaryFlag == sysboundarytype::CONDUCTINGSPHERE)) {
+                technicalGrid.get(x,y,z)->sysBoundaryFlag == sysboundarytype::COPYSPHERE)) {
                technicalGrid.get(x, y, z)->sysBoundaryFlag = sysboundarytype::DO_NOT_COMPUTE;
             }
          }

--- a/sysboundary/sysboundarycondition.h
+++ b/sysboundary/sysboundarycondition.h
@@ -83,13 +83,6 @@ namespace SBC {
             creal& dt,
             cuint& component
          )=0;
-         virtual void fieldSolverBoundaryCondMagneticFieldProjection(
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-            cint i,
-            cint j,
-            cint k
-         )=0;
          virtual void fieldSolverBoundaryCondElectricField(
             FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
             cint i,

--- a/testpackage/tests/Magnetosphere_3D_small/Magnetosphere_3D_small.cfg
+++ b/testpackage/tests/Magnetosphere_3D_small/Magnetosphere_3D_small.cfg
@@ -81,16 +81,16 @@ periodic_y = no
 periodic_z = no
 boundary = Outflow
 boundary = Maxwellian
-boundary = Conductingsphere
+boundary = Copysphere
 
-[conductingsphere]
+[copysphere]
 centerX = 0.0
 centerY = 0.0
 centerZ = 0.0
 radius = 70e6
 precedence = 2
 
-[proton_conductingsphere]
+[proton_copysphere]
 rho = 1.0e6
 T = 0.5e6
 

--- a/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
+++ b/testpackage/tests/Magnetosphere_polar_small/Magnetosphere_polar_small.cfg
@@ -87,9 +87,9 @@ periodic_y = yes
 periodic_z = no
 boundary = Outflow
 boundary = Maxwellian
-boundary = Conductingsphere
+boundary = Copysphere
 
-[conductingsphere]
+[copysphere]
 centerX = 0.0
 centerY = 0.0
 centerZ = 0.0
@@ -97,7 +97,7 @@ geometry = 2
 radius = 50.0e6
 precedence = 2
 
-[proton_conductingsphere]
+[proton_copysphere]
 rho = 1.0e6
 T = 0.5e6
 VX0 = 0.0

--- a/testpackage/tests/Magnetosphere_small/Magnetosphere_small.cfg
+++ b/testpackage/tests/Magnetosphere_small/Magnetosphere_small.cfg
@@ -77,16 +77,16 @@ periodic_y = no
 periodic_z = yes
 boundary = Outflow
 boundary = Maxwellian
-boundary = Conductingsphere
+boundary = Copysphere
 
-[conductingsphere]
+[copysphere]
 centerX = 0.0
 centerY = 0.0
 centerZ = 0.0
 radius = 38.2e6
 precedence = 2
 
-[proton_conductingsphere]
+[proton_copysphere]
 rho = 1.0e6
 T=100000.0
 


### PR DESCRIPTION
So this is the working state. I guess we can even ditch the whole projection functions now that no boundary is using that?