### PR TITLE
Fix git remote syntax in gitlab sync action.

### DIFF
--- a/.github/workflows/sync-hlrs-gitlab.yml
+++ b/.github/workflows/sync-hlrs-gitlab.yml
@@ -14,7 +14,8 @@ jobs:
       uses: actions/checkout@v3
     - name: Push to Gitlab
       run: |
-        git remote set-url gitlab https://oauth2:${token}@codehub.hlrs.de/coes/plasma-pepsc/uoh/vlasiator.git
+        git remote add gitlab https://oauth2:${token}@codehub.hlrs.de/coes/plasma-pepsc/uoh/vlasiator.git
+        git fetch gitlab
         git push gitlab dev:dev
         git push gitlab master:master
         git push gitlab cudasiator:cudasiator


### PR DESCRIPTION
If only there were a way to consecutively test this without needing to spam PRs!

Anyway, progress is happening.