### PR TITLE
Script to automaticall build libraries. Replaces build_libraries CI step

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -17,6 +17,8 @@ jobs:
     container: ursg/vlasiator_ci:20230220_1
 
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
       - name: Run library build script
         run: ./build_libraries.sh
       - name: Build libraries tar

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -17,48 +17,8 @@ jobs:
     container: ursg/vlasiator_ci:20230220_1
 
     steps:
-      - name: Setup libraries dir
-        run: |
-          mkdir -p libraries/include
-          mkdir -p libraries/lib
-          mkdir library-build
-          cd library-build
-      - name: Build phiprof
-        run: |
-          git clone https://github.com/fmihpc/phiprof/
-          cd phiprof/src
-          make -j 4 CCC=mpic++
-          cp ../include/* $GITHUB_WORKSPACE/libraries/include
-          cp ../lib/* $GITHUB_WORKSPACE/libraries/lib
-          cd ../..
-      - name: Build VLSV
-        run: |
-          git clone https://github.com/fmihpc/vlsv.git
-          cd vlsv
-          make
-          cp libvlsv.a $GITHUB_WORKSPACE/libraries/lib
-          cp *.h $GITHUB_WORKSPACE/libraries/include
-          cd ..
-      - name: Build papi
-        run: |
-          git clone https://github.com/icl-utk-edu/papi
-          cd papi/src
-          ./configure --prefix=$GITHUB_WORKSPACE/libraries && make -j 4 CC=gcc && make install
-          cd ../..
-      - name: Build jemalloc
-        run: |
-          wget https://github.com/jemalloc/jemalloc/releases/download/4.0.4/jemalloc-4.0.4.tar.bz2
-          tar xf jemalloc-4.0.4.tar.bz2
-          cd jemalloc-4.0.4
-          ./configure --prefix=$GITHUB_WORKSPACE/libraries --with-jemalloc-prefix=je_ && make -j 4 && make install
-          cd ..
-      - name: Build Zoltan
-        run: |
-          git clone https://github.com/sandialabs/Zoltan.git
-          mkdir zoltan-build
-          cd zoltan-build
-          ../Zoltan/configure --prefix=$GITHUB_WORKSPACE/libraries --enable-mpi --with-mpi-compilers --with-gnumake --with-id-type=ullong && make -j 4 && make install
-          cd ..
+      - name: Run library build script
+        run: ./build_libraries.sh
       - name: Build libraries tar
         run: tar --zstd -cvf libraries.tar.zstd libraries/
       - name: Upload libraries as artifact

--- a/build_libraries.sh
+++ b/build_libraries.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e   # Abort on error
+
+WORKSPACE=`pwd`
+
+if [[ z$1 != "z" ]]; then
+   PLATFORM=-$1
+else 
+   PLATFORM=""
+fi
+
+# Clean up old library build dirs and libraries for this platform
+rm -rf library-build libraries${PLATFORM}
+
+# Create new ones
+mkdir -p libraries${PLATFORM}/include
+mkdir -p libraries${PLATFORM}/lib
+mkdir library-build
+cd library-build
+
+# Build phiprof
+git clone https://github.com/fmihpc/phiprof/ 
+cd phiprof/src
+make -j 4 CCC=mpic++
+cp ../include/* $WORKSPACE/libraries${PLATFORM}/include
+cp ../lib/* $WORKSPACE/libraries${PLATFORM}/lib
+cd ../..
+
+# Build VLSV
+git clone https://github.com/fmihpc/vlsv.git  
+cd vlsv
+make
+cp libvlsv.a $WORKSPACE/libraries${PLATFORM}/lib
+cp *.h $WORKSPACE/libraries${PLATFORM}/include
+cd ..
+
+# Build papi
+if [[ $PLATFORM != "-arriesgado" ]]; then  # This fails on RISCV
+   git clone https://github.com/icl-utk-edu/papi
+   cd papi/src
+   ./configure --prefix=$WORKSPACE/libraries${PLATFORM} && make -j 4 CC=gcc && make install
+   cd ../..
+fi
+
+# Build jemalloc
+wget https://github.com/jemalloc/jemalloc/releases/download/4.0.4/jemalloc-4.0.4.tar.bz2
+tar xjf jemalloc-4.0.4.tar.bz2
+cd jemalloc-4.0.4
+./configure --prefix=$WORKSPACE/libraries${PLATFORM} --with-jemalloc-prefix=je_ && make -j 4 && make install
+cd ..
+
+# Build Zoltan
+git clone https://github.com/sandialabs/Zoltan.git
+mkdir zoltan-build
+cd zoltan-build
+if [[ $PLATFORM != "-arriesgado" ]]; then
+   ../Zoltan/configure --prefix=$WORKSPACE/libraries${PLATFORM} --enable-mpi --with-mpi-compilers --with-gnumake --with-id-type=ullong && make -j 4 && make install
+else
+   ../Zoltan/configure --prefix=$WORKSPACE/libraries${PLATFORM} --enable-mpi --with-mpi-compilers --with-gnumake --with-id-type=ullong --build=arm-linux-gnu && make -j 4 && make install
+cd ..
+fi
+
+git clone https://gitlab.com/libeigen/eigen.git
+cp -ua eigen/Eigen $WORKSPACE/libraries${PLATFORM}/include


### PR DESCRIPTION
This should hopefully run mostly everywhere (the current implementation has some special case handling for RISCV, and will probably need the same for ARM in the future)