### PR TITLE
Flowthrough AMR

### DIFF
--- a/projects/Flowthrough/Flowthrough.cpp
+++ b/projects/Flowthrough/Flowthrough.cpp
@@ -217,46 +217,4 @@ namespace projects {
       return centerPoints;
    }
 
-   bool Flowthrough::canRefine(const std::array<double,3> xyz, const int refLevel) const {
-      const int bw = (2 + 1*refLevel) * VLASOV_STENCIL_WIDTH; // Seems to be the limit
-
-      return refLevel < P::amrMaxSpatialRefLevel &&
-             xyz[0] > P::xmin + P::dx_ini * bw && 
-             xyz[0] < P::xmax - P::dx_ini * bw;
-   }
-
-   int Flowthrough::adaptRefinement( dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid ) const {
-      int myRank;       
-      MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
-      if(myRank == MASTER_RANK) {
-         std::cout << "Maximum refinement level is " << mpiGrid.mapping.get_maximum_refinement_level() << std::endl;
-      }
-
-      if (!P::adaptRefinement) {
-         if (myRank == MASTER_RANK)  {
-            std::cout << "Skipping re-refinement!" << std::endl;
-         }
-         return 0;
-      }
-
-      int refines {0};
-
-      std::vector<CellID> cells = mpiGrid.get_cells();
-      for (CellID id : cells) {
-         std::array<double,3> xyz = mpiGrid.get_center(id);
-         bool inBox = xyz[0] > P::amrBoxCenterX - P::amrBoxHalfWidthX * mpiGrid[id]->parameters[CellParams::DX] &&
-                      xyz[0] < P::amrBoxCenterX + P::amrBoxHalfWidthX * mpiGrid[id]->parameters[CellParams::DX] &&
-                      xyz[1] > P::amrBoxCenterY - P::amrBoxHalfWidthY * mpiGrid[id]->parameters[CellParams::DY] &&
-                      xyz[1] < P::amrBoxCenterY + P::amrBoxHalfWidthY * mpiGrid[id]->parameters[CellParams::DY] &&
-                      xyz[2] > P::amrBoxCenterZ - P::amrBoxHalfWidthZ * mpiGrid[id]->parameters[CellParams::DZ] &&
-                      xyz[2] < P::amrBoxCenterZ + P::amrBoxHalfWidthZ * mpiGrid[id]->parameters[CellParams::DZ];
-         if (inBox) {
-            refines += mpiGrid.refine_completely(id);
-         }
-      }
-
-      return refines;
-   }
-   
-
 } //namespace projects

--- a/projects/Flowthrough/Flowthrough.h
+++ b/projects/Flowthrough/Flowthrough.h
@@ -72,8 +72,6 @@ namespace projects {
                                                       creal z,
                                                       const uint popID
                                                      ) const;
-      int adaptRefinement( dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid ) const;
-      bool canRefine(const std::array<double,3> xyz, const int refLevel) const;
 
       bool emptyBox;               /**< If true, then the simulation domain is empty initially 
                                     * and matter will flow in only through the boundaries.*/

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -498,7 +498,7 @@ namespace projects {
 
    /*
      Refine cells of mpiGrid. Each project that wants refinement should implement this function. 
-     Base class function prints a warning and does nothing.
+     Base class function uses AMR box half width parameters
     */
    bool Project::refineSpatialCells( dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid ) const {
       int myRank;


### PR DESCRIPTION
Remove `canRefine` and `adaptRefinement` from Flowthrough, defaulting to using the same AMR as Magnetosphere.