### PR TITLE
Error handling on failed writes

### DIFF
--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -1557,6 +1557,7 @@ bool writeRestart(
    fname.width(7);
    fname.fill('0');
    fname << fileIndex << "." << currentDate << ".vlsv";
+   P::lastRestart = fname.str();
 
    phiprof::Timer openTimer {"open"};
    //Open the file with vlsvWriter:
@@ -1588,7 +1589,9 @@ bool writeRestart(
       MPI_Info_set(MPIinfo, factor, stripeChar);
    }
    
-   if( vlsvWriter.open( fname.str(), MPI_COMM_WORLD, masterProcessId, MPIinfo ) == false) return false;
+   if (vlsvWriter.open( fname.str(), MPI_COMM_WORLD, masterProcessId, MPIinfo ) == false) {
+      return false;
+   }
 
    if( MPIinfo != MPI_INFO_NULL ) {
       MPI_Info_free(&MPIinfo);

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -194,6 +194,8 @@ std::array<FsGridTools::Task_t,3> P::overrideReadFsGridDecomposition = {0,0,0};
 std::string tracerString; /*!< Fieldline tracer to use for coupling ionosphere and magnetosphere */
 bool P::computeCurvature;
 
+std::string P::lastRestart {""};
+
 bool P::addParameters() {
    typedef Readparameters RP;
    // the other default parameters we read through the add/get interface

--- a/parameters.h
+++ b/parameters.h
@@ -224,6 +224,8 @@ struct Parameters {
    
    static bool computeCurvature; /*<! Boolean flag, if true the curvature of magnetic field is computed. */
 
+   static std::string lastRestart;  // Last restart file written
+
    /*! \brief Add the global parameters.
     *
     * This function adds all the parameters that are loaded at a global level.

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -1029,6 +1029,10 @@ int main(int argn,char* args[]) {
                   version,
                   config,
                   outputReducer,"restart",(uint)P::t,P::restartStripeFactor) == false ) {
+            // If restart write fails, remove the malformed file and hope someone clears space soon
+            MPI_Barrier(MPI_COMM_WORLD);
+            std::remove(P::lastRestart.c_str());
+            P::lastRestart = "";
             logFile << "(IO): ERROR Failed to write restart!" << endl << writeVerbose;
             cerr << "FAILED TO WRITE RESTART" << endl;
          }

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -590,7 +590,7 @@ int main(int argn,char* args[]) {
             writeGhosts
          ) == false
       ) {
-         cerr << "FAILED TO WRITE GRID AT " << __FILE__ << " " << __LINE__ << endl;
+         abort_mpi("FAILED TO WRITE GRID", 1);
       }
 
       phiprof::stop("Initialization");
@@ -729,7 +729,7 @@ int main(int argn,char* args[]) {
             writeGhosts
          ) == false
       ) {
-         cerr << "FAILED TO WRITE GRID AT " << __FILE__ << " " << __LINE__ << endl;
+         abort_mpi("FAILED TO WRITE GRID", 1);
       }
 
       P::systemWriteDistributionWriteStride.pop_back();
@@ -946,7 +946,7 @@ int main(int argn,char* args[]) {
                writeGhosts
                ) == false
             ) {
-               cerr << "FAILED TO WRITE GRID AT" << __FILE__ << " " << __LINE__ << endl;
+               abort_mpi("FAILED TO WRITE GRID", 1);
             }
             P::systemWrites[i]++;
             // Special case for large timesteps


### PR DESCRIPTION
- Failed bulk writes are fatal. If the disk/quota is full, failed writes essentially cause data loss and unreliable output. Due to writing cadence we can't expect someone to be always on hand to clear disk space.
- Try to clean up failed restart writes by removing the malformed file. Since restart writes are less common and much larger than bulk files, it's much easier to recover from a failed restart write. By removing the failed restart, the simulation can possibly run normally for at least some time, hopefully enough for someone to clear disk space and manually trigger a restart write.