### PR TITLE
Add branch to dccrg submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,4 @@
 [submodule "submodules/dccrg"]
 	path = submodules/dccrg
 	url = https://github.com/fmihpc/dccrg.git
+        branch = vlasiator-version


### PR DESCRIPTION
Having the branch specified should make this command work: `git submodule update --remote` (and worked when I tried it now)