### PR TITLE
Fix kernel launch issue and dynamic shared memory type size issue

### DIFF
--- a/arch/arch_device_cuda.h
+++ b/arch/arch_device_cuda.h
@@ -93,7 +93,7 @@
 
 /* Set CUDA blocksize used for reductions */
 #define ARCH_BLOCKSIZE_R 512
-#define ARCH_BLOCKSIZE_R_SMALL 64
+#define ARCH_BLOCKSIZE_R_SMALL 32
 
 /* GPU blocksize used by Vlasov solvers */
 #ifndef GPUBLOCKS
@@ -425,35 +425,36 @@ namespace arch{
        */
       T* d_thread_data_dynamic = 0; // declared zero to suppress unitialized use warning
       if(NReduStatic == 0) {
-             /* Get the cub temp storage sizes for the dynamic shared memory kernel argument */
-    constexpr auto cub_temp_storage_type_size = sizeof(typename cub::BlockReduce<T, ARCH_BLOCKSIZE_R, cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1>::TempStorage);
-    constexpr auto cub_temp_storage_type_size_small = sizeof(typename cub::BlockReduce<T, ARCH_BLOCKSIZE_R_SMALL, cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1>::TempStorage);
-    /* Query device properties */
-    int device_id;
-    CHK_ERR(cudaGetDevice(&device_id));
-    cudaDeviceProp_t deviceProp;
-    CHK_ERR(cudaGetDeviceProperties(&deviceProp, device_id));
-    /* Make sure there is enough shared memory for the used block size */
-    uint blocksize;
-    size_t shared_mem_bytes_per_block_request;
-    if(n_reductions * cub_temp_storage_type_size <= deviceProp.sharedMemPerBlock){
-      blocksize = ARCH_BLOCKSIZE_R;
-      shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size;
-    }
-    else if(n_reductions * cub_temp_storage_type_size_small <= deviceProp.sharedMemPerBlock){
-      blocksize = ARCH_BLOCKSIZE_R_SMALL;
-      shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size_small;
-    }
-    else{
-      printf("The device %d (%s) does not have enough shared memory even for the small blocksize (%d)! The error occurred in %s at line %d\n", device_id, deviceProp.name, ARCH_BLOCKSIZE_R_SMALL, __FILE__, __LINE__);
-      exit(1);
-    }
-    /* Set the kernel grid dimensions */
-    const uint gridsize = (n_total - 1 + blocksize) / blocksize;
+         /* Get the cub temp storage sizes for the dynamic shared memory kernel argument */
+         constexpr auto cub_temp_storage_type_size = sizeof(typename cub::BlockReduce<T, ARCH_BLOCKSIZE_R, cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1>::TempStorage);
+         constexpr auto cub_temp_storage_type_size_small = sizeof(typename cub::BlockReduce<T, ARCH_BLOCKSIZE_R_SMALL, cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1>::TempStorage);
+         /* Query device properties */
+         int device_id;
+         CHK_ERR(cudaGetDevice(&device_id));
+         cudaDeviceProp deviceProp;
+         CHK_ERR(cudaGetDeviceProperties(&deviceProp, device_id));
+         /* Make sure there is enough shared memory for the used block size */
+         uint blocksize;
+         size_t shared_mem_bytes_per_block_request;
+         if(n_reductions * cub_temp_storage_type_size <= deviceProp.sharedMemPerBlock){
+           blocksize = ARCH_BLOCKSIZE_R;
+           shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size;
+         }
+         else if(n_reductions * cub_temp_storage_type_size_small <= deviceProp.sharedMemPerBlock){
+           blocksize = ARCH_BLOCKSIZE_R_SMALL;
+           shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size_small;
+         }
+         else{
+           printf("The device %d (%s) does not have enough shared memory even for the small blocksize (%d)! The error occurred in %s at line %d\n", device_id, deviceProp.name, ARCH_BLOCKSIZE_R_SMALL, __FILE__, __LINE__);
+           exit(1);
+         }
+         /* Set the kernel grid dimensions */
+         const uint gridsize = (n_total - 1 + blocksize) / blocksize;
          /* Allocate memory for the thread data values */
          CHK_ERR(cudaMallocAsync(&d_thread_data_dynamic, n_reductions * blocksize * gridsize * sizeof(T), gpuStreamList[thread_id]));
          /* Call the kernel (the number of reductions not known at compile time) */
-         reduction_kernel<Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+         if(gridsize > 0)
+            reduction_kernel<Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
          /* Check for kernel launch errors */
          CHK_ERR(cudaPeekAtLastError());
          /* Synchronize and free the thread data allocation */
@@ -465,7 +466,8 @@ namespace arch{
          const uint blocksize = ARCH_BLOCKSIZE_R;
          const uint gridsize = (n_total - 1 + blocksize) / blocksize;
          /* Call the kernel (the number of reductions known at compile time) */
-         reduction_kernel<Op, NDim, NReduStatic><<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+         if(gridsize > 0)
+            reduction_kernel<Op, NDim, NReduStatic><<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
          /* Check for kernel launch errors */
          CHK_ERR(cudaPeekAtLastError());
          /* Synchronize after kernel call */

--- a/arch/arch_device_cuda.h
+++ b/arch/arch_device_cuda.h
@@ -314,12 +314,12 @@ namespace arch{
    }
 
 /* A general device kernel for reductions */
-   template <reduce_op Op, uint NDim, uint NReduStatic, typename Lambda, typename T>
+   template <uint Blocksize, reduce_op Op, uint NDim, uint NReduStatic, typename Lambda, typename T>
    __global__ static void __launch_bounds__(ARCH_BLOCKSIZE_R)
       reduction_kernel(Lambda loop_body, const T * __restrict__ init_val, T * __restrict__ rslt, const uint * __restrict__ lims, const uint n_total, const uint n_redu_dynamic, T *thread_data_dynamic)
    {
-      /* Specialize BlockReduce for a 1D block of ARCH_BLOCKSIZE_R threads of type `T` */
-      typedef cub::BlockReduce<T, ARCH_BLOCKSIZE_R, cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1> BlockReduce;
+      /* Specialize BlockReduce for a 1D block of Blocksize threads of type `T` */
+      typedef cub::BlockReduce<T, Blocksize, cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1> BlockReduce;
 
       /* Dynamic shared memory declaration */
       extern __shared__ char temp_storage_dynamic[];
@@ -453,8 +453,18 @@ namespace arch{
          /* Allocate memory for the thread data values */
          CHK_ERR(cudaMallocAsync(&d_thread_data_dynamic, n_reductions * blocksize * gridsize * sizeof(T), gpuStreamList[thread_id]));
          /* Call the kernel (the number of reductions not known at compile time) */
-         if(gridsize > 0)
-            reduction_kernel<Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+         if(gridsize > 0){
+            if(blocksize == ARCH_BLOCKSIZE_R){
+               reduction_kernel<ARCH_BLOCKSIZE_R, Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+            }
+            else if(blocksize == ARCH_BLOCKSIZE_R_SMALL){
+               reduction_kernel<ARCH_BLOCKSIZE_R_SMALL, Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+            }
+            else{
+               printf("The blocksize (%u) does not match with any of the predetermined block sizes! The error occurred in %s at line %d\n", blocksize, __FILE__, __LINE__);
+               exit(1);
+            }
+         }      
          /* Check for kernel launch errors */
          CHK_ERR(cudaPeekAtLastError());
          /* Synchronize and free the thread data allocation */
@@ -467,7 +477,7 @@ namespace arch{
          const uint gridsize = (n_total - 1 + blocksize) / blocksize;
          /* Call the kernel (the number of reductions known at compile time) */
          if(gridsize > 0)
-            reduction_kernel<Op, NDim, NReduStatic><<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+            reduction_kernel<ARCH_BLOCKSIZE_R, Op, NDim, NReduStatic><<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
          /* Check for kernel launch errors */
          CHK_ERR(cudaPeekAtLastError());
          /* Synchronize after kernel call */

--- a/arch/arch_device_hip.h
+++ b/arch/arch_device_hip.h
@@ -291,12 +291,12 @@ __device__ __forceinline__ static void loop_eval(const uint idx_glob, const uint
 }
 
 /* A general device kernel for reductions */
-template <reduce_op Op, uint NDim, uint NReduStatic, typename Lambda, typename T>
+   template <uint Blocksize, reduce_op Op, uint NDim, uint NReduStatic, typename Lambda, typename T>
 __global__ static void __launch_bounds__(ARCH_BLOCKSIZE_R)
 reduction_kernel(Lambda loop_body, const T * __restrict__ init_val, T * __restrict__ rslt, const uint * __restrict__ lims, const uint n_total, const uint n_redu_dynamic, T *thread_data_dynamic)
 {
-  /* Specialize BlockReduce for a 1D block of ARCH_BLOCKSIZE_R threads of type `T` */
-  typedef hipcub::BlockReduce<T, ARCH_BLOCKSIZE_R, hipcub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1> BlockReduce;
+  /* Specialize BlockReduce for a 1D block of Blocksize threads of type `T` */
+  typedef hipcub::BlockReduce<T, Blocksize, hipcub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1> BlockReduce;
 
   /* Dynamic shared memory declaration */
   extern __shared__ char temp_storage_dynamic[];
@@ -426,8 +426,18 @@ __forceinline__ static void parallel_reduce_driver(const uint (&limits)[NDim], L
     /* Allocate memory for the thread data values */
     CHK_ERR(hipMallocAsync(&d_thread_data_dynamic, n_reductions * blocksize * gridsize * sizeof(T), gpuStreamList[thread_id]));
     /* Call the kernel (the number of reductions not known at compile time) */
-    if(gridsize > 0)
-      reduction_kernel<Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+    if(gridsize > 0){
+       if(blocksize == ARCH_BLOCKSIZE_R){
+          reduction_kernel<ARCH_BLOCKSIZE_R, Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+       }
+       else if(blocksize == ARCH_BLOCKSIZE_R_SMALL){
+          reduction_kernel<ARCH_BLOCKSIZE_R_SMALL, Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+       }
+       else{
+          printf("The blocksize (%u) does not match with any of the predetermined block sizes! The error occurred in %s at line %d\n", blocksize, __FILE__, __LINE__);
+          exit(1);
+       }
+    }   
     /* Check for kernel launch errors */
     CHK_ERR(hipPeekAtLastError());
     /* Synchronize and free the thread data allocation */
@@ -440,7 +450,7 @@ __forceinline__ static void parallel_reduce_driver(const uint (&limits)[NDim], L
     const uint gridsize = (n_total - 1 + blocksize) / blocksize;
     /* Call the kernel (the number of reductions known at compile time) */
     if(gridsize > 0)
-      reduction_kernel<Op, NDim, NReduStatic><<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+      reduction_kernel<ARCH_BLOCKSIZE_R, Op, NDim, NReduStatic><<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
     /* Check for kernel launch errors */
     CHK_ERR(hipPeekAtLastError());
     /* Synchronize after kernel call */

--- a/arch/arch_device_hip.h
+++ b/arch/arch_device_hip.h
@@ -426,7 +426,8 @@ __forceinline__ static void parallel_reduce_driver(const uint (&limits)[NDim], L
     /* Allocate memory for the thread data values */
     CHK_ERR(hipMallocAsync(&d_thread_data_dynamic, n_reductions * blocksize * gridsize * sizeof(T), gpuStreamList[thread_id]));
     /* Call the kernel (the number of reductions not known at compile time) */
-    reduction_kernel<Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+    if(gridsize > 0)
+      reduction_kernel<Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
     /* Check for kernel launch errors */
     CHK_ERR(hipPeekAtLastError());
     /* Synchronize and free the thread data allocation */
@@ -438,7 +439,8 @@ __forceinline__ static void parallel_reduce_driver(const uint (&limits)[NDim], L
     const uint blocksize = ARCH_BLOCKSIZE_R;
     const uint gridsize = (n_total - 1 + blocksize) / blocksize;
     /* Call the kernel (the number of reductions known at compile time) */
-    reduction_kernel<Op, NDim, NReduStatic><<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+    if(gridsize > 0)
+      reduction_kernel<Op, NDim, NReduStatic><<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
     /* Check for kernel launch errors */
     CHK_ERR(hipPeekAtLastError());
     /* Synchronize after kernel call */


### PR DESCRIPTION
This PR fixes two issues showing up only with CUDA, but not with HIP+ROCM. First is a kernel launch issue noticed by Markus, and the second is an issue with cub-library tempstorage type size, which depends on the block size. The bug fixes have been added to HIP backend as well.