### PR TITLE
Disable unrefine threshold output

### DIFF
--- a/parameters.cpp
+++ b/parameters.cpp
@@ -449,10 +449,10 @@ bool P::addParameters() {
    RP::add("AMR.should_filter","If true, filter vlasov grid with boxcar filter on restart",false);
    RP::add("AMR.use_alpha1","Use the maximum of dimensionless gradients alpha_1 as a refinement index", true);
    RP::add("AMR.alpha1_refine_threshold","Determines the minimum value of alpha_1 to refine cells", 0.5);
-   RP::add("AMR.alpha1_coarsen_threshold","Determines the maximum value of alpha_1 to unrefine cells", -1.0);
+   RP::add("AMR.alpha1_coarsen_threshold","Determines the maximum value of alpha_1 to unrefine cells, default half of the refine threshold", -1.0);
    RP::add("AMR.use_alpha2","Use J/B_perp as a refinement index", true);
    RP::add("AMR.alpha2_refine_threshold","Determines the minimum value of alpha_2 to refine cells", 0.5);
-   RP::add("AMR.alpha2_coarsen_threshold","Determines the maximum value of alpha_2 to unrefine cells", -1.0);
+   RP::add("AMR.alpha2_coarsen_threshold","Determines the maximum value of alpha_2 to unrefine cells, default half of the refine threshold", -1.0);
    RP::add("AMR.refine_cadence","Refine every nth load balance", 5);
    RP::add("AMR.refine_after","Start refinement after this many simulation seconds", 0.0);
    RP::add("AMR.refine_radius","Maximum distance from Earth to refine", LARGE_REAL);
@@ -711,9 +711,6 @@ void Parameters::getParameters() {
    RP::get("AMR.alpha1_refine_threshold",P::alphaRefineThreshold);
    RP::get("AMR.alpha1_coarsen_threshold",P::alphaCoarsenThreshold);
    if (P::useAlpha && P::alphaCoarsenThreshold < 0) {
-      if (myRank == MASTER_RANK) {
-         cerr << "alpha_1 coarsening threshold not set, using half of refine threshold" << endl;
-      }
       P::alphaCoarsenThreshold = P::alphaRefineThreshold / 2.0;
    }
    if (P::useAlpha && P::alphaRefineThreshold < 0) {
@@ -726,9 +723,6 @@ void Parameters::getParameters() {
    RP::get("AMR.alpha2_refine_threshold",P::jperbRefineThreshold);
    RP::get("AMR.alpha2_coarsen_threshold",P::jperbCoarsenThreshold);
    if (P::useJPerB && P::jperbCoarsenThreshold < 0) {
-      if (myRank == MASTER_RANK) {
-         cerr << "alpha_2 coarsening threshold not set, using half of refine threshold" << endl;
-      }
       P::jperbCoarsenThreshold = P::jperbRefineThreshold / 2.0;
    }
    if (P::useJPerB && P::jperbRefineThreshold < 0) {


### PR DESCRIPTION
Remove output for automatic setting of unrefine threshold and document this in config parameter description instead.