### PR TITLE
Reverting submodule urls to https instead of ssh, for easier accessib…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "submodules/fsgrid"]
 	path = submodules/fsgrid
-	url = git@github.com:fmihpc/fsgrid.git
+	url = https://github.com/fmihpc/fsgrid.git
 
 [submodule "submodules/dccrg"]
 	path = submodules/dccrg
-	url = git@github.com:fmihpc/dccrg.git
+	url = https://github.com/fmihpc/dccrg.git
 	branch = vlasiator-version
 
 [submodule "submodules/vectorclass"]


### PR DESCRIPTION
…ility. These are not supposed to be pushed to directly anyway.

Seems like the recommendations have been in flux and that there is now no straight-up recommendation.
https://stackoverflow.com/questions/11041729/git-clone-with-https-or-ssh-remote