### PR TITLE
Try to squelch CI ucx warnings.

### DIFF
--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -56,7 +56,7 @@ export OMP_NUM_THREADS=$t
 
 #command for running stuff
 run_command="mpirun -mca pml ucx --mca opal_common_ucx_opal_mem_hooks 1 --mca btl ^vader,tcp,openib -x UCX_NET_DEVICES=mlx5_0:1 -x UCX_TLS=rc,sm -x UCX_IB_ADDR_TYPE=ib_global -np $tasks"
-small_run_command="mpirun -mca pml ucx  --mca opal_common_ucx_opal_mem_hooks 1--mca btl ^vader,tcp,openib -x UCX_NET_DEVICES=mlx5_0:1 -x UCX_TLS=rc,sm -x UCX_IB_ADDR_TYPE=ib_global -n 1 -N 1"
+small_run_command="mpirun -mca pml ucx --mca opal_common_ucx_opal_mem_hooks 1 --mca btl ^vader,tcp,openib -x UCX_NET_DEVICES=mlx5_0:1 -x UCX_TLS=rc,sm -x UCX_IB_ADDR_TYPE=ib_global -n 1 -N 1"
 run_command_tools="srun --mpi=pmix_v3 -n 1 "
 
 umask 007

--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -55,8 +55,8 @@ tasks_per_node=$(echo $units_per_node $t  | gawk '{print $1/$2}')
 export OMP_NUM_THREADS=$t
 
 #command for running stuff
-run_command="mpirun -mca pml ucx --mca btl ^vader,tcp,openib -x UCX_NET_DEVICES=mlx5_0:1 -x UCX_TLS=rc,sm -x UCX_IB_ADDR_TYPE=ib_global -np $tasks"
-small_run_command="mpirun -mca pml ucx --mca btl ^vader,tcp,openib -x UCX_NET_DEVICES=mlx5_0:1 -x UCX_TLS=rc,sm -x UCX_IB_ADDR_TYPE=ib_global -n 1 -N 1"
+run_command="mpirun -mca pml ucx --mca opal_common_ucx_opal_mem_hooks 1 --mca btl ^vader,tcp,openib -x UCX_NET_DEVICES=mlx5_0:1 -x UCX_TLS=rc,sm -x UCX_IB_ADDR_TYPE=ib_global -np $tasks"
+small_run_command="mpirun -mca pml ucx  --mca opal_common_ucx_opal_mem_hooks 1--mca btl ^vader,tcp,openib -x UCX_NET_DEVICES=mlx5_0:1 -x UCX_TLS=rc,sm -x UCX_IB_ADDR_TYPE=ib_global -n 1 -N 1"
 run_command_tools="srun --mpi=pmix_v3 -n 1 "
 
 umask 007


### PR DESCRIPTION
(These were spamming the log files, thus exceeding the 64k check
 annotation limit)

Note that this is independent from the actual limiting of PR reports to 64k as part of PR #839