### PR TITLE
Fix version output, add CI cleanup task

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -13,13 +13,12 @@ jobs:
   clean_workspace:
     # Cleans up Carrington workspace, deleting any old lingering directories and files
     runs-on: carrington
-    continue-on-error: true
     steps:
       - name: Delete files and directories
         run: |
           rm -rf libraries library-build testpackage
-          rm libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
-          rm *.xml
+          rm -f libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
+          rm -f *.xml
 
   build_libraries:
     # Build libraries for the current version of the docker image

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -10,16 +10,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  clean_workspace:
-    # Cleans up Carrington workspace, deleting any old lingering directories and files
-    runs-on: carrington
-    steps:
-      - name: Delete files and directories
-        run: |
-          rm -rf libraries library-build testpackage
-          rm -f libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
-          rm -f *.xml
-
   build_libraries:
     # Build libraries for the current version of the docker image
     # (to be used in any subsequent compilation and run jobs on said image)
@@ -135,9 +125,13 @@ jobs:
     # Build Vlasiator with testpackage flags, on the carrington cluster
     # (for subsequent running of the integration test package)
     runs-on: carrington
-    needs: clean_workspace
 
     steps:
+    - name: Clean workspace
+        run: |
+          rm -rf libraries library-build testpackage
+          rm -f libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
+          rm -f *.xml
     - name: Checkout source
       uses: actions/checkout@v3
       with: 
@@ -196,9 +190,13 @@ jobs:
   build_tools:
     # Build vlsvdiff and vlsvextract for testpackage use
     runs-on: carrington
-    needs: clean_workspace
       
     steps:
+    - name: Clean workspace
+        run: |
+          rm -rf libraries library-build testpackage
+          rm -f libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
+          rm -f *.xml
     - name: Checkout source
       uses: actions/checkout@v3 
       with: 
@@ -222,7 +220,7 @@ jobs:
   run_testpackage:
     # Run the testpackage on the carrington cluster
     runs-on: carrington
-    needs: [clean_workspace, build_testpackage, build_tools]
+    needs: [build_testpackage, build_tools]
     continue-on-error: true
 
     steps:
@@ -268,7 +266,7 @@ jobs:
     # Build IonosphereSolverTests miniApp (currently broken)
     runs-on: carrington
       #container: ursg/vlasiator_ci:20230220_1
-    needs: [clean_workspace, build_libraries]
+    needs: [build_libraries]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3 

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -10,6 +10,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  clean_workspace:
+    # Cleans up Carrington workspace, deleting any old lingering directories and files
+    runs-on: carrington
+    continue-on-error: true
+    steps:
+      - name: Delete files and directories
+        run: |
+          rm -rf libraries library-build testpackage
+          rm libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
+          rm *.xml
+
   build_libraries:
     # Build libraries for the current version of the docker image
     # (to be used in any subsequent compilation and run jobs on said image)
@@ -125,6 +136,7 @@ jobs:
     # Build Vlasiator with testpackage flags, on the carrington cluster
     # (for subsequent running of the integration test package)
     runs-on: carrington
+    needs: clean_workspace
 
     steps:
     - name: Checkout source
@@ -185,6 +197,7 @@ jobs:
   build_tools:
     # Build vlsvdiff and vlsvextract for testpackage use
     runs-on: carrington
+    needs: clean_workspace
       
     steps:
     - name: Checkout source
@@ -210,7 +223,7 @@ jobs:
   run_testpackage:
     # Run the testpackage on the carrington cluster
     runs-on: carrington
-    needs: [build_testpackage, build_tools]
+    needs: [clean_workspace, build_testpackage, build_tools]
     continue-on-error: true
 
     steps:
@@ -256,7 +269,7 @@ jobs:
     # Build IonosphereSolverTests miniApp (currently broken)
     runs-on: carrington
       #container: ursg/vlasiator_ci:20230220_1
-    needs: build_libraries
+    needs: [clean_workspace, build_libraries]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3 

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -15,7 +15,7 @@ jobs:
     # (to be used in any subsequent compilation and run jobs on said image)
     runs-on: ubuntu-latest
     container: ursg/vlasiator_ci:20230220_1
-    
+
     steps:
       - name: Setup libraries dir
         run: |
@@ -25,7 +25,7 @@ jobs:
           cd library-build
       - name: Build phiprof
         run: |
-          git clone https://github.com/fmihpc/phiprof/ 
+          git clone https://github.com/fmihpc/phiprof/
           cd phiprof/src
           make -j 4 CCC=mpic++
           cp ../include/* $GITHUB_WORKSPACE/libraries/include
@@ -33,14 +33,14 @@ jobs:
           cd ../..
       - name: Build VLSV
         run: |
-          git clone https://github.com/fmihpc/vlsv.git  
+          git clone https://github.com/fmihpc/vlsv.git
           cd vlsv
           make
           cp libvlsv.a $GITHUB_WORKSPACE/libraries/lib
           cp *.h $GITHUB_WORKSPACE/libraries/include
           cd ..
       - name: Download vectorclass
-        run: | 
+        run: |
           git clone https://github.com/vectorclass/version1
           git clone https://github.com/vectorclass/add-on
           cp add-on/vector3d/vector3d.h version1/
@@ -102,8 +102,8 @@ jobs:
 
     steps:
     - name: Checkout source
-      uses: actions/checkout@v3 
-      with: 
+      uses: actions/checkout@v3
+      with:
         submodules: true
     - name: Download libraries
       uses: actions/download-artifact@v3
@@ -119,8 +119,8 @@ jobs:
    #  - name: Compile vlasiator (Release build)
    #    run: |
    #      srun -M carrington --job-name release_compile --interactive --nodes=1 -n 1 -c 16 --mem=40G -p short -t 0:10:0 bash -c 'module purge; module load GCC/11.2.0; module load OpenMPI/4.1.1-GCC-11.2.0 ; module load PMIx/4.1.0-GCCcore-11.2.0; module load PAPI/6.0.0.1-GCCcore-11.2.0; export VLASIATOR_ARCH=carrington_gcc_openmpi; make clean; make -j 16'
-      
-  
+
+
   build_testpackage:
     # Build Vlasiator with testpackage flags, on the carrington cluster
     # (for subsequent running of the integration test package)
@@ -128,13 +128,13 @@ jobs:
 
     steps:
     - name: Clean workspace
-        run: |
-          rm -rf libraries library-build testpackage
-          rm -f libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
-          rm -f *.xml
+      run: |
+        rm -rf libraries library-build testpackage
+        rm -f libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
+        rm -f *.xml
     - name: Checkout source
       uses: actions/checkout@v3
-      with: 
+      with:
         submodules: true
     - name: Make clean
       run: VLASIATOR_ARCH=carrington_gcc_openmpi make clean
@@ -164,8 +164,8 @@ jobs:
 
     steps:
     - name: Checkout source
-      uses: actions/checkout@v3 
-      with: 
+      uses: actions/checkout@v3
+      with:
         submodules: true
     - name: Download libraries
       uses: actions/download-artifact@v3
@@ -190,16 +190,16 @@ jobs:
   build_tools:
     # Build vlsvdiff and vlsvextract for testpackage use
     runs-on: carrington
-      
+
     steps:
     - name: Clean workspace
-        run: |
-          rm -rf libraries library-build testpackage
-          rm -f libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
-          rm -f *.xml
+      run: |
+        rm -rf libraries library-build testpackage
+        rm -f libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
+        rm -f *.xml
     - name: Checkout source
-      uses: actions/checkout@v3 
-      with: 
+      uses: actions/checkout@v3
+      with:
         submodules: true
     - uses: ursg/gcc-problem-matcher@master
     - name: Make clean
@@ -226,7 +226,7 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
-      with: 
+      with:
         submodules: true
     - name: Download testpackage binary
       uses: actions/download-artifact@v3
@@ -269,7 +269,7 @@ jobs:
     needs: [build_libraries]
     steps:
     - name: Checkout source
-      uses: actions/checkout@v3 
+      uses: actions/checkout@v3
       with:
         submodules: true
           #    - name: Download libraries
@@ -293,4 +293,3 @@ jobs:
           mini-apps/ionosphereSolverTests/differentialFlux
           mini-apps/ionosphereSolverTests/sigmaProfiles
         if-no-files-found: error
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: Doxyfile|libraries|Makefile|README|INSTALL|testpackage|doc|\.txt|\.tex|\.cfg|\.vtk|\.yml|\.clang-format|\.m$|\.sh|\.py
+exclude: Doxyfile|libraries|Makefile|README|INSTALL|testpackage|doc|\.txt|\.tex|\.cfg|\.vtk|\.clang-format|\.m$|\.sh|\.py
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/generate_version.sh
+++ b/generate_version.sh
@@ -102,14 +102,23 @@ std::string getVersion() {
 EOF
 
 echo "  versionInfo+=\"----------- Compilation --------- \n\";" >>version.cpp
-echo "  versionInfo+=\"date:       $(date)\n\";" >>version.cpp
-echo "  versionInfo+=\"CMP:        $1 \n\";" >>version.cpp
-echo "  versionInfo+=\"CXXFLAGS:   $2 \n\";" >>version.cpp
-echo "  versionInfo+=\"FLAGS:      $3 \n\";" >>version.cpp
-echo "  versionInfo+=\"INC_MPI:    $4 \n\";" >>version.cpp
-echo "  versionInfo+=\"INC_DCCRG:  $5 \n\";" >>version.cpp
-echo "  versionInfo+=\"INC_ZOLTAN: $6 \n\";" >>version.cpp
-echo "  versionInfo+=\"INC_BOOST:  $7 \n\";" >>version.cpp
+echo "  versionInfo+=\"date:           $(date)\n\";" >>version.cpp
+echo "  versionInfo+=\"CMP:            $1 \n\";" >>version.cpp
+echo "  versionInfo+=\"CXXFLAGS:       $2 \n\";" >>version.cpp
+echo "  versionInfo+=\"FLAGS:          $3 \n\";" >>version.cpp
+echo "  versionInfo+=\"INC_MPI:        $4 \n\";" >>version.cpp
+echo "  versionInfo+=\"INC_ZOLTAN:     $5 \n\";" >>version.cpp
+echo "  versionInfo+=\"INC_BOOST:      $6 \n\";" >>version.cpp
+echo "  versionInfo+=\"INC_DCCRG:      $7 \n\";" >>version.cpp
+echo "  versionInfo+=\"                commit: $8 \n\";" >>version.cpp
+echo "  versionInfo+=\"INC_FSGRID:     $9 \n\";" >>version.cpp
+echo "  versionInfo+=\"                commit: ${10} \n\";" >>version.cpp
+echo "  versionInfo+=\"INC_VLSV:       ${11} \n\";" >>version.cpp
+echo "  versionInfo+=\"                commit: ${12} \n\";" >>version.cpp
+echo "  versionInfo+=\"INC_HASHINATOR: ${13} \n\";" >>version.cpp
+echo "  versionInfo+=\"                commit: ${14} \n\";" >>version.cpp
+echo "  versionInfo+=\"INC_PHIPROF:    ${15} \n\";" >>version.cpp
+echo "  versionInfo+=\"                commit: ${16} \n\";" >>version.cpp
 
 
 echo "     versionInfo+= \"----------- git branch ---------n\";" >>version.cpp


### PR DESCRIPTION
Version information was updated in #836 to include library git commits, but only half of the version.cpp output was changed. This updates the second function to also output the correct information. Fixes issue #876.

Also, this adds a CI cleanup task which deletes old lingering outputs and libraries when starting a new CI run. Fixes #875.