### PR TITLE
Prefer --offload-arch over the deprecated --amdgpu-target and fix commit parsing in Makefile.

### DIFF
--- a/MAKE/Makefile.lumi_hipcc
+++ b/MAKE/Makefile.lumi_hipcc
@@ -35,11 +35,11 @@ USE_HIP=1
 # LDFLAGS flags for linker
 # Important note: Do not edit COMPFLAGS in this file!
 
-CXXFLAGS += -g -ggdb -O3 -x hip --amdgpu-target=gfx90a:xnack- -march=znver3 -std=c++17 -funroll-loops -fopenmp -fgpu-rdc -I. -Ihip -Iomp -I${CRAY_MPICH_DIR}/include -W -Wall -Wno-unused-parameter -Wno-unused-result -Wno-unused-function -Wno-unused-variable -Wno-unknown-pragmas -Wno-deprecated-register -Wno-unused-but-set-variable
+CXXFLAGS += -g -ggdb -O3 -x hip --offload-arch=gfx90a:xnack- -march=znver3 -std=c++17 -funroll-loops -fopenmp -fgpu-rdc -I. -Ihip -Iomp -I${CRAY_MPICH_DIR}/include -W -Wall -Wno-unused-parameter -Wno-unused-result -Wno-unused-function -Wno-unused-variable -Wno-unknown-pragmas -Wno-deprecated-register -Wno-unused-but-set-variable
 
-testpackage: CXXFLAGS = -g -ggdb -O2 -x hip --amdgpu-target=gfx90a:xnack- -march=znver3 -std=c++17 -fopenmp -fgpu-rdc -I. -Ihip -Iomp -I${CRAY_MPICH_DIR}/include -fgpu-sanitize  -W -Wall -Wno-unused-parameter -Wno-unused-result -Wno-unused-function -Wno-unused-variable -Wno-unknown-pragmas -Wno-deprecated-register -Wno-unused-but-set-variable
+testpackage: CXXFLAGS = -g -ggdb -O2 -x hip --offload-arch=gfx90a:xnack- -march=znver3 -std=c++17 -fopenmp -fgpu-rdc -I. -Ihip -Iomp -I${CRAY_MPICH_DIR}/include -fgpu-sanitize  -W -Wall -Wno-unused-parameter -Wno-unused-result -Wno-unused-function -Wno-unused-variable -Wno-unknown-pragmas -Wno-deprecated-register -Wno-unused-but-set-variable
 
-LDFLAGS = -fopenmp --hip-link -lrt -lpthread -fgpu-rdc -L${CRAY_MPICH_DIR}/lib ${PE_MPICH_GTL_DIR_amd_gfx90a} --amdgpu-target=gfx90a:xnack-
+LDFLAGS = -fopenmp --hip-link -lrt -lpthread -fgpu-rdc -L${CRAY_MPICH_DIR}/lib ${PE_MPICH_GTL_DIR_amd_gfx90a} --offload-arch=gfx90a:xnack-
 LIB_MPI = -lmpi ${PE_MPICH_GTL_LIBS_amd_gfx90a}
 
 # -fgpu-rdc # relocatable device code, needed for the velocity mesh

--- a/Makefile
+++ b/Makefile
@@ -236,11 +236,12 @@ cleantools:
 # Rules for making each object file needed by the executable
 
 # Extract commits for used libraries, silencing errors of missing repositories
-COMMIT_DCCRG=$(shell cd ${subst -system,,${subst -I,,${INC_DCCRG}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
-COMMIT_FSGRID=$(shell cd ${subst -system,,${subst -I,,${INC_FSGRID}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
-COMMIT_VLSV=$(shell cd ${subst -system,,${subst -I,,${INC_VLSV}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
-COMMIT_HASHINATOR=$(shell cd ${subst -system,,${subst -I,,${INC_HASHINATOR}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
-COMMIT_PROFILE=$(shell cd ${subst -system,,${subst -I,,${INC_PROFILE}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
+COMMIT_DCCRG=$(shell cd ${subst -isystem,,${subst -I,,${INC_DCCRG}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
+COMMIT_FSGRID=$(shell cd ${subst -isystem,,${subst -I,,${INC_FSGRID}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
+COMMIT_VLSV=$(shell cd ${subst -isystem,,${subst -I,,${INC_VLSV}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
+COMMIT_HASHINATOR=$(shell cd ${subst -isystem,,${subst -I,,${INC_HASHINATOR}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
+COMMIT_PROFILE=$(shell cd ${subst -isystem,,${subst -I,,${INC_PROFILE}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
+
 # Build version description file
 version.cpp: FORCE
 	@echo "[GENERATE] version.cpp"


### PR DESCRIPTION
`--amdgpu-target` is deprecated and include flags use `-isystem` as opposed to `-system`.