### PR TITLE
Github actions workflow to automatically sync branches to HLRS gitlab

### DIFF
--- a/.github/workflows/sync-hlrs-gitlab.yml
+++ b/.github/workflows/sync-hlrs-gitlab.yml
@@ -2,7 +2,7 @@ name: Generate testpackage reference data
 
 on:
   push:
-    branches : ["dev","master","cudasiator"]
+    branches : ["dev","master","vlasiator_gpu"]
 
 jobs:
   push_to_gitlab:

--- a/.github/workflows/sync-hlrs-gitlab.yml
+++ b/.github/workflows/sync-hlrs-gitlab.yml
@@ -1,0 +1,23 @@
+name: Generate testpackage reference data
+
+on:
+  push:
+    branches : ["dev","master","cudasiator"]
+
+jobs:
+  push_to_gitlab:
+    # Run the testpackage on the carrington cluster
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+    - name: Push to Gitlab
+      run: |
+        git remote set-url gitlab https://oauth2:${token}@codehub.hlrs.de/coes/plasma-pepsc/uoh/vlasiator.git
+        git push gitlab dev:dev
+        git push gitlab master:master
+        git push gitlab cudasiator:cudasiator
+      with:
+        env:
+          token: ${{ secrets.GITLAB_ACCESS_TOKEN }}


### PR DESCRIPTION
Right now, this would keep the dev, master and cudasiator branches up to date there, so that development is visible to EuroHPC and can potentially trigger CI runs on their hardware, too.

I guess this can only really be tested by merging into dev, because why would it otherwise trigger?