### PR TITLE
Mem and cell reports

### DIFF
--- a/memoryallocation.cpp
+++ b/memoryallocation.cpp
@@ -171,11 +171,11 @@ void report_process_memory_consumption(double extra_bytes){
          if (max_mem_papi[3] != 0.0) {
             logFile << "(MEM) Estimating increased high water mark from refinement" << endl;
          }
-         logFile << "(MEM) Resident per node (avg, min, max): " << sum_mem_papi[2]/nNodes/GiB << " " << min_mem_papi[2]/GiB << " "  << max_mem_papi[2]/GiB << endl;
-         logFile << "(MEM) High water mark per node                 (GiB) avg: " << sum_mem_papi[0]/nNodes/GiB << " min: " << min_mem_papi[0]/GiB << " max: "  << max_mem_papi[0]/GiB <<
+         logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " Resident per node (avg, min, max): " << sum_mem_papi[2]/nNodes/GiB << " " << min_mem_papi[2]/GiB << " "  << max_mem_papi[2]/GiB << endl;
+         logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " High water mark per node                 (GiB) avg: " << sum_mem_papi[0]/nNodes/GiB << " min: " << min_mem_papi[0]/GiB << " max: "  << max_mem_papi[0]/GiB <<
             " sum (TiB): " << sum_mem_papi[0]/TiB << " on "<< nNodes << " nodes" << endl;
          if(max_mem_papi[3] != 0.0) {
-            logFile << "(MEM) High water mark per node with refinement (GiB) avg: " << sum_mem_papi[1]/nNodes/GiB << " min: " << min_mem_papi[1]/GiB << " max: "  << max_mem_papi[1]/GiB <<
+            logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " High water mark per node with refinement (GiB) avg: " << sum_mem_papi[1]/nNodes/GiB << " min: " << min_mem_papi[1]/GiB << " max: "  << max_mem_papi[1]/GiB <<
                " sum (TiB): " << sum_mem_papi[1]/TiB << " on "<< nNodes << " nodes" << endl;
          }
       }

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -884,16 +884,21 @@ int main(int argn,char* args[]) {
          beforeTime = MPI_Wtime();
          beforeSimulationTime=P::t;
          beforeStep=P::tstep;
-         //report_grid_memory_consumption(mpiGrid);
-         report_process_memory_consumption();
-         report_cell_and_block_counts(mpiGrid);
       }
       logFile << writeVerbose;
       loggingTimer.stop();
 
 // Check whether diagnostic output has to be produced
       if (P::diagnosticInterval != 0 && P::tstep % P::diagnosticInterval == 0) {
-         
+         phiprof::Timer memTimer {"memory-report"};
+         memTimer.start();
+         report_process_memory_consumption();
+         memTimer.stop();
+         phiprof::Timer cellTimer {"cell-count-report"};
+         cellTimer.start();
+         report_cell_and_block_counts(mpiGrid);
+         cellTimer.stop();
+
          phiprof::Timer diagnosticTimer {"diagnostic-io"};
          if (writeDiagnostic(mpiGrid, diagnosticReducer) == false) {
             if(myRank == MASTER_RANK)  cerr << "ERROR with diagnostic computation" << endl;

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -91,6 +91,45 @@ void addTimedBarrier(string name){
    MPI_Barrier(MPI_COMM_WORLD);
 }
 
+
+/*! Report spatial cell counts per refinement level as well as velocity cell counts per population into logfile
+ */
+void report_cell_and_block_counts(dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid){
+   cint maxRefLevel = mpiGrid.get_maximum_refinement_level();
+   const vector<CellID> localCells = getLocalCells();
+   cint popCount = getObjectWrapper().particleSpecies.size();
+
+   // popCount+1 as we store the spatial cell counts and then the populations' v_cell counts.
+   // maxRefLevel+1 as e.g. there's 2 levels at maxRefLevel == 1
+   std::vector<int64_t> localCounts((popCount+1)*(maxRefLevel+1), 0), globalCounts((popCount+1)*(maxRefLevel+1), 0);
+
+   for (const auto cellid : localCells) {
+      cint level = mpiGrid.get_refinement_level(cellid);
+      localCounts[level]++;
+      for(int pop=0; pop<popCount; pop++) {
+         localCounts[maxRefLevel+1 + level*popCount + pop] += mpiGrid[cellid]->get_number_of_velocity_blocks(pop);
+      }
+   }
+
+   MPI_Reduce(localCounts.data(), globalCounts.data(), (popCount+1)*(maxRefLevel+1), MPI_INT64_T, MPI_SUM, MASTER_RANK, MPI_COMM_WORLD);
+
+   logFile << "(CELLS) tstep = " << P::tstep << " time = " << P::t << " spatial cells [ ";
+   for(int level = 0; level <= maxRefLevel; level++) {
+      logFile << globalCounts[level] << " ";
+   }
+   logFile << "] blocks ";
+   for(int pop=0; pop<popCount; pop++) {
+      logFile << getObjectWrapper().particleSpecies[pop].name << " [ ";
+      for(int level = 0; level <= maxRefLevel; level++) {
+         logFile << globalCounts[maxRefLevel+1 + level*popCount + pop] << " ";
+      }
+      logFile << "] ";
+   }
+   logFile << endl << flush;
+
+}
+
+
 void computeNewTimeStep(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
 			FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, Real &newDt, bool &isChanged) {
 
@@ -847,6 +886,7 @@ int main(int argn,char* args[]) {
          beforeStep=P::tstep;
          //report_grid_memory_consumption(mpiGrid);
          report_process_memory_consumption();
+         report_cell_and_block_counts(mpiGrid);
       }
       logFile << writeVerbose;
       loggingTimer.stop();


### PR DESCRIPTION
Here's a new function to report spatial cell counts per refinement level as well as velocity blocks per population and refinement level into the logfile at the same time as memory reports.

Includes the addition of t and timestep in the MEM lines of the logfile for better grepping and plotting.