### PR TITLE
Use mpirun instead of srun for tool runs on carrington for CI

### DIFF
--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -57,7 +57,7 @@ export OMP_NUM_THREADS=$t
 #command for running stuff
 run_command="mpirun --mca btl self -mca pml ^vader,tcp,openib,uct,yalla -x UCX_NET_DEVICES=mlx5_0:1 -x UCX_TLS=rc,sm -x UCX_IB_ADDR_TYPE=ib_global -np $tasks"
 small_run_command="mpirun --mca btl self -mca pml ^vader,tcp,openib,uct,yalla -x UCX_NET_DEVICES=mlx5_0:1 -x UCX_TLS=rc,sm -x UCX_IB_ADDR_TYPE=ib_global -n 1 -N 1"
-run_command_tools="srun --mpi=pmix_v3 -n 1 "
+run_command_tools="mpirun -np 1 "
 
 umask 007
 # Launch the OpenMP job to the allocated compute node


### PR DESCRIPTION
Diagnosing something entirely unrelated, I found that testpackage runs spend plenty of time on the carrington nodes doing nothing at 100% cpu idle.
Apparently, srun wants to wait for some timeout to place the jobs locally. Maybe this is related to the recent slurm restructuring?

Anyway, mpirun seems to do the job.