### PR TITLE
Fix arch-interface issues in DRO and add HIP kernel launch error checking

### DIFF
--- a/arch/arch_device_hip.h
+++ b/arch/arch_device_hip.h
@@ -89,7 +89,8 @@
 #define HIPCUB_STDERR
 
 /* Set HIP blocksize used for reductions */
-#define ARCH_BLOCKSIZE_R 256
+#define ARCH_BLOCKSIZE_R 512
+#define ARCH_BLOCKSIZE_R_SMALL 64
 
 /* GPU blocksize used by Vlasov solvers */
 #ifndef GPUBLOCKS
@@ -371,10 +372,6 @@ __forceinline__ static void parallel_reduce_driver(const uint (&limits)[NDim], L
   for(uint i = 0; i < NDim; i++)
     n_total *= limits[i];
 
-  /* Set the kernel dimensions */
-  const uint blocksize = ARCH_BLOCKSIZE_R;
-  const uint gridsize = (n_total - 1 + blocksize) / blocksize;
-
   /* Check the HIP default mempool settings and correct if wrong */
   device_mempool_check(UINT64_MAX);
 
@@ -399,14 +396,37 @@ __forceinline__ static void parallel_reduce_driver(const uint (&limits)[NDim], L
   /* Call the reduction kernel with different arguments depending
    * on if the number of reductions is known at the compile time
    */
-  T* d_thread_data_dynamic=0; // declared zero to suppress unitialized use warning
+  T* d_thread_data_dynamic = 0; // declared zero to suppress unitialized use warning
   if(NReduStatic == 0) {
-    /* Get the cub temp storage size for the dynamic shared memory kernel argument */
+    /* Get the cub temp storage sizes for the dynamic shared memory kernel argument */
     constexpr auto cub_temp_storage_type_size = sizeof(typename hipcub::BlockReduce<T, ARCH_BLOCKSIZE_R, hipcub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1>::TempStorage);
+    constexpr auto cub_temp_storage_type_size_small = sizeof(typename hipcub::BlockReduce<T, ARCH_BLOCKSIZE_R_SMALL, hipcub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1>::TempStorage);
+    /* Query device properties */
+    int device_id;
+    CHK_ERR(hipGetDevice(&device_id));
+    hipDeviceProp_t deviceProp;
+    CHK_ERR(hipGetDeviceProperties(&deviceProp, device_id));
+    /* Make sure there is enough shared memory for the used block size */
+    uint blocksize;
+    size_t shared_mem_bytes_per_block_request;
+    if(n_reductions * cub_temp_storage_type_size <= deviceProp.sharedMemPerBlock){
+      blocksize = ARCH_BLOCKSIZE_R;
+      shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size;
+    }
+    else if(n_reductions * cub_temp_storage_type_size_small <= deviceProp.sharedMemPerBlock){
+      blocksize = ARCH_BLOCKSIZE_R_SMALL;
+      shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size_small;
+    }
+    else{
+      printf("The device %d (%s) does not have enough shared memory even for the small blocksize (%d)! The error occurred in %s at line %d\n", device_id, deviceProp.gcnArchName, ARCH_BLOCKSIZE_R_SMALL, __FILE__, __LINE__);
+      exit(1);
+    }
+    /* Set the kernel grid dimensions */
+    const uint gridsize = (n_total - 1 + blocksize) / blocksize;
     /* Allocate memory for the thread data values */
     CHK_ERR(hipMallocAsync(&d_thread_data_dynamic, n_reductions * blocksize * gridsize * sizeof(T), gpuStreamList[thread_id]));
     /* Call the kernel (the number of reductions not known at compile time) */
-    reduction_kernel<Op, NDim, 0><<<gridsize, blocksize, n_reductions * cub_temp_storage_type_size, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+    reduction_kernel<Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
     /* Check for kernel launch errors */
     CHK_ERR(hipPeekAtLastError());
     /* Synchronize and free the thread data allocation */
@@ -414,6 +434,9 @@ __forceinline__ static void parallel_reduce_driver(const uint (&limits)[NDim], L
     CHK_ERR(hipFreeAsync(d_thread_data_dynamic, gpuStreamList[thread_id]));
   }
   else{
+    /* Set the kernel dimensions */
+    const uint blocksize = ARCH_BLOCKSIZE_R;
+    const uint gridsize = (n_total - 1 + blocksize) / blocksize;
     /* Call the kernel (the number of reductions known at compile time) */
     reduction_kernel<Op, NDim, NReduStatic><<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
     /* Check for kernel launch errors */

--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -638,7 +638,7 @@ namespace DRO {
             PTensor[2] += sum[2];
          }
       }
-      printf("VariablePTensorDiagonal: sum0: %e, sum1: %e, sum2: %e\n", PTensor[0], PTensor[1], PTensor[2]);fflush(stdout);
+
       const char* ptr = reinterpret_cast<const char*>(&PTensor);
       for (uint i = 0; i < 3*sizeof(Real); ++i) buffer[i] = ptr[i];
       return true;
@@ -711,7 +711,6 @@ namespace DRO {
             PTensor[2] += sum[0];
          }
       }
-      printf("VariablePTensorOffDiagonal: sum0: %e, sum1: %e, sum2: %e\n", PTensor[0], PTensor[1], PTensor[2]);fflush(stdout);
       const char* ptr = reinterpret_cast<const char*>(&PTensor);
       for (uint i = 0; i < 3*sizeof(Real); ++i) buffer[i] = ptr[i];
       return true;
@@ -758,7 +757,6 @@ namespace DRO {
             maxF = max(threadMax, maxF);
          }
       }
-      printf("MaxDistributionFunction: maxF: %e\n", maxF);fflush(stdout);
 
       *buffer = maxF;
       return true;
@@ -810,7 +808,6 @@ namespace DRO {
             minF = min(threadMin, minF);
          }
       }
-      printf("MinDistributionFunction: minF: %e\n", minF);fflush(stdout);
 
       *buffer = minF;
       return true;
@@ -889,7 +886,6 @@ namespace DRO {
             rho += thread_n_sum;
          }
       }
-      printf("rhoNonthermalCalculation: rho: %e\n", rho);fflush(stdout);
       return;
    }
 
@@ -968,7 +964,7 @@ namespace DRO {
       V[0]/=n_sum;
       V[1]/=n_sum;
       V[2]/=n_sum;
-      printf("VNonthermalCalculation: V0: %e, V1: %e, V2: %e\n", V[0], V[1], V[2]);fflush(stdout);
+
       return;
    }
 
@@ -1039,7 +1035,6 @@ namespace DRO {
             PTensor[2] += sum[2];
          }
       }
-      printf("PTensorDiagonalNonthermalCalculations: sum0: %e, sum1: %e, sum2: %e\n", PTensor[0], PTensor[1], PTensor[2]);fflush(stdout);
       return;
    }
 
@@ -1110,7 +1105,6 @@ namespace DRO {
             PTensor[2] += sum[0];
          }
       }
-      printf("PTensorOffDiagonalNonthermalCalculations: sum0: %e, sum1: %e, sum2: %e\n", PTensor[0], PTensor[1], PTensor[2]);fflush(stdout);
       return;
    }
 
@@ -1554,21 +1548,16 @@ namespace DRO {
 
                                              lsum[binNumber] += block_data[n * SIZE_VELBLOCK + cellIndex(i,j,k)] * countAndGate * normV*normV * DV3;
                                              lsum[nChannelsLocal + binNumber] += countAndGate * DV3;
-
-                                             //printf("i: %d, j: %d, k:%d, n:%d, countAndGate: %e, Dv3: %e\n",i,j,k,n,countAndGate,DV3);
                                           }, sum);
 
          // Accumulate contributions coming from this velocity block
          // If multithreading / OpenMP is used, these updates need to be atomic:
          # pragma omp critical
          {
-            printf("VariablePrecipitationDiffFlux: %d, %d, %d,%d\n",WID, WID, WID, (uint)cell->get_number_of_velocity_blocks(popID));
             for (int i=0; i<nChannels; i++) {
                dataDiffFlux[i] += sum[i];
                sumWeights[i] += sum[nChannels + i];
-               printf("dataDiffFlux[%d]: %e, sumWeights[%d]: %e\n", i,sum[i],i, sum[nChannels + i]);
             }
-            fflush(stdout);
          }
       }
 
@@ -1825,8 +1814,6 @@ namespace DRO {
 
       }
 
-      printf("VariableEnergyDensity: sum0: %e, sum1: %e, sum2: %e,\n",EDensity[0],EDensity[1],EDensity[2]);fflush(stdout);
-
       // Output energy density in units eV/cm^3 instead of Joules per m^3
       EDensity[0] *= (1.0e-6)/physicalconstants::CHARGE;
       EDensity[1] *= (1.0e-6)/physicalconstants::CHARGE;
@@ -2039,8 +2026,6 @@ namespace DRO {
 #pragma omp critical
          { epsilon += thread_epsilon_sum; }
       }
-
-      printf("VariableNonMaxwellianity: epsilon: %e\n", epsilon);fflush(stdout);
 
       epsilon *= HALF / rho;
       epsilon += HALF;


### PR DESCRIPTION
This PR does the following:

1. Porting of "VariableNonMaxwellianity" datareducer to GPUs using the arch-interface.
2. Fix the inaccessibility issues of some read-only variables in the arch-based kernels.
3. Adjust the blocksize during runtime (from two predefined values) if the GPU is running out of dynamically allocated shared memory
5. Add error checking for HIP kernel launch to capture errors such as the above, ie, 
```
    /* Check for kernel launch errors */
    CHK_ERR(hipPeekAtLastError());
```

The "arched" datareducers, as well as the arch-loop in vlasiator.cpp have been checked for correctness using the test case "transtest_allreducers.cfg". Ie, all loops that are triggered by this example, produce same results with GPU and CPU loop execution.