### PR TITLE
add "BOUNDARY_PADDING" boundarytype, for non-coupled DO_NOT_COMPUTE.

### DIFF
--- a/common.h
+++ b/common.h
@@ -447,6 +447,7 @@ namespace sysboundarytype {
       OUTFLOW,          /*!< No fixed conditions on the fields and distribution function. */
       SET_MAXWELLIAN,   /*!< Set Maxwellian boundary condition, i.e. set fields and distribution function. */
       CONDUCTINGSPHERE, /*!< A perfectly conducting sphere as the simple inner boundary */
+      BOUNDARY_PADDING, /*!< These cells only occur on FSGrid, where boundaries are not at the highest refinement level */
       N_SYSBOUNDARY_CONDITIONS
    };
 }

--- a/common.h
+++ b/common.h
@@ -447,7 +447,7 @@ namespace sysboundarytype {
       OUTFLOW,          /*!< No fixed conditions on the fields and distribution function. */
       SET_MAXWELLIAN,   /*!< Set Maxwellian boundary condition, i.e. set fields and distribution function. */
       CONDUCTINGSPHERE, /*!< A perfectly conducting sphere as the simple inner boundary */
-      BOUNDARY_PADDING, /*!< These cells only occur on FSGrid, where boundaries are not at the highest refinement level */
+      OUTER_BOUNDARY_PADDING, /*!< These cells only occur on FSGrid, where boundaries are not at the highest refinement level */
       N_SYSBOUNDARY_CONDITIONS
    };
 }

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -373,7 +373,9 @@ void calculateDerivativesSimple(
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
             if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
-                 technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) continue;
+                 technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) {
+               continue;
+            }
             if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
                calculateDerivatives(i,j,k, perBGrid, momentsGrid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RKCase);
             } else {

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -372,7 +372,8 @@ void calculateDerivativesSimple(
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
-            if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) continue;
+            if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
+                 technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) continue;
             if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
                calculateDerivatives(i,j,k, perBGrid, momentsGrid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, RKCase);
             } else {
@@ -513,7 +514,8 @@ void calculateBVOLDerivativesSimple(
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
-            if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) {
+            if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
+                 technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) {
                continue;
             }
             calculateBVOLDerivatives(volGrid,technicalGrid,i,j,k,sysBoundaries);
@@ -658,7 +660,8 @@ void calculateCurvatureSimple(
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
-            if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) {
+            if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
+                 technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) {
                continue;
             }
             calculateCurvature(volGrid,bgbGrid,technicalGrid,i,j,k,sysBoundaries);

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -373,7 +373,7 @@ void calculateDerivativesSimple(
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
             if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
-                 technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) {
+                 technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) {
                continue;
             }
             if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
@@ -517,7 +517,7 @@ void calculateBVOLDerivativesSimple(
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
             if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
-                 technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) {
+                 technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) {
                continue;
             }
             calculateBVOLDerivatives(volGrid,technicalGrid,i,j,k,sysBoundaries);
@@ -663,7 +663,7 @@ void calculateCurvatureSimple(
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
             if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
-                 technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) {
+                 technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) {
                continue;
             }
             calculateCurvature(volGrid,bgbGrid,technicalGrid,i,j,k,sysBoundaries);

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -390,6 +390,13 @@ void getFieldsFromFsGrid(
          for (auto const fsgridCell: fsgridCells){
             //loop over fsgrid cells for which we compute the average that is sent to dccrgCell on rank remoteRank
             if(technicalGrid.get(fsgridCell)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) {
+               // We skip boundary padding cells on the outer boundaries here,
+               // because their fields anyway don't contribute anything
+               // meaningful (as there are never properly updated).
+               //
+               // Note we do *NOT* skip DO_NOT_COMPUTE cells, because we need
+               // the bg vol fields to contribute to the innermost simulation
+               // cell's DCCRG volume averages.
                continue;
             }
             std::array<Real, fsgrids::volfields::N_VOL> * volcell = volumeFieldsGrid.get(fsgridCell);

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -388,10 +388,10 @@ void getFieldsFromFsGrid(
          //loop over dccrg cells to which we shall send data for this remoteRank
          auto const &fsgridCells = onFsgridMapCells[dccrgCell];
          for (auto const fsgridCell: fsgridCells){
-         //loop over fsgrid cells for which we compute the average that is sent to dccrgCell on rank remoteRank
-//        if(technicalGrid.get(fsgridCell)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) {
-//           continue;
-//        }
+            //loop over fsgrid cells for which we compute the average that is sent to dccrgCell on rank remoteRank
+            if(technicalGrid.get(fsgridCell)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) {
+               continue;
+            }
             std::array<Real, fsgrids::volfields::N_VOL> * volcell = volumeFieldsGrid.get(fsgridCell);
             std::array<Real, fsgrids::bgbfield::N_BGB> * bgcell = BgBGrid.get(fsgridCell);
             std::array<Real, fsgrids::egradpe::N_EGRADPE> * egradpecell = EGradPeGrid.get(fsgridCell);	

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -389,7 +389,7 @@ void getFieldsFromFsGrid(
          auto const &fsgridCells = onFsgridMapCells[dccrgCell];
          for (auto const fsgridCell: fsgridCells){
             //loop over fsgrid cells for which we compute the average that is sent to dccrgCell on rank remoteRank
-            if(technicalGrid.get(fsgridCell)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) {
+            if(technicalGrid.get(fsgridCell)->sysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) {
                // We skip boundary padding cells on the outer boundaries here,
                // because their fields anyway don't contribute anything
                // meaningful (as there are never properly updated).

--- a/fieldsolver/gridGlue.hpp
+++ b/fieldsolver/gridGlue.hpp
@@ -168,7 +168,8 @@ template< unsigned int numFields > void getFieldDataFromFsGrid(
       int nCellsToSum = 0;
       
       for(int iCell = 0; iCell < nCells; ++iCell) {
-         if ((transferBufferPointerTechnical[i] + iCell)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) {
+         if ((transferBufferPointerTechnical[i] + iCell)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
+              (transferBufferPointerTechnical[i] + iCell)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) {
             continue;
          } else {
             nCellsToSum++;

--- a/fieldsolver/gridGlue.hpp
+++ b/fieldsolver/gridGlue.hpp
@@ -169,7 +169,7 @@ template< unsigned int numFields > void getFieldDataFromFsGrid(
       
       for(int iCell = 0; iCell < nCells; ++iCell) {
          if ((transferBufferPointerTechnical[i] + iCell)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
-              (transferBufferPointerTechnical[i] + iCell)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) {
+              (transferBufferPointerTechnical[i] + iCell)->sysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) {
             continue;
          } else {
             nCellsToSum++;

--- a/fieldsolver/ldz_electric_field.cpp
+++ b/fieldsolver/ldz_electric_field.cpp
@@ -1556,7 +1556,7 @@ void calculateElectricField(
 ) {
    cuint cellSysBoundaryFlag = technicalGrid.get(i,j,k)->sysBoundaryFlag;
    
-   if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || cellSysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) return;
+   if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || cellSysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) return;
    
    cuint bitfield = technicalGrid.get(i,j,k)->SOLVE;
    

--- a/fieldsolver/ldz_electric_field.cpp
+++ b/fieldsolver/ldz_electric_field.cpp
@@ -1556,7 +1556,7 @@ void calculateElectricField(
 ) {
    cuint cellSysBoundaryFlag = technicalGrid.get(i,j,k)->sysBoundaryFlag;
    
-   if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) return;
+   if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || cellSysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) return;
    
    cuint bitfield = technicalGrid.get(i,j,k)->SOLVE;
    

--- a/fieldsolver/ldz_gradpe.cpp
+++ b/fieldsolver/ldz_gradpe.cpp
@@ -135,7 +135,7 @@ void calculateGradPeTerm(
    
    cuint cellSysBoundaryFlag = technicalGrid.get(i,j,k)->sysBoundaryFlag;
    
-   if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || cellSysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) return;
+   if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || cellSysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) return;
    
    cuint cellSysBoundaryLayer = technicalGrid.get(i,j,k)->sysBoundaryLayer;
    

--- a/fieldsolver/ldz_gradpe.cpp
+++ b/fieldsolver/ldz_gradpe.cpp
@@ -135,7 +135,7 @@ void calculateGradPeTerm(
    
    cuint cellSysBoundaryFlag = technicalGrid.get(i,j,k)->sysBoundaryFlag;
    
-   if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) return;
+   if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || cellSysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) return;
    
    cuint cellSysBoundaryLayer = technicalGrid.get(i,j,k)->sysBoundaryLayer;
    

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -746,7 +746,7 @@ void calculateHallTerm(
    
    cuint cellSysBoundaryFlag = technicalGrid.get(i,j,k)->sysBoundaryFlag;
    
-   if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || cellSysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) return;
+   if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || cellSysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) return;
    
    cuint cellSysBoundaryLayer = technicalGrid.get(i,j,k)->sysBoundaryLayer;
    

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -746,7 +746,7 @@ void calculateHallTerm(
    
    cuint cellSysBoundaryFlag = technicalGrid.get(i,j,k)->sysBoundaryFlag;
    
-   if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) return;
+   if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || cellSysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) return;
    
    cuint cellSysBoundaryLayer = technicalGrid.get(i,j,k)->sysBoundaryLayer;
    

--- a/fieldsolver/ldz_volume.cpp
+++ b/fieldsolver/ldz_volume.cpp
@@ -47,8 +47,7 @@ void calculateVolumeAveragedFields(
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
-            if(technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE 
-                  || technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) continue;
+            if(technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) continue;
             
             std::array<Real, Rec::N_REC_COEFFICIENTS> perturbedCoefficients;
             std::array<Real, fsgrids::volfields::N_VOL> * volGrid0 = volGrid.get(i,j,k);

--- a/fieldsolver/ldz_volume.cpp
+++ b/fieldsolver/ldz_volume.cpp
@@ -47,7 +47,8 @@ void calculateVolumeAveragedFields(
    for (int k=0; k<gridDims[2]; k++) {
       for (int j=0; j<gridDims[1]; j++) {
          for (int i=0; i<gridDims[0]; i++) {
-            if(technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE) continue;
+            if(technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE 
+                  || technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::BOUNDARY_PADDING) continue;
             
             std::array<Real, Rec::N_REC_COEFFICIENTS> perturbedCoefficients;
             std::array<Real, fsgrids::volfields::N_VOL> * volGrid0 = volGrid.get(i,j,k);

--- a/sysboundary/setbyuser.cpp
+++ b/sysboundary/setbyuser.cpp
@@ -111,7 +111,7 @@ namespace SBC {
       creal& dt,
       cuint& component
    ) {
-      // There is projects that have non-uniform and non-zero perturbed B, e.g. Magnetosphere with dipole type 4.
+      // There are projects that have non-uniform and non-zero perturbed B, e.g. Magnetosphere with dipole type 4.
       // We cannot take a value from the templateCell, we need a copy of the value from initialization which has
       // been set in perBGrid as well as perBDt2Grid and isn't touched as we are in boundary cells for components
       // that aren't solved.

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -636,8 +636,11 @@ bool SysBoundary::classifyCells(dccrg::Dccrg<spatial_cell::SpatialCell, dccrg::C
 
                      technicalGrid.get(x, y, z)->sysBoundaryLayer = layer;
 
-                     if (layer > 2 && technicalGrid.get(x, y, z)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY) {
+                     if (layer > 2 && (technicalGrid.get(x,y,z)->sysBoundaryFlag == sysboundarytype::IONOSPHERE || 
+                                       technicalGrid.get(x,y,z)->sysBoundaryFlag == sysboundarytype::CONDUCTINGSPHERE)) {
                         technicalGrid.get(x, y, z)->sysBoundaryFlag = sysboundarytype::DO_NOT_COMPUTE;
+                     } else if (layer > 2 && technicalGrid.get(x, y, z)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY) {
+                        technicalGrid.get(x, y, z)->sysBoundaryFlag = sysboundarytype::BOUNDARY_PADDING;
                      }
                   }
                }

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -640,7 +640,7 @@ bool SysBoundary::classifyCells(dccrg::Dccrg<spatial_cell::SpatialCell, dccrg::C
                                        technicalGrid.get(x,y,z)->sysBoundaryFlag == sysboundarytype::CONDUCTINGSPHERE)) {
                         technicalGrid.get(x, y, z)->sysBoundaryFlag = sysboundarytype::DO_NOT_COMPUTE;
                      } else if (layer > 2 && technicalGrid.get(x, y, z)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY) {
-                        technicalGrid.get(x, y, z)->sysBoundaryFlag = sysboundarytype::BOUNDARY_PADDING;
+                        technicalGrid.get(x, y, z)->sysBoundaryFlag = sysboundarytype::OUTER_BOUNDARY_PADDING;
                      }
                   }
                }

--- a/sysboundary/sysboundarycondition.cpp
+++ b/sysboundary/sysboundarycondition.cpp
@@ -902,6 +902,7 @@ namespace SBC {
                if( technicalGrid.get(i+ii,j+jj,k+kk) // skip invalid cells returning NULL
                    && (technicalGrid.get(i+ii,j+jj,k+kk)->SOLVE & mask) == mask // Did that guy solve this component?
                    && technicalGrid.get(i+ii,j+jj,k+kk)->sysBoundaryFlag != sysboundarytype::DO_NOT_COMPUTE // Do not copy from there
+                   &&  technicalGrid.get(i+ii,j+jj,k+kk)->sysBoundaryFlag != sysboundarytype::BOUNDARY_PADDING // Do not copy from there either
                ) {
                   distance = min(distance, ii*ii + jj*jj + kk*kk);
                }

--- a/sysboundary/sysboundarycondition.cpp
+++ b/sysboundary/sysboundarycondition.cpp
@@ -902,7 +902,7 @@ namespace SBC {
                if( technicalGrid.get(i+ii,j+jj,k+kk) // skip invalid cells returning NULL
                    && (technicalGrid.get(i+ii,j+jj,k+kk)->SOLVE & mask) == mask // Did that guy solve this component?
                    && technicalGrid.get(i+ii,j+jj,k+kk)->sysBoundaryFlag != sysboundarytype::DO_NOT_COMPUTE // Do not copy from there
-                   &&  technicalGrid.get(i+ii,j+jj,k+kk)->sysBoundaryFlag != sysboundarytype::BOUNDARY_PADDING // Do not copy from there either
+                   &&  technicalGrid.get(i+ii,j+jj,k+kk)->sysBoundaryFlag != sysboundarytype::OUTER_BOUNDARY_PADDING // Do not copy from there either
                ) {
                   distance = min(distance, ii*ii + jj*jj + kk*kk);
                }

--- a/sysboundary/sysboundarycondition.cpp
+++ b/sysboundary/sysboundarycondition.cpp
@@ -916,6 +916,7 @@ namespace SBC {
                if( technicalGrid.get(i+ii,j+jj,k+kk) // skip invalid cells returning NULL
                    && (technicalGrid.get(i+ii,j+jj,k+kk)->SOLVE & mask) == mask // Did that guy solve this component?
                    && technicalGrid.get(i+ii,j+jj,k+kk)->sysBoundaryFlag != sysboundarytype::DO_NOT_COMPUTE // Do not copy from there
+                   &&  technicalGrid.get(i+ii,j+jj,k+kk)->sysBoundaryFlag != sysboundarytype::OUTER_BOUNDARY_PADDING // Do not copy from there either
                ) {
                   int d = ii*ii + jj*jj + kk*kk;
                   if( d == distance ) {

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -453,7 +453,7 @@ int main(int argn,char* args[]) {
       *project
    );
    
-   // There is projects that have non-uniform and non-zero perturbed B, e.g. Magnetosphere with dipole type 4.
+   // There are projects that have non-uniform and non-zero perturbed B, e.g. Magnetosphere with dipole type 4.
    // For setbyuser inflow cells, we cannot take a value from the templateCell, we need a copy of the value
    // from initialization in both perBGrid and perBDt2Grid and isn't touched as we are in boundary cells for
    // components that aren't solved. We do a straight full copy instead of looping and detecting boundary types here.


### PR DESCRIPTION
This type only gets assigned to fsgrid cells that are left outside the actual simulation domain after dccrg refinement. They should not be computed or coupled into dccrg, as not to distort the volume averages.

Not that there is special treatment near the ionosphere, where *do* want to couple fsgrid cells.