### PR TITLE
LUMI makefile fixes

### DIFF
--- a/MAKE/Makefile.lumi_cray
+++ b/MAKE/Makefile.lumi_cray
@@ -2,7 +2,7 @@ CMP = CC
 LNK = CC
 
 # Modules loaded
-# module --force purge ; module load LUMI/22.08 ; module load cpeCray ; module load papi
+# module --force purge ; module load LUMI/22.08 ; module load cpeCray ; module load papi; module load Eigen; module load Boost/1.79.0-cpeCray-22.08
 
 #======== Vectorization ==========
 #Set vector backend type for vlasov solvers, sets precision and length. 
@@ -28,8 +28,8 @@ CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mfma
 testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++20 -mno-fma -mno-avx2 -mno-avx
 
 MATHFLAGS = -ffast-math
-LDFLAGS = -lrt -fopenmp -lgomp
-LIB_MPI = -lgomp
+LDFLAGS = -lrt -fopenmp
+LIB_MPI = -fopenmp
 
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
@@ -60,13 +60,12 @@ LIBRARY_PREFIX = /scratch/project_465000287/kempfyan/libraries/LUMI22.08_cpeCray
 LIBRARY_PREFIX_HEADERS = /scratch/project_465000287/libraries
 
 #compiled libraries
-INC_BOOST = -I$(LIBRARY_PREFIX)/boost/include
-LIB_BOOST = -L$(LIBRARY_PREFIX)/boost/lib -lboost_program_options -Wl,-rpath=$(LIBRARY_PREFIX)/boost/lib
+LIB_BOOST = -lboost_program_options
 
-INC_ZOLTAN = -I$(LIBRARY_PREFIX)/zoltan/include
+INC_ZOLTAN = -isystem$(LIBRARY_PREFIX)/zoltan/include
 LIB_ZOLTAN = -L$(LIBRARY_PREFIX)/zoltan/lib -lzoltan -Wl,-rpath=$(LIBRARY_PREFIX)/zoltan/lib
 
-INC_JEMALLOC = -I$(LIBRARY_PREFIX)/jemalloc/include
+INC_JEMALLOC = -isystem$(LIBRARY_PREFIX)/jemalloc/include
 LIB_JEMALLOC = -L$(LIBRARY_PREFIX)/jemalloc/lib -ljemalloc -Wl,-rpath=$(LIBRARY_PREFIX)/jemalloc/lib
 
 INC_PAPI =
@@ -82,6 +81,5 @@ INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include
 #header libraries
 
 INC_FSGRID = -I$(LIBRARY_PREFIX_HEADERS)/fsgrid/
-INC_EIGEN = -I$(LIBRARY_PREFIX_HEADERS)/eigen/
 INC_DCCRG = -I$(LIBRARY_PREFIX_HEADERS)/dccrg/
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX_HEADERS)/vectorclass/
+INC_VECTORCLASS = -isystem$(LIBRARY_PREFIX_HEADERS)/vectorclass/

--- a/MAKE/Makefile.lumi_cray
+++ b/MAKE/Makefile.lumi_cray
@@ -2,7 +2,7 @@ CMP = CC
 LNK = CC
 
 # Modules loaded
-# module --force purge ; module load LUMI/22.08 ; module load cpeCray ; module load papi; module load Eigen; module load Boost/1.79.0-cpeCray-22.08
+# module load LUMI/22.08 ; module load cpeCray ; module load papi; module load Eigen; module load Boost/1.79.0-cpeCray-22.08
 
 #======== Vectorization ==========
 #Set vector backend type for vlasov solvers, sets precision and length. 

--- a/MAKE/Makefile.lumi_gnu
+++ b/MAKE/Makefile.lumi_gnu
@@ -28,8 +28,8 @@ CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mfma
 testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++20 -mno-fma -mno-avx2 -mno-avx
 
 MATHFLAGS = -ffast-math
-LDFLAGS = -lrt -lgomp
-LIB_MPI = -lgomp
+LDFLAGS = -lrt -fopenmp
+LIB_MPI = -fopenmp
 
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?

--- a/MAKE/Makefile.lumi_gnu
+++ b/MAKE/Makefile.lumi_gnu
@@ -2,7 +2,7 @@ CMP = CC
 LNK = CC
 
 # Modules loaded
-# module --force purge ; module load LUMI/22.08 ; module load cpeGNU ; module load papi; module load Eigen
+# module --force purge ; module load LUMI/22.08 ; module load cpeGNU ; module load papi; module load Eigen; module load Boost/1.79.0-cpeGNU-22.08
 
 #======== Vectorization ==========
 #Set vector backend type for vlasov solvers, sets precision and length. 
@@ -28,7 +28,7 @@ CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mfma
 testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++20 -mno-fma -mno-avx2 -mno-avx
 
 MATHFLAGS = -ffast-math
-LDFLAGS = -lrt -fopenmp -lgomp
+LDFLAGS = -lrt -lgomp
 LIB_MPI = -lgomp
 
 #======== PAPI ==========
@@ -60,16 +60,14 @@ LIBRARY_PREFIX = /scratch/project_465000287/kempfyan/libraries/LUMI22.08_cpeGNU
 LIBRARY_PREFIX_HEADERS = /scratch/project_465000287/libraries
 
 #compiled libraries
-INC_BOOST = -I$(LIBRARY_PREFIX)/boost/include
-LIB_BOOST = -L$(LIBRARY_PREFIX)/boost/lib -lboost_program_options -Wl,-rpath=$(LIBRARY_PREFIX)/boost/lib
+LIB_BOOST = -lboost_program_options
 
-INC_ZOLTAN = -I$(LIBRARY_PREFIX)/zoltan/include
+INC_ZOLTAN = -isystem$(LIBRARY_PREFIX)/zoltan/include
 LIB_ZOLTAN = -L$(LIBRARY_PREFIX)/zoltan/lib -lzoltan -Wl,-rpath=$(LIBRARY_PREFIX)/zoltan/lib
 
-INC_JEMALLOC = -I$(LIBRARY_PREFIX)/jemalloc/include
+INC_JEMALLOC = -isystem$(LIBRARY_PREFIX)/jemalloc/include
 LIB_JEMALLOC = -L$(LIBRARY_PREFIX)/jemalloc/lib -ljemalloc -Wl,-rpath=$(LIBRARY_PREFIX)/jemalloc/lib
 
-INC_PAPI =
 LIB_PAPI = -lpapi
 
 INC_VLSV = -I$(LIBRARY_PREFIX)/vlsv
@@ -82,6 +80,5 @@ INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include
 #header libraries
 
 INC_FSGRID = -I$(LIBRARY_PREFIX_HEADERS)/fsgrid/
-INC_EIGEN = -I$(LIBRARY_PREFIX_HEADERS)/eigen/
 INC_DCCRG = -I$(LIBRARY_PREFIX_HEADERS)/dccrg/
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX_HEADERS)/vectorclass/
+INC_VECTORCLASS = -isystem$(LIBRARY_PREFIX_HEADERS)/vectorclass/

--- a/MAKE/Makefile.lumi_gnu
+++ b/MAKE/Makefile.lumi_gnu
@@ -2,7 +2,7 @@ CMP = CC
 LNK = CC
 
 # Modules loaded
-# module --force purge ; module load LUMI/22.08 ; module load cpeGNU ; module load papi; module load Eigen; module load Boost/1.79.0-cpeGNU-22.08
+# module load LUMI/22.08 ; module load cpeGNU ; module load papi; module load Eigen; module load Boost/1.79.0-cpeGNU-22.08
 
 #======== Vectorization ==========
 #Set vector backend type for vlasov solvers, sets precision and length. 


### PR DESCRIPTION
- Fix OpenMP for Cray environment. Using `-lgomp` breaks the function `omp_get_thread_num()` causing errors in phiprof output.
- Use modules for Eigen and Boost.
- Use `-isystem` to avoid warnings from outside libraries.