### PR TITLE
Makefile and CI integration for Barcelona's "arriesgado" RISC-V cluster

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -86,6 +86,25 @@ jobs:
           retention-days: 5
           if-no-files-found: error
 
+  build_libraries_riscv:
+    # Build libraries for the current version of the docker image
+    # (to be used in any subsequent compilation and run jobs on said image)
+    runs-on: risc-v
+
+    steps:
+      - name: Setup libraries dir
+        run: |
+          srun --interactive -p arriesgado-jammy --pty -t 01:00:00 bash -lc 'module load openmpi; cp ~/vlasiator/build_libraries.sh .; ./build_libraries.sh arriesgado'
+      - name: Build libraries tar
+        run: tar --zstd -cvf libraries-arriesgado.tar.zstd libraries-arriesgado/
+      - name: Upload libraries as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: libraries-arriesgado
+          path: libraries-arriesgado.tar.zstd
+          retention-days: 5
+          if-no-files-found: error
+
   build_production:
     # Build Vlasiator witth production flags
     runs-on: ubuntu-latest
@@ -137,6 +156,28 @@ jobs:
     #  with:
     #    name: Testpackage build log
     #    path: build.log
+
+  build_riscv:
+    runs-on: risc-v
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3 
+    - name: Download libraries
+      uses: actions/download-artifact@v3
+      with:
+        name: libraries-arriesgado
+    - name: Unpack libraries
+      run: tar --zstd -xvf libraries-arriesgado.tar.zstd
+    - name: Compile vlasiator (RISC-V)
+      run: |
+          srun --interactive -p arriesgado-jammy --pty -t 01:00:00 bash -lc 'module load boost eigen papi openmpi; export VLASIATOR_ARCH=arriesgado; make -j4'
+    - name: Upload riscv binary
+      uses: actions/upload-artifact@v3
+      with:
+        name: vlasiator-riscv
+        path: vlasiator
+        if-no-files-found: error
 
   build_tools:
     # Build vlsvdiff and vlsvextract for testepackage use

--- a/MAKE/Makefile.arriesgado
+++ b/MAKE/Makefile.arriesgado
@@ -1,0 +1,57 @@
+# Makefile for the arriesgado RISCV cluster at BSC
+#
+# Note:
+# o Load modules:
+#   module load boost eigen papi openmpi
+# o Zoltan's configure script requires a "--build=arm-linux-gnu" parameter.
+#   (Yes, this needs to be arm, not riscv!)
+
+CMP = mpic++
+LNK = mpic++
+
+#======== Vectorization ==========
+#Set vector backend type for vlasov solvers, sets precision and length. 
+#Options: 
+# AVX:      VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
+# AVX512:   VEC8D_AGNER, VEC16F_AGNER
+# Fallback: VEC4D_FALLBACK, VEC4F_FALLBACK, VEC8F_FALLBACK
+
+ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
+#Single-precision        
+        VECTORCLASS = VEC8F_FALLBACK
+        INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/../vlasiator/vlasovsolver
+else
+#Double-precision
+#       VECTORCLASS = VEC4D_AGNER
+#       INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass
+        VECTORCLASS = VEC4D_FALLBACK
+        INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/../vlasiator/vlasovsolver
+endif
+
+FLAGS =
+# note: std was c++11
+# note: testpackage settings missing
+CXXFLAGS = -O3 -std=c++17 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces  -fopenmp -march=rv64imafdc
+MATHFLAGS = -ffast-math
+LDFLAGS = -fopenmp
+LIB_MPI =
+# LIB_MPI = 
+
+LIBRARY_PREFIX = libraries-arriesgado
+
+INC_BOOST =
+LIB_BOOST = ${BOOST_LIBS} -lboost_program_options
+
+INC_ZOLTAN = -I${LIBRARY_PREFIX}/include
+LIB_ZOLTAN = -L${LIBRARY_PREFIX}/lib -lzoltan
+
+INC_VLSV = -I$(LIBRARY_PREFIX)/vlsv
+LIB_VLSV = -L$(LIBRARY_PREFIX)/vlsv -lvlsv
+
+INC_DCCRG = -I${LIBRARY_PREFIX}/dccrg -I${LIBRARY_PREFIX}/fsgrid
+
+LIB_PROFILE = -L${LIBRARY_PREFIX}/phiprof/lib -lphiprof -Wl,-rpath=${LIBRARY_PREFIX}/lib 
+INC_PROFILE = -I${LIBRARY_PREFIX}/phiprof/include
+INC_TOPO =
+
+INC_EIGEN = ${EIGEN3_INCL}


### PR DESCRIPTION
This PR includes a Makefile for Barcelona Supercomputing Centre's "arriesgado" cluster of SiFive RISC-V boards. Note that these do not have a vector extension, but this is purely to keep up the code's general portability to RISC-V

Since I setup a github runner there, it also adds a workflow step to our CI that should automatically build the code there.

Not 100% sure if we want to merge this, but it was an opportune moment to develop it, as I was sitting in the same room with the Barcelona people during the Plasma-PEPSC meeting in Ljubljana.