### PR TITLE
Fix CI runs on RISCV failing, probably due to old libraries still lingering in the work directory.

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -145,8 +145,6 @@ jobs:
         name: libraries-arriesgado
     - name: Unpack libraries
       run: tar -xzvf libraries-arriesgado.tar.gz
-    - name: STOPGAP remove conflicting submoduled header libraries from the tarball extract
-      run: rm ./libraries-arriesgado/include/fsgrid.hpp ./libraries-arriesgado/include/dccrg.hpp
     - name: Make clean
       run: VLASIATOR_ARCH=arriesgado make clean
     - name: Compile vlasiator (RISC-V)

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -37,9 +37,16 @@ jobs:
     runs-on: risc-v
 
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Clean workspace
+        run: |
+          rm -rf libraries library-build libraries-arriesgado.tar.gz
       - name: Submit library job
         run: |
-          srun --interactive -p arriesgado-jammy -J vlasiator-libs -n 1 -c 4 --pty -t 01:00:00 bash -lc 'module load openmpi; cp ~/vlasiator/build_libraries.sh .; ./build_libraries.sh arriesgado'
+          srun --interactive -p arriesgado-jammy -J vlasiator-libs -n 1 -c 4 -t 01:00:00 bash -lc 'module load openmpi; cp ~/vlasiator/build_libraries.sh .; ./build_libraries.sh arriesgado'
       - name: Build libraries tar
         run: tar -czvf libraries-arriesgado.tar.gz libraries-arriesgado/
       - name: Upload libraries as artifact
@@ -127,6 +134,11 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Clean workspace
+      run: |
+        rm -rf libraries library-build libraries-arriesgado.tar.gz
+        rm -rf stdout.txt stderr.txt metrics.txt
+        rm -rf *.xml
     - name: Download libraries
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -46,7 +46,7 @@ jobs:
           rm -rf libraries library-build libraries-arriesgado.tar.gz
       - name: Submit library job
         run: |
-          srun --interactive -p arriesgado-jammy -J vlasiator-libs -n 1 -c 4 -t 01:00:00 bash -lc 'module load openmpi; cp ~/vlasiator/build_libraries.sh .; ./build_libraries.sh arriesgado'
+          srun --interactive -p arriesgado-jammy -J vlasiator-libs -n 1 -c 4 -t 01:00:00 bash -lc 'module load openmpi; ./build_libraries.sh arriesgado'
       - name: Build libraries tar
         run: tar -czvf libraries-arriesgado.tar.gz libraries-arriesgado/
       - name: Upload libraries as artifact

--- a/build_libraries.sh
+++ b/build_libraries.sh
@@ -22,7 +22,13 @@ cd library-build
 # Build phiprof
 git clone https://github.com/fmihpc/phiprof/ 
 cd phiprof/src
-make -j 4 CCC=mpic++
+
+if [[ $PLATFORM != "-arriesgado" ]]; then
+   make -j 4 CCC=mpic++
+else
+   # Special workaround for missing include paths on arriesgado
+   make -j 4 CCC=mpic++ CCFLAGS="-I /usr/lib/gcc/riscv64-linux-gnu/11/include -fpic -O2 -std=c++17 -DCLOCK_ID=CLOCK_MONOTONIC -fopenmp -W -Wall -Wextra -pedantic"
+fi
 cp ../include/* $WORKSPACE/libraries${PLATFORM}/include
 cp ../lib/* $WORKSPACE/libraries${PLATFORM}/lib
 cd ../..

--- a/build_libraries.sh
+++ b/build_libraries.sh
@@ -9,6 +9,7 @@ if [[ z$1 != "z" ]]; then
 else 
    PLATFORM=""
 fi
+echo "Using platform $PLATFORM"
 
 # Clean up old library build dirs and libraries for this platform
 rm -rf library-build libraries${PLATFORM}


### PR DESCRIPTION
First attempt: let's clean the CI workspace before actually building anything.