### PR TITLE
Reduce compiler optimizations on arriesgado, for faster RISC-V compiles

### DIFF
--- a/MAKE/Makefile.arriesgado
+++ b/MAKE/Makefile.arriesgado
@@ -30,7 +30,7 @@ endif
 
 FLAGS =
 # note: std was c++11
-CXXFLAGS = -O3 -std=c++17 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces  -fopenmp -march=rv64imafdc -isystem /usr/lib/gcc/riscv64-linux-gnu/11/include/
+CXXFLAGS = -O1 -std=c++17 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces  -fopenmp -march=rv64imafdc -isystem /usr/lib/gcc/riscv64-linux-gnu/11/include/
 MATHFLAGS = -ffast-math -fno-finite-math-only
 testpackage: MATHFLAGS = -fno-unsafe-math-optimizations
 LDFLAGS = -fopenmp


### PR DESCRIPTION
Hopefully, this makes it such that RISC-V compilation is no longer the CI bottleneck