### PR TITLE
Disable -ffast-math for building on carrington.

### DIFF
--- a/MAKE/Makefile.Freezer
+++ b/MAKE/Makefile.Freezer
@@ -33,7 +33,7 @@ endif
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -mfma -mavx2 -Wno-unknown-pragmas -Wno-sign-compare
 testpackage: CXXFLAGS = -g -ggdb -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -mno-avx -mno-fma -fno-unsafe-math-optimizations
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 testpackage: MATHFLAGS = -fno-unsafe-math-optimizations
 
 #LDFLAGS = -g -ggdb

--- a/MAKE/Makefile.bsc_jetsontx
+++ b/MAKE/Makefile.bsc_jetsontx
@@ -31,7 +31,7 @@ FLAGS =
 # note: std was c++11
 # note: testpackage settings missing
 CXXFLAGS = -I$(HOME)/include -O3 -std=c++17 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces  -fopenmp -march=native
-MATHFLAGS = -ffast-math
+MATHFLAGS = 
 LDFLAGS = -fopenmp
 LIB_MPI =
 # LIB_MPI = 

--- a/MAKE/Makefile.carrington_gcc_openmpi
+++ b/MAKE/Makefile.carrington_gcc_openmpi
@@ -62,7 +62,7 @@ CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2 #-flto
 testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2 -DIONOSPHERE_SORTED_SUMS
 CXXFLAGS += -Wall -Wextra -Wno-unused
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -lrt -lgfortran -std=c++17 -lgomp
 LIB_MPI = -lgomp -lmpi
 

--- a/MAKE/Makefile.cubbli20
+++ b/MAKE/Makefile.cubbli20
@@ -74,7 +74,7 @@ FLAGS =
 # Debug flags:
 #CXXFLAGS = -g  -funroll-loops -std=c++17 -fopenmp -W -Wall -pedantic -Wno-unused -fabi-version=0 -mavx
 CXXFLAGS = -O3  -funroll-loops -std=c++17 -fopenmp -W -Wall -Wno-unused -fabi-version=0 -mavx
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -L $(HOME)/lib
 LIB_MPI = -lgomp 
 

--- a/MAKE/Makefile.docker
+++ b/MAKE/Makefile.docker
@@ -24,7 +24,7 @@ FLAGS =
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -mavx2
 testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mavx
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -g
 LIB_MPI = -lgomp
 

--- a/MAKE/Makefile.hawk_gcc_mpt
+++ b/MAKE/Makefile.hawk_gcc_mpt
@@ -50,7 +50,7 @@ not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx
 testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0
 not_parallel_tools: CC_BRAND_VERSION = 4.9.2-noavx2
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS =
 LIB_MPI = -lgomp
 

--- a/MAKE/Makefile.hawk_gcc_openmpi
+++ b/MAKE/Makefile.hawk_gcc_openmpi
@@ -31,7 +31,7 @@ not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx
 testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0
 not_parallel_tools: CC_BRAND_VERSION = 4.9.2-noavx2
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS =
 LIB_MPI = -lgomp
 

--- a/MAKE/Makefile.hawk_intel_mpt
+++ b/MAKE/Makefile.hawk_intel_mpt
@@ -32,7 +32,7 @@ testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++14 -W -Wno-unused -ma
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
 not_parallel_tools: CC_BRAND_VERSION = 4.9.2-noavx2
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -qopenmp -lifcore -liomp5 -pthread -lboost_program_options -lzoltan -ljemalloc -lvlsv -lphiprof
 LIB_MPI = -lgomp
 

--- a/MAKE/Makefile.hawk_intel_openmpi
+++ b/MAKE/Makefile.hawk_intel_openmpi
@@ -32,7 +32,7 @@ testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++14 -W -Wno-unused -ma
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
 not_parallel_tools: CC_BRAND_VERSION = 4.9.2-noavx2
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -qopenmp -lifcore -liomp5 -pthread -lboost_program_options -lzoltan -ljemalloc -lvlsv -lphiprof
 LIB_MPI = -lgomp
 

--- a/MAKE/Makefile.home
+++ b/MAKE/Makefile.home
@@ -6,7 +6,7 @@ FLAGS =
 # note: testpackage settings missing
 CXXFLAGS = -I$(HOME)/include -I/usr/include -L$(HOME)/lib -L/usr/lib -O3 -funroll-loops -std=c++17 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces  -fopenmp
 #CXXFLAGS = -I$(HOME)/include -L$(HOME)/lib -O0 -funroll-loops -std=c++17 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces -g -fopenmp
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -L $(HOME)/lib
 LIB_MPI = -lgomp
 # LIB_MPI = 

--- a/MAKE/Makefile.kstppd
+++ b/MAKE/Makefile.kstppd
@@ -28,7 +28,7 @@ FLAGS =
 CXXFLAGS = -O3   -funroll-loops -std=c++17 -fopenmp -W -Wall -Wno-unused -Wno-unused-parameter -Wno-missing-braces -fabi-version=0 -mavx
 testpackage: CXXFLAGS = -g -ggdb -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mno-avx -mno-fma -fno-unsafe-math-optimizations
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE -DPAPI_MEM
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 testpackage: MATHFLAGS =  -fno-unsafe-math-optimizations
 LDFLAGS = -L $(HOME)/lib
 LIB_MPI = -lgomp -lpapi 

--- a/MAKE/Makefile.lumi_cpeGnu
+++ b/MAKE/Makefile.lumi_cpeGnu
@@ -31,7 +31,7 @@ FLAGS =
 CXXFLAGS += -g -ggdb -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mfma -mavx2 -Wno-unused-parameter
 testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++20 -mno-fma -mno-avx2 -mno-avx
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -lrt -fopenmp -lgomp
 LIB_MPI = -lgomp
 

--- a/MAKE/Makefile.lumi_cray
+++ b/MAKE/Makefile.lumi_cray
@@ -27,7 +27,7 @@ CC_BRAND_VERSION = 9.3.0
 CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mfma -mavx2
 testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++20 -mno-fma -mno-avx2 -mno-avx
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -lrt -fopenmp
 LIB_MPI = -fopenmp
 

--- a/MAKE/Makefile.lumi_gnu
+++ b/MAKE/Makefile.lumi_gnu
@@ -27,7 +27,7 @@ CC_BRAND_VERSION = 9.3.0
 CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mfma -mavx2
 testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++20 -mno-fma -mno-avx2 -mno-avx
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -lrt -fopenmp
 LIB_MPI = -fopenmp
 

--- a/MAKE/Makefile.mahti_gcc
+++ b/MAKE/Makefile.mahti_gcc
@@ -33,7 +33,7 @@ CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi
 testpackage: CXXFLAGS = -g -ggdb -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -mfma -fpermissive
 
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -lrt
 # Add -lnvToolsExt for nvtx profiling
 LIB_MPI = -lgomp

--- a/MAKE/Makefile.perlmutter_gcc
+++ b/MAKE/Makefile.perlmutter_gcc
@@ -27,7 +27,7 @@ CC_BRAND_VERSION = 11.2.0
 CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mfma -mavx2
 testpackage: CXXFLAGS = -g -O2 -fopenmp -funroll-loops -std=c++20 -mno-fma -mno-avx2 -mno-avx
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -lrt -fopenmp -lgomp
 LIB_MPI = -lgomp
 

--- a/MAKE/Makefile.puhti_gcc
+++ b/MAKE/Makefile.puhti_gcc
@@ -24,7 +24,7 @@ CC_BRAND_VERSION = 9.1.0
 CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -march=native -mfma -mavx512f
 testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0 -mfma
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -lrt
 LIB_MPI = -lgomp 
 

--- a/MAKE/Makefile.puhti_intel
+++ b/MAKE/Makefile.puhti_intel
@@ -24,7 +24,7 @@ CC_BRAND_VERSION = 19.0.4
 CXXFLAGS += -traceback -g -O3 -qopenmp -std=c++17 -W -Wall -Wno-unused -xHost -ipo -qopt-zmm-usage=high 
 testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++17 -W -Wno-unused -xHost -ipo
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -qopenmp -lifcore -ipo
 LIB_MPI = 
 

--- a/MAKE/Makefile.ukko_gcc_openmpi
+++ b/MAKE/Makefile.ukko_gcc_openmpi
@@ -62,7 +62,7 @@ CC_BRAND_VERSION = 11.2.0
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mavx -march=znver2 #-flto
 testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx -march=znver2
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -lrt -lgfortran -std=c++17 -lgomp
 LIB_MPI = -lgomp -lmpi
 

--- a/MAKE/Makefile.vorna_gcc
+++ b/MAKE/Makefile.vorna_gcc
@@ -38,7 +38,7 @@ CXXFLAGS += -g -O3 -fopenmp -funroll-loops -std=c++17 -mavx
 testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -mavx
 CXXFLAGS += -Wall -Wextra -Wno-unused
 
-MATHFLAGS = -ffast-math
+MATHFLAGS =
 LDFLAGS = -lrt -lgfortran -std=c++17
 LIB_MPI = -lgomp
 


### PR DESCRIPTION
Because fast math is bad for you and we shouldn't have had it there in the first place!

(and, in particular, not for CI test runs)