### PR TITLE
Actually build on multiple cores on arriesgado.

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Submit library job
         run: |
-          srun --interactive -p arriesgado-jammy -J vlasiator-libs --pty -t 01:00:00 bash -lc 'module load openmpi; cp ~/vlasiator/build_libraries.sh .; ./build_libraries.sh arriesgado'
+          srun --interactive -p arriesgado-jammy -J vlasiator-libs -n 1 -c 4 --pty -t 01:00:00 bash -lc 'module load openmpi; cp ~/vlasiator/build_libraries.sh .; ./build_libraries.sh arriesgado'
       - name: Build libraries tar
         run: tar -czvf libraries-arriesgado.tar.gz libraries-arriesgado/
       - name: Upload libraries as artifact
@@ -174,7 +174,7 @@ jobs:
       run: VLASIATOR_ARCH=arriesgado make clean
     - name: Compile vlasiator (RISC-V)
       run: |
-          srun --interactive -p arriesgado-jammy -J vlasiator_build --pty -t 01:00:00 bash -lc 'module load boost papi openmpi; export VLASIATOR_ARCH=arriesgado; make -j4'
+          srun --interactive -p arriesgado-jammy -J vlasiator_build -n 1 -c 4 --pty -t 01:00:00 bash -lc 'module load boost papi openmpi; export VLASIATOR_ARCH=arriesgado; make -j4'
     - name: Upload riscv binary
       uses: actions/upload-artifact@v3
       with:

--- a/MAKE/Makefile.arriesgado
+++ b/MAKE/Makefile.arriesgado
@@ -30,7 +30,7 @@ endif
 
 FLAGS =
 # note: std was c++11
-CXXFLAGS = -O3 -std=c++17 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces  -fopenmp -march=rv64imafdc -isystem /usr/lib/gcc/riscv64-linux-gnu/11/include/
+CXXFLAGS = -O1 -std=c++17 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces  -fopenmp -march=rv64imafdc -isystem /usr/lib/gcc/riscv64-linux-gnu/11/include/
 MATHFLAGS = -ffast-math -fno-finite-math-only
 testpackage: MATHFLAGS = -fno-unsafe-math-optimizations
 LDFLAGS = -fopenmp


### PR DESCRIPTION
A slurm parameter for multiple cores was missing, so I suppose we were actually running on a single core before.

Let's see if this actually has a positive effect on riscv build times.