### PR TITLE
Include Vectorclass as a submodule

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -39,12 +39,6 @@ jobs:
           cp libvlsv.a $GITHUB_WORKSPACE/libraries/lib
           cp *.h $GITHUB_WORKSPACE/libraries/include
           cd ..
-      - name: Download vectorclass
-        run: |
-          git clone https://github.com/vectorclass/version1
-          git clone https://github.com/vectorclass/add-on
-          cp add-on/vector3d/vector3d.h version1/
-          cp version1/*.h $GITHUB_WORKSPACE/libraries/include
       - name: Build papi
         run: |
           git clone https://github.com/icl-utk-edu/papi

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,9 @@
 [submodule "submodules/dccrg"]
 	path = submodules/dccrg
 	url = https://github.com/fmihpc/dccrg.git
+[submodule "submodules/vectorclass"]
+	path = submodules/vectorclass
+	url = https://github.com/vectorclass/version2
+[submodule "submodules/vectorclass-addon"]
+	path = submodules/vectorclass-addon
+	url = https://github.com/vectorclass/add-on

--- a/MAKE/Makefile.Freezer
+++ b/MAKE/Makefile.Freezer
@@ -13,13 +13,13 @@ LNK = mpic++
 ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
 #Single-precision        
 	VECTORCLASS = VEC8F_AGNER
-	INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass
+	INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 # 	VECTORCLASS = VEC8F_FALLBACK
 #	INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/../vlasiator/vlasovsolver
 else
 #Double-precision
 	VECTORCLASS = VEC4D_AGNER
-	INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass
+	INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 #	VECTORCLASS = VEC4D_FALLBACK
 #	INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/../vlasiator/vlasovsolver
 endif

--- a/MAKE/Makefile.carrington_gcc_openmpi
+++ b/MAKE/Makefile.carrington_gcc_openmpi
@@ -115,5 +115,5 @@ LIB_PAPI = -lpapi
 INC_EIGEN = -isystem $(LIBRARY_PREFIX)/ -isystem $(LIBRARY_PREFIX)/Eigen/
 INC_FSGRID = -I./submodules/fsgrid/
 INC_DCCRG = -I./submodules/dccrg/
-INC_VECTORCLASS = -isystem $(LIBRARY_PREFIX)/vectorclass/
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 

--- a/MAKE/Makefile.cubbli20
+++ b/MAKE/Makefile.cubbli20
@@ -53,11 +53,11 @@ LIB_JEMALLOC = #-L$(LIBRARY_PREFIX)/lib -ljemalloc
 
 ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
 #Single-precision        
-        INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/version1
+        INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 	VECTORCLASS = VEC4F_FALLBACK
 else
 #Double-precision
-        INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/version1
+        INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 	VECTORCLASS = VEC4D_FALLBACK
 endif
 

--- a/MAKE/Makefile.docker
+++ b/MAKE/Makefile.docker
@@ -89,5 +89,5 @@ LIB_PAPI = -L$(LIBRARY_PREFIX)/papi/lib -lpapi
 
 INC_EIGEN = -I/usr/include/eigen3
 INC_DCCRG = -I./submodules/dccrg
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 INC_FSGRID = -I./submodules/fsgrid

--- a/MAKE/Makefile.github_actions
+++ b/MAKE/Makefile.github_actions
@@ -84,3 +84,4 @@ LIB_PROFILE = -I $(LIBRARY_PREFIX)/include ${GITHUB_WORKSPACE}/libraries/lib/lib
 INC_PROFILE =
 INC_TOPO =
 
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/

--- a/MAKE/Makefile.hawk_gcc_mpt
+++ b/MAKE/Makefile.hawk_gcc_mpt
@@ -22,13 +22,13 @@ LNK = mpicxx
 ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
 #Single-precision        
 	VECTORCLASS = VEC8F_AGNER
-	INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass-version1
+	INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 #	VECTORCLASS = VEC8F_FALLBACK
 #	INC_VECTORCLASS = -I$(HOME)/vlasiator/vlasovsolver
 else
 #Double-precision
 	VECTORCLASS = VEC4D_AGNER
-	INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass-version1
+	INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 #	VECTORCLASS = VEC4D_FALLBACK
 #	VECTORCLASS = VEC8D_FALLBACK
 #	INC_VECTORCLASS = -I$(HOME)/vlasiator/vlasovsolver
@@ -103,5 +103,5 @@ LIB_PAPI = -L/opt/hlrs/spack/rev-004_2020-06-17/papi/c048e224f-gcc-9.2.0-hxfnx7k
 INC_EIGEN = -I$(LIBRARY_PREFIX)/
 INC_DCCRG = -I./submodules/dccrg
 INC_FSGRID = -I./submodules/fsgrid
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass-version1
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 

--- a/MAKE/Makefile.hawk_gcc_openmpi
+++ b/MAKE/Makefile.hawk_gcc_openmpi
@@ -85,7 +85,7 @@ LIB_PAPI = -L/opt/hlrs/spack/rev-004_2020-06-17/papi/c048e224f-gcc-9.2.0-hxfnx7k
 INC_EIGEN = -I$(LIBRARY_PREFIX)/
 INC_DCCRG = -I./submodules/dccrg
 INC_FSGRID = -I./submodules/fsgrid
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass-version1
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 
 
 

--- a/MAKE/Makefile.hawk_intel_mpt
+++ b/MAKE/Makefile.hawk_intel_mpt
@@ -86,7 +86,7 @@ LIB_PAPI = -L/opt/hlrs/spack/rev-004_2020-06-17/papi/c048e224f-intel-19.1.0-wlgb
 INC_EIGEN = -I$(LIBRARY_PREFIX)/
 INC_DCCRG = -I./submodules/dccrg
 INC_FSGRID = -I./submodules/fsgrid
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass-version1
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 
 
 

--- a/MAKE/Makefile.hawk_intel_openmpi
+++ b/MAKE/Makefile.hawk_intel_openmpi
@@ -86,7 +86,7 @@ LIB_PAPI = -L/opt/hlrs/spack/rev-004_2020-06-17/papi/c048e224f-intel-19.1.0-wlgb
 INC_EIGEN = -I$(LIBRARY_PREFIX)/
 INC_DCCRG = -I./submodules/dccrg
 INC_FSGRID = -I./submodules/fsgrid
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass-version1
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 
 
 

--- a/MAKE/Makefile.horakons
+++ b/MAKE/Makefile.horakons
@@ -59,7 +59,7 @@ PAPI_FLAG =
 
 LIBRARY_PREFIX = /home/horakons/vlasiator_libs/
 
-INC_VECTORCLASS=-I$(LIBRARY_PREFIX)/version1
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 
 INC_BOOST = -I/usr/include/boost/
 LIB_BOOST = -L/usr/lib/x86_64-linux-gnu/ -lboost_program_options

--- a/MAKE/Makefile.kstppd
+++ b/MAKE/Makefile.kstppd
@@ -59,7 +59,7 @@ PAPI_FLAG =
 
 LIBRARY_PREFIX = $(HOME)
 
-INC_VECTORCLASS=-I$(LIBRARY_PREFIX)/version1
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 
 INC_BOOST = -I/usr/include/boost/
 LIB_BOOST = -L/usr/lib/x86_64-linux-gnu/ -lboost_program_options

--- a/MAKE/Makefile.lumi_cpeGnu
+++ b/MAKE/Makefile.lumi_cpeGnu
@@ -89,4 +89,4 @@ INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include
 INC_FSGRID = -I./submodules/fsgrid
 INC_EIGEN = -isystem $(LIBRARY_PREFIX_HEADERS)/eigen/
 INC_DCCRG = -I./submodules/dccrg
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX_HEADERS)/vectorclass/
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/

--- a/MAKE/Makefile.lumi_cray
+++ b/MAKE/Makefile.lumi_cray
@@ -84,4 +84,4 @@ INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include
 
 INC_FSGRID = -I./submodules/fsgrid
 INC_DCCRG = -I./submodules/dccrg
-INC_VECTORCLASS = -isystem$(LIBRARY_PREFIX_HEADERS)/vectorclass/
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/

--- a/MAKE/Makefile.lumi_gnu
+++ b/MAKE/Makefile.lumi_gnu
@@ -83,4 +83,4 @@ INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include
 
 INC_FSGRID = -I./submodules/fsgrid
 INC_DCCRG = -I./submodules/dccrg
-INC_VECTORCLASS = -isystem$(LIBRARY_PREFIX_HEADERS)/vectorclass/
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/

--- a/MAKE/Makefile.lumi_gnu358
+++ b/MAKE/Makefile.lumi_gnu358
@@ -83,4 +83,4 @@ INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include
 
 INC_FSGRID = -I./submodules/fsgrid/
 INC_DCCRG = -I./submodules/dccrg/
-INC_VECTORCLASS = -isystem$(LIBRARY_PREFIX_HEADERS)/vectorclass/
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/

--- a/MAKE/Makefile.mahti_gcc
+++ b/MAKE/Makefile.mahti_gcc
@@ -88,4 +88,4 @@ INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include
 INC_FSGRID = -I./submodules/fsgrid
 INC_EIGEN = -I$(LIBRARY_PREFIX)/../libraries/eigen/
 INC_DCCRG = -I./submodules/dccrg
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/../libraries/vectorclass/
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/

--- a/MAKE/Makefile.marconi
+++ b/MAKE/Makefile.marconi
@@ -89,6 +89,6 @@ LIB_PAPI = -L$(LIBRARY_PREFIX)/papi/lib -lpapi -lpfm
 INC_FSGRID = -I./submodules/fsgrid
 INC_EIGEN = -I$(HEADER_LIBRARY_PREFIX)/eigen
 INC_DCCRG = -I./submodules/dccrg
-INC_VECTORCLASS = -I$(HEADER_LIBRARY_PREFIX)/vectorclass
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 
 

--- a/MAKE/Makefile.perlmutter_gcc
+++ b/MAKE/Makefile.perlmutter_gcc
@@ -85,4 +85,4 @@ INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include
 
 INC_FSGRID = -I./submodules/fsgrid
 INC_DCCRG = -I./submodules/dccrg
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX_HEADERS)/vectorclass/
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/

--- a/MAKE/Makefile.puhti_gcc
+++ b/MAKE/Makefile.puhti_gcc
@@ -88,7 +88,7 @@ INC_PAPI = -I$(LIBRARY_PREFIX)/hpcx-mpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VE
 INC_FSGRID = -I./submodules/fsgrid
 INC_EIGEN = -I$(LIBRARY_PREFIX)/eigen/3.3.7/
 INC_DCCRG = -I./submodules/dccrg
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 
 
 

--- a/MAKE/Makefile.puhti_intel
+++ b/MAKE/Makefile.puhti_intel
@@ -92,7 +92,7 @@ INC_PAPI = -I$(LIBRARY_PREFIX)/hpcx-mpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_VE
 INC_FSGRID = -I./submodules/fsgrid
 INC_EIGEN = -I$(LIBRARY_PREFIX)/eigen/3.3.7/
 INC_DCCRG = -I./submodules/dccrg
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass-old
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 
 
 

--- a/MAKE/Makefile.puhti_pgi
+++ b/MAKE/Makefile.puhti_pgi
@@ -91,7 +91,7 @@ INC_PROFILE = -I$(LIBRARY_PREFIX)/openmpi/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_
 INC_FSGRID = -I./submodules/fsgrid
 INC_EIGEN = -I$(LIBRARY_PREFIX)/eigen/3.3.7/
 INC_DCCRG = -I./submodules/dccrg
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass-old
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 
 
 

--- a/MAKE/Makefile.ukko_gcc_openmpi
+++ b/MAKE/Makefile.ukko_gcc_openmpi
@@ -115,4 +115,4 @@ LIB_PAPI = -lpapi
 INC_EIGEN = -I$(LIBRARY_PREFIX)/ -I$(LIBRARY_PREFIX)/Eigen/
 INC_FSGRID = -I./submodules/fsgrid
 INC_DCCRG = -I./submodules/dccrg
-INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass/
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/

--- a/MAKE/Makefile.vorna_gcc
+++ b/MAKE/Makefile.vorna_gcc
@@ -93,7 +93,7 @@ INC_PAPI = -isystem $(LIBRARY_PREFIX)/$(CC_BRAND)/$(CC_BRAND_VERSION)/$(MPT_BRAN
 #header libraries
 INC_FSGRID = -I./submodules/fsgrid
 INC_DCCRG = -I./submodules/dccrg
-INC_VECTORCLASS = -isystem $(LIBRARY_PREFIX)/vectorclass/
+INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 INC_EIGEN = -isystem $(LIBRARY_PREFIX)/ -I$(LIBRARY_PREFIX)/Eigen
 
 

--- a/MAKE/Makefile.yann
+++ b/MAKE/Makefile.yann
@@ -10,11 +10,11 @@
 
 ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
 #Single-precision        
-        INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/Codes/vectorclass/version1
+        INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 	VECTORCLASS = VEC4F_FALLBACK
 else
 #Double-precision
-        INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/Codes/vectorclass/version1
+        INC_VECTORCLASS = -I ./submodules/vectorclass/ -I ./submodules/vectorclass-addon/vector3d/
 	VECTORCLASS = VEC4D_FALLBACK
 endif
 

--- a/mini-apps/ionosphereSolverTests/Makefile
+++ b/mini-apps/ionosphereSolverTests/Makefile
@@ -63,8 +63,8 @@ common.o: ../../common.h ../../common.cpp
 datareducer.o: ../../datareduction/datareducer.h ../../datareduction/datareductionoperator.h ../../datareduction/datareducer.cpp
 	${CMP} ${CXXFLAGS} ${FLAGS} ${MATHFLAGS} -c ../../datareduction/datareducer.cpp ${INC_DCCRG} ${INC_ZOLTAN} ${INC_MPI} ${INC_BOOST} ${INC_EIGEN} ${INC_VLSV} ${INC_FSGRID} ${INC_JEMALLOC} ${INC_PROFILE}
 
-datareductionoperator.o:  ../../parameters.h ../../datareduction/datareductionoperator.h ../../datareduction/datareductionoperator.cpp
-	${CMP} ${CXXFLAGS} ${FLAGS} ${MATHFLAGS} -c ../../datareduction/datareductionoperator.cpp ${INC_DCCRG} ${INC_ZOLTAN} ${INC_MPI} ${INC_BOOST} ${INC_EIGEN} ${INC_VLSV} ${INC_FSGRID} ${INC_PROFILE} ${INC_JEMALLOC}
+datareductionoperator.o:  ../../parameters.h ../../datareduction/datareductionoperator.h ../../datareduction/datareductionoperator.cpp 
+	${CMP} ${CXXFLAGS} ${FLAGS} ${MATHFLAGS} -c ../../datareduction/datareductionoperator.cpp ${INC_DCCRG} ${INC_ZOLTAN} ${INC_MPI} ${INC_BOOST} ${INC_EIGEN} ${INC_VLSV} ${INC_FSGRID} ${INC_PROFILE} ${INC_JEMALLOC} ${INC_VECTORCLASS}
 
 fs_common.o: ../../fieldsolver/fs_limiters.h ../../fieldsolver/fs_limiters.cpp
 	${CMP} ${CXXFLAGS} ${FLAGS} ${MATHFLAGS} -c ../../fieldsolver/fs_common.cpp -I$(CURDIR)  ${INC_BOOST} ${INC_EIGEN} ${INC_DCCRG} ${INC_FSGRID} ${INC_PROFILE} ${INC_ZOLTAN} ${INC_JEMALLOC}


### PR DESCRIPTION
Two submodules actually, one for the vectorclass proper and one for the addons.

Makefiles are also updated, except for those platforms that require the fallback class anyway.