### PR TITLE
Use multiple handlers of device mesh wrapper to avoid relocatable code device builds

### DIFF
--- a/MAKE/Makefile.lumi_hipcc
+++ b/MAKE/Makefile.lumi_hipcc
@@ -1,5 +1,5 @@
 CMP = hipcc
-LNK = hipcc
+LNK = clang++
 
 # Modules loaded (after clean shell, no module purging, one-by-one not oneline)
 # module load LUMI/22.08
@@ -35,11 +35,11 @@ USE_HIP=1
 # LDFLAGS flags for linker
 # Important note: Do not edit COMPFLAGS in this file!
 
-CXXFLAGS += -g -ggdb -O3 -x hip --amdgpu-target=gfx90a:xnack- -march=znver3 -std=c++17 -funroll-loops -fopenmp -fgpu-rdc -I. -Ihip -Iomp -I${CRAY_MPICH_DIR}/include -W -Wall -Wno-unused-parameter -Wno-unused-result -Wno-unused-function -Wno-unused-variable -Wno-unknown-pragmas -Wno-deprecated-register -Wno-unused-but-set-variable
+CXXFLAGS += -g -ggdb -O3 -x hip --offload-arch=gfx90a:xnack- -march=znver3 -std=c++17 -funroll-loops -fopenmp -I. -Ihip -Iomp -I${CRAY_MPICH_DIR}/include -W -Wall -Wno-unused-parameter -Wno-unused-result -Wno-unused-function -Wno-unused-variable -Wno-unknown-pragmas -Wno-deprecated-register -Wno-unused-but-set-variable
 
-testpackage: CXXFLAGS = -g -ggdb -O2 -x hip --amdgpu-target=gfx90a:xnack- -march=znver3 -std=c++17 -fopenmp -fgpu-rdc -I. -Ihip -Iomp -I${CRAY_MPICH_DIR}/include -fgpu-sanitize  -W -Wall -Wno-unused-parameter -Wno-unused-result -Wno-unused-function -Wno-unused-variable -Wno-unknown-pragmas -Wno-deprecated-register -Wno-unused-but-set-variable
+testpackage: CXXFLAGS = -g -ggdb -O2 -x hip --offload-arch=gfx90a:xnack- -march=znver3 -std=c++17 -fopenmp -I. -Ihip -Iomp -I${CRAY_MPICH_DIR}/include -fgpu-sanitize  -W -Wall -Wno-unused-parameter -Wno-unused-result -Wno-unused-function -Wno-unused-variable -Wno-unknown-pragmas -Wno-deprecated-register -Wno-unused-but-set-variable
 
-LDFLAGS = -fopenmp --hip-link -lrt -lpthread -fgpu-rdc -L${CRAY_MPICH_DIR}/lib ${PE_MPICH_GTL_DIR_amd_gfx90a} --amdgpu-target=gfx90a:xnack-
+LDFLAGS = -fopenmp -lrt -lpthread -L${CRAY_MPICH_DIR}/lib ${PE_MPICH_GTL_DIR_amd_gfx90a} -L${ROCM_PATH}/lib -lamdhip64
 LIB_MPI = -lmpi ${PE_MPICH_GTL_LIBS_amd_gfx90a}
 
 # -fgpu-rdc # relocatable device code, needed for the velocity mesh

--- a/Makefile
+++ b/Makefile
@@ -236,11 +236,12 @@ cleantools:
 # Rules for making each object file needed by the executable
 
 # Extract commits for used libraries, silencing errors of missing repositories
-COMMIT_DCCRG=$(shell cd ${subst -system,,${subst -I,,${INC_DCCRG}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
-COMMIT_FSGRID=$(shell cd ${subst -system,,${subst -I,,${INC_FSGRID}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
-COMMIT_VLSV=$(shell cd ${subst -system,,${subst -I,,${INC_VLSV}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
-COMMIT_HASHINATOR=$(shell cd ${subst -system,,${subst -I,,${INC_HASHINATOR}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
-COMMIT_PROFILE=$(shell cd ${subst -system,,${subst -I,,${INC_PROFILE}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
+COMMIT_DCCRG=$(shell cd ${subst -isystem,,${subst -I,,${INC_DCCRG}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
+COMMIT_FSGRID=$(shell cd ${subst -isystem,,${subst -I,,${INC_FSGRID}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
+COMMIT_VLSV=$(shell cd ${subst -isystem,,${subst -I,,${INC_VLSV}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
+COMMIT_HASHINATOR=$(shell cd ${subst -isystem,,${subst -I,,${INC_HASHINATOR}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
+COMMIT_PROFILE=$(shell cd ${subst -isystem,,${subst -I,,${INC_PROFILE}}} && git log -1 --pretty=format:"%H" 2>/dev/null)
+
 # Build version description file
 version.cpp: FORCE
 	@echo "[GENERATE] version.cpp"

--- a/velocity_mesh_parameters.cpp
+++ b/velocity_mesh_parameters.cpp
@@ -11,7 +11,6 @@
 static vmesh::MeshWrapper *meshWrapper;
 
 #ifdef USE_GPU
-__device__ __constant__ vmesh::MeshWrapper *meshWrapperDev;
 vmesh::MeshWrapper* MWdev;
 std::array<vmesh::MeshParameters,MAX_VMESH_PARAMETERS_COUNT> *velocityMeshes_upload;
 
@@ -33,9 +32,22 @@ vmesh::MeshWrapper* vmesh::host_getMeshWrapper() {
 #ifdef USE_GPU
 //#pragma hd_warning_disable // only applies to next function
 #pragma nv_diag_suppress=20091
-ARCH_HOSTDEV vmesh::MeshWrapper* vmesh::gpu_getMeshWrapper() {
-   return meshWrapperDev;
+// We record the set of constant memory symbols to static arrays. We are avoiding using objects with non-trivial Ctors
+// to not risk they to be constructed after the static object that uses them. There will be an instance of the static
+// objects per compilation unit, so the ordering is hard to control.
+static vmesh::MeshWrapper** meshWrapperDevRegister[128] = {0};
+vmesh::meshWrapperDevRegistor::meshWrapperDevRegistor(vmesh::MeshWrapper*& v) {
+   for (size_t InstanceIdx = 0; InstanceIdx < sizeof(meshWrapperDevRegister) / sizeof(vmesh::MeshWrapper**);
+        ++InstanceIdx)
+      if (auto*& slot = meshWrapperDevRegister[InstanceIdx]; !slot) {
+         slot = &v;
+         printf("Got instance of device mesh wrapper handler %p (index %ld)\n", &v, InstanceIdx);
+         return;
+      }
+
+   assert(false && "Not enough slots to register mesh wrapper slots.");
 }
+
 void vmesh::MeshWrapper::uploadMeshWrapper() {
    // Store address to velocityMeshes array
    std::array<vmesh::MeshParameters,MAX_VMESH_PARAMETERS_COUNT> * temp = meshWrapper->velocityMeshes;
@@ -48,7 +60,16 @@ void vmesh::MeshWrapper::uploadMeshWrapper() {
    CHK_ERR( gpuMalloc((void **)&MWdev, sizeof(vmesh::MeshWrapper)) );
    CHK_ERR( gpuMemcpy(MWdev, meshWrapper, sizeof(vmesh::MeshWrapper),gpuMemcpyHostToDevice) );
    // Set the global symbol of meshWrapper
-   CHK_ERR( gpuMemcpyToSymbol(meshWrapperDev, &MWdev, sizeof(vmesh::MeshWrapper*)) );
+   for (size_t InstanceIdx = 0; InstanceIdx < sizeof(meshWrapperDevRegister) / sizeof(vmesh::MeshWrapper**);
+        ++InstanceIdx)
+      if (auto* slot = meshWrapperDevRegister[InstanceIdx]; slot) {
+         printf("Setting device mesh wrapper handler %p (index %ld)\n", slot, InstanceIdx);
+         CHK_ERR( gpuMemcpyToSymbol(*slot, &MWdev, sizeof(vmesh::MeshWrapper*)) );
+      } else
+         break;
+
+   printf("Done setting all instances of device mesh wrapper handler!\n");
+
    // Copy host-side address back
    meshWrapper->velocityMeshes = temp;
    // And sync
@@ -57,7 +78,7 @@ void vmesh::MeshWrapper::uploadMeshWrapper() {
 void vmesh::deallocateMeshWrapper() {
    CHK_ERR( gpuFree(velocityMeshes_upload) );
    CHK_ERR( gpuFree(MWdev) );
-   CHK_ERR( gpuFree(meshWrapperDev) );
+   CHK_ERR( gpuFree(meshWrapperDevInstance) );
    // And sync
    CHK_ERR( gpuDeviceSynchronize() );
 }


### PR DESCRIPTION
This PR remove the relocatable code build and link options for hipcc builds and only does host code linking using clang++.

To avoid further code disruption, the idea pursued is to let each compilation unit have their own instance of the device pointer to the device mesh wrapper in constant memory and use static object Ctors to facilitate the registration of all these instances so that each can be initialized.

The downside is that there will be extra pointers in device memory (66 at the moment - 528 bytes) the upside is that parallel builds are a small fraction of the time they used to be. There should't be any performance degradation.

Portability of the approach needs to be verified to NVIDIA toolchain.