### PR TITLE
Add IPShock option for performing coordinate transformation or not

### DIFF
--- a/projects/IPShock/IPShock.cfg
+++ b/projects/IPShock/IPShock.cfg
@@ -134,6 +134,7 @@ BX0d =   3.93058e-09
 BY0d =       0.00000
 BZ0d =    1.1553350e-08
 Width = 1.0e6
+deHoffmanTeller = 0
 
 AMR_L1width = 3.0e6
 AMR_L2width = 1.5e6
@@ -151,4 +152,3 @@ rhod =        17561178.
 Temperatured =        1367039.3
 
 maxwCutoff = 1.0e-15
-

--- a/projects/IPShock/IPShock.h
+++ b/projects/IPShock/IPShock.h
@@ -85,7 +85,7 @@ namespace projects {
          virtual std::vector<std::array<Real, 3>> getV0(creal x, creal y, creal z, const uint popID) const;
          //virtual void calcCellParameters(Real* cellParams,creal& t);
          virtual void calcCellParameters(spatial_cell::SpatialCell* cell, creal& t);
-	 bool refineSpatialCells( dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid ) const;
+         bool refineSpatialCells( dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid ) const;
          // Interpolate between up- and downstream quantities
          // based on position
          Real interpolate(Real u, Real d, Real x) const;
@@ -105,11 +105,12 @@ namespace projects {
          int Bzusign;
          int Bzdsign;
 
+         bool doConvertdHT;
          Real Shockwidth;
-	 Real AMR_L1width;
-	 Real AMR_L2width;
-	 Real AMR_L3width;
-	 Real AMR_L4width;
+         Real AMR_L1width;
+         Real AMR_L2width;
+         Real AMR_L3width;
+         Real AMR_L4width;
 
          std::vector<IPShockSpeciesParameters> speciesParams;
 


### PR DESCRIPTION
The current IPShock project always perform a coordinate transformation into the deHoffman-Teller frame for the variables in the physical cells, but not the boundary cells. This PR adds an option to let users choose whether the coordinate transformation is performed or not.

Side notes:

1. There is a hidden assumption that the shock always locates at x = 0. 

