### PR TITLE
Use Github "Retry Step" Action to wait for vlasiator binary on lustre.

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -99,9 +99,13 @@ jobs:
       run: |
         export VLASIATOR_ARCH=carrington_gcc_openmpi
         srun -M carrington --job-name tp_compile --interactive --nodes=1 -n 1 -c 16 --mem=40G -p short -t 0:10:0 bash -c 'module purge; module load GCC/11.2.0; module load OpenMPI/4.1.1-GCC-11.2.0 ; module load PMIx/4.1.0-GCCcore-11.2.0; module load PAPI/6.0.0.1-GCCcore-11.2.0; export VLASIATOR_ARCH=carrington_gcc_openmpi; make -j 16 testpackage; sleep 10s'
-    - name: Sleep for 10 seconds
-      run: sleep 10s
-      shell: bash
+    - name: Make sure the output binary is visible in lustre
+      uses: nick-fields/retry@v3
+      with:
+        timeout_seconds: 15
+        max_attempts: 3
+        retry_on: error
+        command: ls vlasiator
     - name: Upload testpackage binary
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Instead of speculatively waiting for 10 seconds and then potentially failing the whole action, this uses the "retry step" action to run "ls vlasiator", and if that fails, wait 10 seconds to try again, a total of three times.
Maybe that helps with the lustre synchronization issues on vakka.