### PR TITLE
Fix project initialization fixing due to bogus free

### DIFF
--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -191,7 +191,6 @@ namespace projects {
                const vmesh::GlobalID blockGID = cell->get_velocity_block(popID,blockIndices,refLevel);
                blocksToInitialize.push_back(blockGID);
             }
-      delete vblocks_ini;
       return blocksToInitialize;
    }
 


### PR DESCRIPTION
Instead of freeing something temporary, it was actually an internal pointer of the spatial stell, and then smashing the stack.