### PR TITLE
Add precommit config, so that precommit CI can auto-fix whitespace.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+exclude: Doxyfile|libraries|Makefile|README|INSTALL|testpackage|doc|\.txt|\.tex|\.cfg|\.vtk|\.yml|\.clang-format|\.m$|\.sh|\.py
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.4
+    hooks:
+    -   id: remove-tabs
+        args: [--whitespaces-count, '8']
+#-   repo: https://github.com/pocc/pre-commit-hooks
+#    rev: v1.3.5
+#    hooks:
+#    -   id: clang-format
+#        args: [-i]
+
+ci:
+    autofix_commit_msg: |
+      automatic style and whitespace fixes
+    autofix_prs: true
+    autoupdate_branch: dev


### PR DESCRIPTION
See https://pre-commit.com/ and https://pre-commit.ci/ for details.

This config is pretty conservative, and only concerns itself with fixing trailing whitespace and turning tabs into spaces.
I'm not even sure if the large file checker has any effect in CI mode, but we'll see.