### PR TITLE
Avoid rdc device code mk2

### DIFF
--- a/MAKE/Makefile.Freezer_cuda
+++ b/MAKE/Makefile.Freezer_cuda
@@ -45,9 +45,9 @@ LNK = mpic++
 # Geforce GTX 1060 6GB is compute version 61
 # https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
 
-CXXFLAGS = -g -O2 -x cu -std=c++17 -Xcompiler -std=c++17 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_60,code=sm_60 -Xcompiler -fopenmp --generate-line-info -line-info -Xcompiler="-fpermissive" -dc -Xptxas -v --extra-device-vectorization
+CXXFLAGS = -g -O2 -x cu -std=c++17 -Xcompiler -std=c++17 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_60,code=sm_60 -Xcompiler -fopenmp --generate-line-info -line-info -Xcompiler="-fpermissive" -Xptxas -v --extra-device-vectorization
 
-testpackage: CXXFLAGS = -g -O2 -x cu -std=c++17 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_60,code=sm_60 -Xcompiler -fopenmp --prec-sqrt=true --prec-div=true --ftz=false --fmad=false --generate-line-info -line-info -Xcompiler="-fpermissive" -dc
+testpackage: CXXFLAGS = -g -O2 -x cu -std=c++17 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_60,code=sm_60 -Xcompiler -fopenmp --prec-sqrt=true --prec-div=true --ftz=false --fmad=false --generate-line-info -line-info -Xcompiler="-fpermissive"
 
 # Tell mpic++ to use nvcc for all compiling
 CMP = OMPI_CXX='nvcc' OMPI_CXXFLAGS='' mpic++

--- a/MAKE/Makefile.mahti_cuda
+++ b/MAKE/Makefile.mahti_cuda
@@ -50,8 +50,8 @@ CUDABLOCKS=108
 #-G (device debug) overrides --generate-line-info -line-info but also requires more device-side resources to run
 # use "-Xptxas -v" for verbose output of ptx compilation
 
-CXXFLAGS = -g -O2 -x cu -std=c++17 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_80,code=sm_80 --generate-line-info -line-info -Xcompiler="-fopenmp" -Xcompiler="-fpermissive" -dc -maxrregcount 24
-testpackage: CXXFLAGS = -g -O2 -x cu -std=c++17 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_80,code=sm_80 --generate-line-info -line-info -Xcompiler="-fopenmp" --prec-sqrt=true --prec-div=true --ftz=false --fmad=false -Xcompiler="-fpermissive" -dc  -maxrregcount 24
+CXXFLAGS = -g -O2 -x cu -std=c++17 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_80,code=sm_80 --generate-line-info -line-info -Xcompiler="-fopenmp" -Xcompiler="-fpermissive" -maxrregcount 24
+testpackage: CXXFLAGS = -g -O2 -x cu -std=c++17 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_80,code=sm_80 --generate-line-info -line-info -Xcompiler="-fopenmp" --prec-sqrt=true --prec-div=true --ftz=false --fmad=false -Xcompiler="-fpermissive"  -maxrregcount 24
 
 # Tell mpic++ to use nvcc for all compiling
 CMP = OMPI_CXX='nvcc' OMPI_CXXFLAGS='' mpic++

--- a/velocity_mesh_parameters.h
+++ b/velocity_mesh_parameters.h
@@ -120,7 +120,7 @@ namespace vmesh {
    // address, we use the Ctor of a static object to register all intances so that the allocated memory pointer
    // could be copied to all of them.
    __device__ __constant__ MeshWrapper* meshWrapperDevInstance;
-   ARCH_HOSTDEV static MeshWrapper* gpu_getMeshWrapper() { return meshWrapperDevInstance; };
+   ARCH_DEV static MeshWrapper* gpu_getMeshWrapper() { return meshWrapperDevInstance; };
    // Static object and corresponding instance whose Ctor is used register all the instances of device meshWrapperDev
    // symbols.
    struct meshWrapperDevRegistor {


### PR DESCRIPTION
Cleanup of outputs, deactivate rdc on Mahti and Freezer