### PR TITLE
Fix gitlab sync action yaml syntax

### DIFF
--- a/.github/workflows/sync-hlrs-gitlab.yml
+++ b/.github/workflows/sync-hlrs-gitlab.yml
@@ -18,6 +18,5 @@ jobs:
         git push gitlab dev:dev
         git push gitlab master:master
         git push gitlab cudasiator:cudasiator
-      with:
-        env:
-          token: ${{ secrets.GITLAB_ACCESS_TOKEN }}
+      env:
+        token: ${{ secrets.GITLAB_ACCESS_TOKEN }}


### PR DESCRIPTION
Followup to #901, this hopefully fixes the gitlab sync action. Compare [the error here](https://github.com/fmihpc/vlasiator/actions/runs/7826448847)