### PR TITLE
Adjust blocks at sysboundaries

### DIFF
--- a/spatial_cell.cpp
+++ b/spatial_cell.cpp
@@ -353,7 +353,7 @@ namespace spatial_cell {
 
    #endif
 
-   void SpatialCell::adjustSingleCellVelocityBlocks(const uint popID) {
+   void SpatialCell::adjustSingleCellVelocityBlocks(const uint popID, bool doDeleteEmpty) {
       #ifdef DEBUG_SPATIAL_CELL
       if (popID >= populations.size()) {
          std::cerr << "ERROR, popID " << popID << " exceeds populations.size() " << populations.size() << " in ";
@@ -367,7 +367,7 @@ namespace spatial_cell {
       //space. TODO: should this delete blocks or not? Now not
       std::vector<SpatialCell*> neighbor_ptrs;
       update_velocity_block_content_lists(popID);
-      adjust_velocity_blocks(neighbor_ptrs,popID,false);
+      adjust_velocity_blocks(neighbor_ptrs,popID,doDeleteEmpty);
    }
 
    void SpatialCell::coarsen_block(const vmesh::GlobalID& parent,const std::vector<vmesh::GlobalID>& children,const uint popID) {

--- a/spatial_cell.hpp
+++ b/spatial_cell.hpp
@@ -265,7 +265,7 @@ namespace spatial_cell {
       bool add_velocity_block(const vmesh::GlobalID& block,const uint popID);
       void add_velocity_blocks(const std::vector<vmesh::GlobalID>& blocks,const uint popID);
       bool add_velocity_block_octant(const vmesh::GlobalID& blockGID,const uint popID);
-      void adjustSingleCellVelocityBlocks(const uint popID);
+      void adjustSingleCellVelocityBlocks(const uint popID, bool doDeleteEmpty=false);
       void adjust_velocity_blocks(const std::vector<SpatialCell*>& spatial_neighbors,
                                   const uint popID,
                                   bool doDeleteEmptyBlocks=true);

--- a/sysboundary/copysphere.cpp
+++ b/sysboundary/copysphere.cpp
@@ -785,7 +785,7 @@ namespace SBC {
          } // for-loop over velocity blocks
 
          // let's get rid of blocks not fulfilling the criteria here to save memory.
-         templateCell.adjustSingleCellVelocityBlocks(popID);
+         templateCell.adjustSingleCellVelocityBlocks(popID,true);
       } // for-loop over particle species
       
       calculateCellMoments(&templateCell,true,false,true);

--- a/sysboundary/donotcompute.cpp
+++ b/sysboundary/donotcompute.cpp
@@ -79,8 +79,9 @@ namespace SBC {
          
          //let's get rid of blocks not fulfilling the criteria here to save
          //memory.
-         for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID)
-            cell->adjustSingleCellVelocityBlocks(popID);
+         for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
+            cell->adjustSingleCellVelocityBlocks(popID,true);
+         }
       }
    }
    

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -3315,7 +3315,7 @@ namespace SBC {
          }
 
          // Block adjust and recalculate moments
-         mpiGrid[cellID]->adjustSingleCellVelocityBlocks(popID);
+         mpiGrid[cellID]->adjustSingleCellVelocityBlocks(popID,true);
          // TODO: The moments can also be analytically calculated from ionosphere parameters.
          // Maybe that's faster?
          calculateCellMoments(mpiGrid[cellID], true, false, true);
@@ -3382,7 +3382,7 @@ namespace SBC {
          } // for-loop over velocity blocks
 
          // let's get rid of blocks not fulfilling the criteria here to save memory.
-         templateCell.adjustSingleCellVelocityBlocks(popID);
+         templateCell.adjustSingleCellVelocityBlocks(popID,true);
       } // for-loop over particle species
 
       calculateCellMoments(&templateCell,true,false,true);

--- a/sysboundary/setmaxwellian.cpp
+++ b/sysboundary/setmaxwellian.cpp
@@ -259,7 +259,7 @@ namespace SBC {
          
          //let's get rid of blocks not fulfilling the criteria here to save
          //memory.
-         templateCell.adjustSingleCellVelocityBlocks(popID);
+         templateCell.adjustSingleCellVelocityBlocks(popID,true);
       } // for-loop over particle species
       
       B[0] = Bx;


### PR DESCRIPTION
Whenever a sysboundary template cell (or for ionosphere, an actual cell) is updated, it goes through block adjustment to add the necessary buffer zones. The comment states that unnecessary blocks would also be pruned, but that is not the case. This PR remedies that. Might help with artefacts along side walls in low-res-vspace simulations.