### PR TITLE
Limit PR reports to 60kb in size.

### DIFF
--- a/.github/workflows/pr_report.yml
+++ b/.github/workflows/pr_report.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           tar -xzvf testpackage-output.tar.gz
           cat testpackage_output_variables.txt >> $GITHUB_OUTPUT
+          # Limit Report filesize, as github only allows 64k PR reports
+          truncate --size='<60K' testpackage_check_description.txt
       - name: Generate PR check report
         uses: ursg/checks-action@v1.6.0
         if: always()

--- a/.github/workflows/pr_report.yml
+++ b/.github/workflows/pr_report.yml
@@ -25,7 +25,7 @@ jobs:
           tar -xzvf testpackage-output.tar.gz
           cat testpackage_output_variables.txt >> $GITHUB_OUTPUT
           # Limit Report filesize, as github only allows 64k PR reports
-          truncate --size='<60K' testpackage_check_description.txt
+          SIZE=`stat -c%s testpackage_check_description.txt` if (( SIZE > 60000 )); then truncate --size='<60K' testpackage_check_description.txt; echo -e '\nWarning: report was truncated to 60k in length.' > testpackage_check_description.txt; fi
       - name: Generate PR check report
         uses: ursg/checks-action@v1.6.0
         if: always()


### PR DESCRIPTION
If they exceed 64kb, github refuses them. This mechanism just truncates them slightly before, which might not be ideal (since it chops of information at the end), but at least allows the PR to give the proper response code. Full testpackage output can still always be looked at as part of the uploaded artefact.

Note that this is a PR directly against the master branch, as the pr_report CI workflow always runs in the context of that branch, for unexplainable github security reasons.