### PR TITLE
Call MPI_Abort from all ranks in abort_mpi.

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -96,7 +96,6 @@ void bailout(
       } else {
          std::cerr << __FILE__ << ":" << __LINE__ << ": " << str << std::endl;
       }
-
-      MPI_Abort(MPI_COMM_WORLD, 1);
    }
+   MPI_Abort(MPI_COMM_WORLD, 1);
 }


### PR DESCRIPTION
This squeches a warning about "noreturn" function returning.