### PR TITLE
Fix compute-time loop

### DIFF
--- a/arch/arch_device_host.h
+++ b/arch/arch_device_host.h
@@ -65,9 +65,11 @@ inline static void host_unregister(T* ptr){}
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T>
 inline static void parallel_reduce_driver(const uint (&limits)[1], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
 
-  #pragma omp for
-  for (uint idx0 = 0; idx0 < limits[0]; ++idx0)
-    loop_body(idx0, sum);
+  uint idx[1];
+         
+  //#pragma omp for
+  for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
+    loop_body(idx[0], sum);
 
   (void) n_redu_dynamic;
 }
@@ -75,11 +77,13 @@ inline static void parallel_reduce_driver(const uint (&limits)[1], Lambda loop_b
 /* Parallel reduce driver function - specialization for 2D case */
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T, typename = typename std::enable_if<std::is_void<typename std::result_of<Lambda(uint, uint, T*)>::type>::value>::type>
 inline static void parallel_reduce_driver(const uint (&limits)[2], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
-   
-  #pragma omp for collapse(2)
-  for (uint idx1 = 0; idx1 < limits[1]; ++idx1) 
-    for (uint idx0 = 0; idx0 < limits[0]; idx0 +=limits[0])
-      loop_body(idx0, idx1, sum);
+
+  uint idx[2];
+         
+  //#pragma omp for collapse(2)
+  for (idx[1] = 0; idx[1] < limits[1]; ++idx[1]) 
+    for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
+      loop_body(idx[0], idx[1], sum);
 
   (void) n_redu_dynamic;
 }
@@ -87,12 +91,14 @@ inline static void parallel_reduce_driver(const uint (&limits)[2], Lambda loop_b
 /* Parallel reduce driver function - specialization for 2D case with nested bodies */
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T, typename = typename std::enable_if<!std::is_void<typename std::result_of<Lambda(uint, uint, T*)>::type>::value>::type, typename = void>
 inline static void parallel_reduce_driver(const uint (&limits)[2], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
-   
-  #pragma omp for //collapse(2)
-  for (uint idx1 = 0; idx1 < limits[1]; ++idx1) {
-    auto inner_loop = loop_body(idx1, idx1, sum);
-    for (uint idx0 = 0; idx0 < limits[0]; ++idx0)
-      inner_loop(idx0, idx1, sum);
+
+  uint idx[2];
+         
+  //#pragma omp for collapse(2)
+  for (idx[1] = 0; idx[1] < limits[1]; ++idx[1]) {
+    auto inner_loop = loop_body(idx[0], idx[1], sum);
+    for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
+      inner_loop(idx[0], idx[1], sum);
   }
   (void) n_redu_dynamic;
 }
@@ -100,12 +106,14 @@ inline static void parallel_reduce_driver(const uint (&limits)[2], Lambda loop_b
 /* Parallel reduce driver function - specialization for 3D case */
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T, typename = typename std::enable_if<std::is_void<typename std::result_of<Lambda(uint, uint, uint, T*)>::type>::value>::type>
 inline static void parallel_reduce_driver(const uint (&limits)[3], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
- 
-  #pragma omp for collapse(3)
-  for (uint idx2 = 0; idx2 < limits[2]; ++idx2) 
-    for (uint idx1 = 0; idx1 < limits[1]; ++idx1) 
-      for (uint idx0 = 0; idx0 < limits[0]; ++idx0)
-        loop_body(idx0, idx1, idx2, sum);
+
+  uint idx[3];
+         
+  //#pragma omp for collapse(3)
+  for (idx[2] = 0; idx[2] < limits[2]; ++idx[2]) 
+    for (idx[1] = 0; idx[1] < limits[1]; ++idx[1]) 
+      for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
+        loop_body(idx[0], idx[1], idx[2], sum);
 
   (void) n_redu_dynamic;
 }
@@ -113,13 +121,15 @@ inline static void parallel_reduce_driver(const uint (&limits)[3], Lambda loop_b
 /* Parallel reduce driver function - specialization for 3D case with nested bodies */
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T, typename = typename std::enable_if<!std::is_void<typename std::result_of<Lambda(uint, uint, uint, T*)>::type>::value>::type, typename = void>
 inline static void parallel_reduce_driver(const uint (&limits)[3], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
- 
-  #pragma omp for //collapse(3)
-  for (uint idx2 = 0; idx2 < limits[2]; ++idx2) {
-    auto inner_loop = loop_body(idx2, idx2, idx2, sum);
-    for (uint idx1 = 0; idx1 < limits[1]; ++idx1) 
-      for (uint idx0 = 0; idx0 < limits[0]; ++idx0)
-        inner_loop(idx0, idx1, idx2, sum);
+
+  uint idx[3];
+         
+  //#pragma omp for collapse(3)
+  for (idx[2] = 0; idx[2] < limits[2]; ++idx[2]) {
+    auto inner_loop = loop_body(idx[0], idx[1], idx[2], sum);
+    for (idx[1] = 0; idx[1] < limits[1]; ++idx[1]) 
+      for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
+        inner_loop(idx[0], idx[1], idx[2], sum);
   }
   (void) n_redu_dynamic;
 }
@@ -128,13 +138,14 @@ inline static void parallel_reduce_driver(const uint (&limits)[3], Lambda loop_b
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T, typename = typename std::enable_if<std::is_void<typename std::result_of<Lambda(uint, uint, uint, uint, T*)>::type>::value>::type>
 inline static void parallel_reduce_driver(const uint (&limits)[4], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
 
-  #pragma omp for collapse(4)
-  for (uint idx3 = 0; idx3 < limits[3]; ++idx3){
-    for (uint idx2 = 0; idx2 < limits[2]; ++idx2) 
-      for (uint idx1 = 0; idx1 < limits[1]; ++idx1) 
-        for (uint idx0 = 0; idx0 < limits[0]; ++idx0)
-          loop_body(idx0, idx1, idx2, idx3, sum);
-  }
+  uint idx[4];
+         
+  //#pragma omp for collapse(4)
+  for (idx[3] = 0; idx[3] < limits[3]; ++idx[3]) 
+    for (idx[2] = 0; idx[2] < limits[2]; ++idx[2]) 
+      for (idx[1] = 0; idx[1] < limits[1]; ++idx[1]) 
+        for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
+          loop_body(idx[0], idx[1], idx[2], idx[3], sum);
 
   (void) n_redu_dynamic;
 }
@@ -143,13 +154,15 @@ inline static void parallel_reduce_driver(const uint (&limits)[4], Lambda loop_b
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T, typename = typename std::enable_if<!std::is_void<typename std::result_of<Lambda(uint, uint, uint, uint, T*)>::type>::value>::type, typename = void>
 inline static void parallel_reduce_driver(const uint (&limits)[4], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
 
-  #pragma omp for //collapse(4)
-  for (uint idx3 = 0; idx3 < limits[3]; ++idx3) { 
-    auto inner_loop = loop_body(idx3, idx3, idx3, idx3, sum);
-    for (uint idx2 = 0; idx2 < limits[2]; ++idx2) 
-      for (uint idx1 = 0; idx1 < limits[1]; ++idx1) 
-        for (uint idx0 = 0; idx0 < limits[0]; ++idx0)
-          inner_loop(idx0, idx1, idx2, idx3, sum);
+  uint idx[4];
+         
+  //#pragma omp for collapse(4)
+  for (idx[3] = 0; idx[3] < limits[3]; ++idx[3]) { 
+    auto inner_loop = loop_body(idx[0], idx[1], idx[2], idx[3], sum);
+    for (idx[2] = 0; idx[2] < limits[2]; ++idx[2]) 
+      for (idx[1] = 0; idx[1] < limits[1]; ++idx[1]) 
+        for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
+          inner_loop(idx[0], idx[1], idx[2], idx[3], sum);
   } 
   (void) n_redu_dynamic;
 }

--- a/arch/arch_device_host.h
+++ b/arch/arch_device_host.h
@@ -65,11 +65,9 @@ inline static void host_unregister(T* ptr){}
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T>
 inline static void parallel_reduce_driver(const uint (&limits)[1], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
 
-  uint idx[1];
-         
-  //#pragma omp for
-  for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
-    loop_body(idx[0], sum);
+  #pragma omp for
+  for (uint idx0 = 0; idx0 < limits[0]; ++idx0)
+    loop_body(idx0, sum);
 
   (void) n_redu_dynamic;
 }
@@ -77,13 +75,11 @@ inline static void parallel_reduce_driver(const uint (&limits)[1], Lambda loop_b
 /* Parallel reduce driver function - specialization for 2D case */
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T, typename = typename std::enable_if<std::is_void<typename std::result_of<Lambda(uint, uint, T*)>::type>::value>::type>
 inline static void parallel_reduce_driver(const uint (&limits)[2], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
-
-  uint idx[2];
-         
-  //#pragma omp for collapse(2)
-  for (idx[1] = 0; idx[1] < limits[1]; ++idx[1]) 
-    for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
-      loop_body(idx[0], idx[1], sum);
+   
+  #pragma omp for collapse(2)
+  for (uint idx1 = 0; idx1 < limits[1]; ++idx1) 
+    for (uint idx0 = 0; idx0 < limits[0]; idx0 +=limits[0])
+      loop_body(idx0, idx1, sum);
 
   (void) n_redu_dynamic;
 }
@@ -91,14 +87,12 @@ inline static void parallel_reduce_driver(const uint (&limits)[2], Lambda loop_b
 /* Parallel reduce driver function - specialization for 2D case with nested bodies */
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T, typename = typename std::enable_if<!std::is_void<typename std::result_of<Lambda(uint, uint, T*)>::type>::value>::type, typename = void>
 inline static void parallel_reduce_driver(const uint (&limits)[2], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
-
-  uint idx[2];
-         
-  //#pragma omp for collapse(2)
-  for (idx[1] = 0; idx[1] < limits[1]; ++idx[1]) {
-    auto inner_loop = loop_body(idx[0], idx[1], sum);
-    for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
-      inner_loop(idx[0], idx[1], sum);
+   
+  #pragma omp for //collapse(2)
+  for (uint idx1 = 0; idx1 < limits[1]; ++idx1) {
+    auto inner_loop = loop_body(idx1, idx1, sum);
+    for (uint idx0 = 0; idx0 < limits[0]; ++idx0)
+      inner_loop(idx0, idx1, sum);
   }
   (void) n_redu_dynamic;
 }
@@ -106,14 +100,12 @@ inline static void parallel_reduce_driver(const uint (&limits)[2], Lambda loop_b
 /* Parallel reduce driver function - specialization for 3D case */
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T, typename = typename std::enable_if<std::is_void<typename std::result_of<Lambda(uint, uint, uint, T*)>::type>::value>::type>
 inline static void parallel_reduce_driver(const uint (&limits)[3], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
-
-  uint idx[3];
-         
-  //#pragma omp for collapse(3)
-  for (idx[2] = 0; idx[2] < limits[2]; ++idx[2]) 
-    for (idx[1] = 0; idx[1] < limits[1]; ++idx[1]) 
-      for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
-        loop_body(idx[0], idx[1], idx[2], sum);
+ 
+  #pragma omp for collapse(3)
+  for (uint idx2 = 0; idx2 < limits[2]; ++idx2) 
+    for (uint idx1 = 0; idx1 < limits[1]; ++idx1) 
+      for (uint idx0 = 0; idx0 < limits[0]; ++idx0)
+        loop_body(idx0, idx1, idx2, sum);
 
   (void) n_redu_dynamic;
 }
@@ -121,15 +113,13 @@ inline static void parallel_reduce_driver(const uint (&limits)[3], Lambda loop_b
 /* Parallel reduce driver function - specialization for 3D case with nested bodies */
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T, typename = typename std::enable_if<!std::is_void<typename std::result_of<Lambda(uint, uint, uint, T*)>::type>::value>::type, typename = void>
 inline static void parallel_reduce_driver(const uint (&limits)[3], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
-
-  uint idx[3];
-         
-  //#pragma omp for collapse(3)
-  for (idx[2] = 0; idx[2] < limits[2]; ++idx[2]) {
-    auto inner_loop = loop_body(idx[0], idx[1], idx[2], sum);
-    for (idx[1] = 0; idx[1] < limits[1]; ++idx[1]) 
-      for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
-        inner_loop(idx[0], idx[1], idx[2], sum);
+ 
+  #pragma omp for //collapse(3)
+  for (uint idx2 = 0; idx2 < limits[2]; ++idx2) {
+    auto inner_loop = loop_body(idx2, idx2, idx2, sum);
+    for (uint idx1 = 0; idx1 < limits[1]; ++idx1) 
+      for (uint idx0 = 0; idx0 < limits[0]; ++idx0)
+        inner_loop(idx0, idx1, idx2, sum);
   }
   (void) n_redu_dynamic;
 }
@@ -138,14 +128,13 @@ inline static void parallel_reduce_driver(const uint (&limits)[3], Lambda loop_b
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T, typename = typename std::enable_if<std::is_void<typename std::result_of<Lambda(uint, uint, uint, uint, T*)>::type>::value>::type>
 inline static void parallel_reduce_driver(const uint (&limits)[4], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
 
-  uint idx[4];
-         
-  //#pragma omp for collapse(4)
-  for (idx[3] = 0; idx[3] < limits[3]; ++idx[3]) 
-    for (idx[2] = 0; idx[2] < limits[2]; ++idx[2]) 
-      for (idx[1] = 0; idx[1] < limits[1]; ++idx[1]) 
-        for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
-          loop_body(idx[0], idx[1], idx[2], idx[3], sum);
+  #pragma omp for collapse(4)
+  for (uint idx3 = 0; idx3 < limits[3]; ++idx3){
+    for (uint idx2 = 0; idx2 < limits[2]; ++idx2) 
+      for (uint idx1 = 0; idx1 < limits[1]; ++idx1) 
+        for (uint idx0 = 0; idx0 < limits[0]; ++idx0)
+          loop_body(idx0, idx1, idx2, idx3, sum);
+  }
 
   (void) n_redu_dynamic;
 }
@@ -154,15 +143,13 @@ inline static void parallel_reduce_driver(const uint (&limits)[4], Lambda loop_b
 template <reduce_op Op, uint NReductions, uint NDim, typename Lambda, typename T, typename = typename std::enable_if<!std::is_void<typename std::result_of<Lambda(uint, uint, uint, uint, T*)>::type>::value>::type, typename = void>
 inline static void parallel_reduce_driver(const uint (&limits)[4], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
 
-  uint idx[4];
-         
-  //#pragma omp for collapse(4)
-  for (idx[3] = 0; idx[3] < limits[3]; ++idx[3]) { 
-    auto inner_loop = loop_body(idx[0], idx[1], idx[2], idx[3], sum);
-    for (idx[2] = 0; idx[2] < limits[2]; ++idx[2]) 
-      for (idx[1] = 0; idx[1] < limits[1]; ++idx[1]) 
-        for (idx[0] = 0; idx[0] < limits[0]; ++idx[0])
-          inner_loop(idx[0], idx[1], idx[2], idx[3], sum);
+  #pragma omp for //collapse(4)
+  for (uint idx3 = 0; idx3 < limits[3]; ++idx3) { 
+    auto inner_loop = loop_body(idx3, idx3, idx3, idx3, sum);
+    for (uint idx2 = 0; idx2 < limits[2]; ++idx2) 
+      for (uint idx1 = 0; idx1 < limits[1]; ++idx1) 
+        for (uint idx0 = 0; idx0 < limits[0]; ++idx0)
+          inner_loop(idx0, idx1, idx2, idx3, sum);
   } 
   (void) n_redu_dynamic;
 }

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -164,40 +164,32 @@ void computeNewTimeStep(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
       cell->parameters[CellParams::MAXRDT] = numeric_limits<Real>::max();
 
       for (uint popID = 0; popID < getObjectWrapper().particleSpecies.size(); ++popID) {
+         cell->set_max_r_dt(popID, numeric_limits<Real>::max());
+         const Real* blockParams = cell->get_block_parameters(popID);
+         const Real EPS = numeric_limits<Real>::min() * 1000;
+
          const uint nBlocks = cell->get_number_of_velocity_blocks(popID);
-         if (nBlocks==0) {
-            continue;
-         }
-         const Real* parameters = cell->get_block_parameters(popID);
-         const Real HALF = 0.5;
-         Real popMin = std::numeric_limits<Real>::max();
-#pragma omp parallel
-         {
-            Real threadMin = std::numeric_limits<Real>::max();
-            arch::parallel_reduce<arch::min>(
-               {WID, WID, WID, nBlocks},
-               ARCH_LOOP_LAMBDA (const uint i, const uint j, const uint k, const uint n, Real *lthreadMin) -> void{
-                  const Real VX
-                     =            parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::VXCRD]
-                     + (i + HALF)*parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVX];
-                  const Real VY
-                     =            parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::VYCRD]
-                     + (j + HALF)*parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVY];
-                  const Real VZ
-                     =            parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::VZCRD]
-                     + (k + HALF)*parameters[n * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVZ];
-                  Real loopMin = dx / fabs(VX);
-                  loopMin = min(dy / fabs(VY), loopMin);
-                  loopMin = min(dz / fabs(VZ), loopMin);
-                  lthreadMin[0] = min(loopMin,lthreadMin[0]);
-               }, threadMin);
-#pragma omp critical
-            {
-               popMin = min(threadMin, popMin);
-            }
-         } // end parallel region
-         cell->set_max_r_dt(popID, popMin);
-         cell->parameters[CellParams::MAXRDT] = min(popMin, cell->parameters[CellParams::MAXRDT]);
+         if (nBlocks==0) continue;
+
+         Real threadMin = std::numeric_limits<Real>::max();
+         arch::parallel_reduce<arch::min>({2, nBlocks},
+            ARCH_LOOP_LAMBDA (uint i, const uint blockLID, Real *lthreadMin) -> void{
+               i = i * (WID - 1); // ie, i == 0, i == WID - 1
+               const Real Vx =
+                   blockParams[blockLID * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::VXCRD] +
+                   (i + HALF) * blockParams[blockLID * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVX] + EPS;
+               const Real Vy =
+                   blockParams[blockLID * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::VYCRD] +
+                   (i + HALF) * blockParams[blockLID * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVY] + EPS;
+               const Real Vz =
+                   blockParams[blockLID * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::VZCRD] +
+                   (i + HALF) * blockParams[blockLID * BlockParams::N_VELOCITY_BLOCK_PARAMS + BlockParams::DVZ] + EPS;
+
+               const Real dt_max_cell = min({dx / fabs(Vx), dy / fabs(Vy), dz / fabs(Vz)});
+               lthreadMin[0] = min(dt_max_cell,lthreadMin[0]);
+         }, threadMin);
+         cell->set_max_r_dt(popID, threadMin);
+         cell->parameters[CellParams::MAXRDT] = min(cell->get_max_r_dt(popID), cell->parameters[CellParams::MAXRDT]);
       } // end loop over popID
 
 


### PR DESCRIPTION
Only evaluate arch loop across 2 loop dimensions, not 4 (similarly to the original non-arch approach).