### PR TITLE
Makefile and a small fix to build on jetsonTX Arm cluster at BSC.

### DIFF
--- a/MAKE/Makefile.bsc_jetsontx
+++ b/MAKE/Makefile.bsc_jetsontx
@@ -1,0 +1,57 @@
+# Makefile for the jetson-tx cluster at BSC
+#
+# Note:
+# o Load modules:
+#   module load boost eigen
+# o Zoltan's configure script requires a "--build=arm-linux-gnu" parameter.
+
+CMP = mpic++
+LNK = mpic++
+
+#======== Vectorization ==========
+#Set vector backend type for vlasov solvers, sets precision and length. 
+#Options: 
+# AVX:      VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
+# AVX512:   VEC8D_AGNER, VEC16F_AGNER
+# Fallback: VEC4D_FALLBACK, VEC4F_FALLBACK, VEC8F_FALLBACK
+
+ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
+#Single-precision        
+        VECTORCLASS = VEC8F_FALLBACK
+        INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/../vlasiator/vlasovsolver
+else
+#Double-precision
+#       VECTORCLASS = VEC4D_AGNER
+#       INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass
+        VECTORCLASS = VEC4D_FALLBACK
+        INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/../vlasiator/vlasovsolver
+endif
+
+FLAGS =
+# note: std was c++11
+# note: testpackage settings missing
+CXXFLAGS = -I$(HOME)/include -O3 -std=c++17 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces  -fopenmp -march=native
+MATHFLAGS = -ffast-math
+LDFLAGS = -fopenmp
+LIB_MPI =
+# LIB_MPI = 
+
+LIBRARY_PREFIX = $(HOME)/vlasiator/libraries-jetsontx
+LIBRARY_PREFIX_B = $(HOME)
+
+INC_BOOST =
+LIB_BOOST = ${BOOST_LIBS} -lboost_program_options
+
+INC_ZOLTAN = -I${LIBRARY_PREFIX}/include
+LIB_ZOLTAN = -L${LIBRARY_PREFIX}/lib -lzoltan
+
+INC_VLSV = -I$(LIBRARY_PREFIX)/vlsv
+LIB_VLSV = -L$(LIBRARY_PREFIX)/vlsv -lvlsv
+
+INC_DCCRG = -I${LIBRARY_PREFIX}/dccrg -I${LIBRARY_PREFIX}/fsgrid
+
+LIB_PROFILE = -L${LIBRARY_PREFIX}/phiprof/lib -lphiprof -Wl,-rpath=${LIBRARY_PREFIX}/phiprof/lib 
+INC_PROFILE = -I${LIBRARY_PREFIX}/phiprof/include
+INC_TOPO =
+
+INC_EIGEN = ${EIGEN3_INCL}

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -924,7 +924,7 @@ namespace SBC {
       }
 
       // Antisymmetric tensor epsilon_ijk
-      static const char epsilon[3][3][3] = {
+      static const int epsilon[3][3][3] = {
          {{0,0,0},{0,0,1},{0,-1,0}},
          {{0,0,-1},{0,0,0},{1,0,0}},
          {{0,1,0},{-1,0,0},{0,0,0}}


### PR DESCRIPTION
Note that the type change in ionosphere.cpp is also required to build on RISC-V, so I suppose this is relevant for all architectures with some alignment constraints. Not a performance issue either, so why not just fix it for all.

This has been tested to compile and run at least the Magnetosphere_small test from the testpackage on the cluster in Barcelona.