### PR TITLE
Cross-compile on BSC RiscV cluster for much faster CI builds

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -79,7 +79,8 @@ jobs:
           rm -rf libraries library-build libraries-arriesgado.tar.gz
       - name: Submit library job
         run: |
-          srun --interactive -p arriesgado-jammy -J vlasiator-libs -n 1 -c 4 -t 01:00:00 bash -lc 'module load openmpi; ./build_libraries.sh arriesgado'
+          #srun --interactive -p arriesgado-jammy -J vlasiator-libs -n 1 -c 4 -t 01:00:00 bash -lc 'module load openmpi; ./build_libraries.sh arriesgado'
+          ssh synth-hca 'source /etc/profile.d/lmod.sh; export PATH=$PATH:$HOME/bin; module load llvm/cross/EPI-0.7-development; cd '$GITHUB_WORKSPACE'; ./build_libraries.sh arriesgado'
       - name: Build libraries tar
         run: tar -czvf libraries-arriesgado.tar.gz libraries-arriesgado/
       - name: Upload libraries as artifact
@@ -182,7 +183,8 @@ jobs:
       run: VLASIATOR_ARCH=arriesgado make clean
     - name: Compile vlasiator (RISC-V)
       run: |
-          srun --interactive -p arriesgado-jammy -J vlasiator_build -n 1 -c 4 --pty -t 01:00:00 bash -lc 'module load boost papi openmpi; export VLASIATOR_ARCH=arriesgado; make -j4'
+        #srun --interactive -p arriesgado-jammy -J vlasiator_build -n 1 -c 4 --pty -t 01:00:00 bash -lc 'module load boost papi openmpi; export VLASIATOR_ARCH=arriesgado; make -j4'
+        ssh synth-hca 'source /etc/profile.d/lmod.sh; export PATH=$PATH:$HOME/bin; module load llvm/cross/EPI-0.7-development; export VLASIATOR_ARCH=arriesgado; cd '$GITHUB_WORKSPACE'; make -j 12'
     - name: Upload riscv binary
       uses: actions/upload-artifact@v3
       with:

--- a/MAKE/Makefile.arriesgado
+++ b/MAKE/Makefile.arriesgado
@@ -39,21 +39,21 @@ LIB_MPI =
 
 LIBRARY_PREFIX = libraries-arriesgado
 
-INC_BOOST =
-LIB_BOOST = ${BOOST_LIBS} -lboost_program_options
+INC_BOOST = -I/apps/riscv/boost/1.77.0/include
+LIB_BOOST = -L/apps/riscv/boost/1.77.0/lib -lboost_program_options
 
 INC_ZOLTAN = -I${LIBRARY_PREFIX}/include
 LIB_ZOLTAN = -L${LIBRARY_PREFIX}/lib -lzoltan
 
-INC_VLSV = -I$(LIBRARY_PREFIX)/vlsv
-LIB_VLSV = -L$(LIBRARY_PREFIX)/vlsv -lvlsv
+INC_VLSV = -I$(LIBRARY_PREFIX)/include
+LIB_VLSV = -L$(LIBRARY_PREFIX)/lib -lvlsv
 
 INC_DCCRG = -I./submodules/dccrg
 
 INC_FSGRID = -I./submodules/fsgrid
 
-LIB_PROFILE = -L${LIBRARY_PREFIX}/phiprof/lib -lphiprof -Wl,-rpath=${LIBRARY_PREFIX}/lib 
-INC_PROFILE = -I${LIBRARY_PREFIX}/phiprof/include
+LIB_PROFILE = -L${LIBRARY_PREFIX}/lib -lphiprof -Wl,-rpath=${LIBRARY_PREFIX}/lib 
+INC_PROFILE = -I${LIBRARY_PREFIX}/include
 INC_TOPO =
 
 INC_EIGEN = ${EIGEN3_INCL}

--- a/build_libraries.sh
+++ b/build_libraries.sh
@@ -68,7 +68,7 @@ git clone https://github.com/sandialabs/Zoltan.git
 mkdir zoltan-build
 cd zoltan-build
 if [[ $PLATFORM == "-arriesgado" ]]; then
-   ../Zoltan/configure --prefix=$WORKSPACE/libraries${PLATFORM} --enable-mpi --with-mpi-compilers --with-gnumake --with-id-type=ullong --build=arm-linux-gnu && make -j 4 && make install
+   ../Zoltan/configure --prefix=$WORKSPACE/libraries${PLATFORM} --enable-mpi --with-mpi-compilers --with-gnumake --with-id-type=ullong --host=riscv64-unknown-linux-gnu --build=arm-linux-gnu && make -j 4 && make install
 elif [[ $PLATFORM == "-appleM1" ]]; then
    ../Zoltan/configure --prefix=$WORKSPACE/libraries${PLATFORM} --enable-mpi --with-mpi-compilers --with-gnumake --with-id-type=ullong CC=mpicc CXX=mpic++ && make -j 4 && make install
 else


### PR DESCRIPTION
Instead of building on the (slow) riscV-nodes itself, it uses the "synth-hca" server in the cluster (which is nominally used to build the FPGA payloads for the hardware development platforms, but is mostly just idle), to cross-compile for the nodes.

The result has been verified to run just fine on the arriesgado cluster.

This accelerates riscv library + code builds from 26 minutes to about 2.5 minutes.