### PR TITLE
Add Umpire memory manager for GPU pool memory allocation

### DIFF
--- a/MAKE/Makefile.lumi_hipcc
+++ b/MAKE/Makefile.lumi_hipcc
@@ -91,6 +91,11 @@ LIB_VLSV = -L$(LIBRARY_PREFIX)/vlsv -lvlsv -Wl,-rpath=$(LIBRARY_PREFIX)/vlsv
 INC_PROFILE = -isystem $(LIBRARY_PREFIX)/phiprof/include -D_ROCTX -I${ROCM_PATH}/include
 LIB_PROFILE = -L$(LIBRARY_PREFIX)/phiprof/lib -lphiprof -lgfortran -Wl,-rpath=$(LIBRARY_PREFIX)/phiprof/lib -Wl,-rpath=${ROCM_PATH}/lib -lroctx64 -lroctracer64
 
+INC_UMPIRE = -isystem $(LIBRARY_PREFIX)/umpire/include
+LIB_UMPIRE = -L$(LIBRARY_PREFIX)/umpire/lib -L$(LIBRARY_PREFIX)/umpire/lib64 -lcamp -lumpire -lfmt
+CXXFLAGS += -DUSE_UMPIRE
+testpackage: CXXFLAGS += -DUSE_UMPIRE
+
 #header libraries
 
 #INC_EIGEN = -isystem $(LIBRARY_PREFIX)/eigen/

--- a/MAKE/Makefile.lumi_hipcc
+++ b/MAKE/Makefile.lumi_hipcc
@@ -54,7 +54,7 @@ LIB_MPI = -lmpi ${PE_MPICH_GTL_LIBS_amd_gfx90a}
 CXXFLAGS +=  -DPAPI_MEM
 testpackage: CXXFLAGS +=  -DPAPI_MEM
 
-#======== Allocator =========
+#======== Jemalloc =========
 #Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
 #Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
 #Note: jemalloc not supported with GPUs
@@ -63,6 +63,10 @@ testpackage: CXXFLAGS +=  -DPAPI_MEM
 
 #-DNO_WRITE_AT_ALL:  Define to disable write at all to 
 #                    avoid memleak (much slower IO)
+
+#======== Umpire =========
+CXXFLAGS += -DUSE_UMPIRE
+testpackage: CXXFLAGS += -DUSE_UMPIRE
 
 #======== Libraries ===========
 # Select the base directory based on which project you are using:
@@ -93,8 +97,6 @@ LIB_PROFILE = -L$(LIBRARY_PREFIX)/phiprof/lib -lphiprof -lgfortran -Wl,-rpath=$(
 
 INC_UMPIRE = -isystem $(LIBRARY_PREFIX)/umpire/include
 LIB_UMPIRE = -L$(LIBRARY_PREFIX)/umpire/lib -L$(LIBRARY_PREFIX)/umpire/lib64 -lcamp -lumpire -lfmt
-CXXFLAGS += -DUSE_UMPIRE
-testpackage: CXXFLAGS += -DUSE_UMPIRE
 
 #header libraries
 

--- a/MAKE/Makefile.mahti_cuda
+++ b/MAKE/Makefile.mahti_cuda
@@ -75,12 +75,16 @@ INC_CUDA = -isystem /usr/local/cuda/include
 CXXFLAGS += -DPAPI_MEM
 testpackage: CXXFLAGS += -DPAPI_MEM
 
-#======== Allocator =========
+#======== Jemalloc =========
 #Use jemalloc instead of system malloc to reduce memory fragmentation https://github.com/jemalloc/jemalloc
 #Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
 #NOTE: jemalloc not supported with GPUs
 #CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 #testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+
+#======== Umpire =========
+CXXFLAGS += -DUSE_UMPIRE
+testpackage: CXXFLAGS += -DUSE_UMPIRE
 
 #======== Libraries ===========
 
@@ -113,6 +117,9 @@ LIB_VLSV = -L$(LIBRARY_PREFIX2)/vlsv -lvlsv -Xlinker=-rpath=$(LIBRARY_PREFIX2)/v
 INC_PROFILE = -I$(LIBRARY_PREFIX2)/phiprof_nvcc/include
 LIB_PROFILE = -L$(LIBRARY_PREFIX2)/phiprof_nvcc/lib -lphiprof -Xlinker=-rpath=$(LIBRARY_PREFIX2)/phiprof_nvcc/lib
 #LIB_PROFILE = -L$(LIBRARY_PREFIX2)/phiprof_nvcc/lib -lphiprof -Wl,-rpath=$(LIBRARY_PREFIX2)/phiprof_nvcc/lib
+
+INC_UMPIRE = -isystem $(LIBRARY_PREFIX2)/umpire/include
+LIB_UMPIRE = -L$(LIBRARY_PREFIX2)/umpire/lib -L$(LIBRARY_PREFIX)/umpire/lib64 -lcamp -lumpire -lfmt
 
 #======== Header-only Libraries ===========
 

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,9 @@ COMPFLAGS += ${INC_PROFILE}
 #use jemalloc
 COMPFLAGS += ${INC_JEMALLOC}
 
+#use umpire
+COMPFLAGS += ${INC_UMPIRE}
+
 #define precision
 COMPFLAGS += -D${FP_PRECISION}
 
@@ -165,6 +168,8 @@ LIBS += ${LIB_PROFILE}
 LIBS += ${LIB_VLSV}
 LIBS += ${LIB_JEMALLOC}
 LIBS += ${LIB_PAPI}
+LIBS += ${LIB_UMPIRE}
+
 
 # Define common dependencies
 DEPS_COMMON = common.h common.cpp definitions.h mpiconversion.h logger.h object_wrapper.h
@@ -346,7 +351,7 @@ vlsv2silo:  ${DEPS_VLSVREADERINTERFACE} tools/vlsv2silo.cpp  ${OBJS_VLSVREADERIN
 vlsvdiff: ${DEPS_VLSVREADERINTERFACE} tools/vlsvdiff.cpp ${OBJS_VLSVREADEREXTRA} ${OBJS_VLSVREADERINTERFACE}
 	@echo [CC] $<
 	$(SILENT)$(CMP) $(CXXEXTRAFLAGS) ${MATHFLAGS} ${FLAGS} -c tools/vlsvdiff.cpp ${INC_VLSV} ${INC_FSGRID} -I$(CURDIR)
-	$(SILENT)${LNK} ${LDFLAGS} -o vlsvdiff_${FP_PRECISION} vlsvdiff.o ${OBJS_VLSVREADERINTERFACE} ${LIB_VLSV} ${LIBS}}
+	$(SILENT)${LNK} ${LDFLAGS} -o vlsvdiff_${FP_PRECISION} vlsvdiff.o ${OBJS_VLSVREADERINTERFACE} ${LIB_VLSV} ${LIBS}
 
 vlsvreaderinterface.o:  tools/vlsvreaderinterface.h tools/vlsvreaderinterface.cpp
 	${CMP} ${CXXFLAGS} ${FLAGS} -c tools/vlsvreaderinterface.cpp ${INC_VLSV} -I$(CURDIR)

--- a/arch/arch_device_cuda.h
+++ b/arch/arch_device_cuda.h
@@ -3,129 +3,131 @@
 #define ARCH_DEVICE_CUDA_H
 
 /* Include required headers */
-#include <cuda.h>
-#include <cuda_runtime.h>
 #include <cub/cub.cuh>
 #include <cub/device/device_radix_sort.cuh>
+#include <cuda.h>
+#include <cuda_runtime.h>
 #ifdef _OPENMP
-  #include <omp.h>
+#include <omp.h>
 #endif
 
 #if defined(USE_UMPIRE)
-  #include "umpire/Allocator.hpp"
-  #include "umpire/ResourceManager.hpp"
-  #include "umpire/strategy/QuickPool.hpp"
+#include "umpire/Allocator.hpp"
+#include "umpire/ResourceManager.hpp"
+#include "umpire/strategy/QuickPool.hpp"
 #endif
 
 /* architecture-agnostic definitions for CUDA */
 
-#define gpuGetLastError                  cudaGetLastError
-#define gpuGetErrorString                cudaGetErrorString
-#define gpuPeekAtLastError               cudaPeekAtLastError
+#define gpuGetLastError cudaGetLastError
+#define gpuGetErrorString cudaGetErrorString
+#define gpuPeekAtLastError cudaPeekAtLastError
 
-#define gpuSetDevice                     cudaSetDevice
-#define gpuGetDevice                     cudaGetDevice
-#define gpuGetDeviceCount                cudaGetDeviceCount
-#define gpuGetDeviceProperties           cudaGetDeviceProperties
-#define gpuDeviceSynchronize             cudaDeviceSynchronize
-#define gpuDeviceReset                   cudaDeviceReset
+#define gpuSetDevice cudaSetDevice
+#define gpuGetDevice cudaGetDevice
+#define gpuGetDeviceCount cudaGetDeviceCount
+#define gpuGetDeviceProperties cudaGetDeviceProperties
+#define gpuDeviceSynchronize cudaDeviceSynchronize
+#define gpuDeviceReset cudaDeviceReset
 
 #if defined(USE_UMPIRE)
-  static cudaError_t gpuMalloc(void** dev_ptr, size_t size) {
-      auto& rm = umpire::ResourceManager::getInstance();
-      auto allocator = rm.getAllocator("DEV_POOL");
-      void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
-      if (umpire_ptr != nullptr) {
-          *dev_ptr = umpire_ptr;
-          return cudaSuccess;
-      } else {
-          return cudaErrorMemoryAllocation;
-      }
-  }
-  static cudaError_t gpuFree(void* dev_ptr) {
-        auto& rm = umpire::ResourceManager::getInstance();
-        auto allocator = rm.getAllocator("DEV_POOL");
-        allocator.deallocate(dev_ptr);
-        return cudaSuccess;
-  }
-    static cudaError_t gpuMallocManaged(void** dev_ptr, size_t size) {
-      auto& rm = umpire::ResourceManager::getInstance();
-      auto allocator = rm.getAllocator("UM_POOL");
-      void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
-      if (umpire_ptr != nullptr) {
-          *dev_ptr = umpire_ptr;
-          return cudaSuccess;
-      } else {
-          return cudaErrorMemoryAllocation;
-      }
-  }
-  static cudaError_t gpuFreeManaged(void* dev_ptr) {
-        auto& rm = umpire::ResourceManager::getInstance();
-        auto allocator = rm.getAllocator("UM_POOL");
-        allocator.deallocate(dev_ptr);
-        return cudaSuccess;
-  }
+static cudaError_t gpuMalloc(void** dev_ptr, size_t size) {
+   auto& rm = umpire::ResourceManager::getInstance();
+   auto allocator = rm.getAllocator("DEV_POOL");
+   void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
+   if (umpire_ptr != nullptr) {
+      *dev_ptr = umpire_ptr;
+      return cudaSuccess;
+   } else {
+      return cudaErrorMemoryAllocation;
+   }
+}
+static cudaError_t gpuFree(void* dev_ptr) {
+   auto& rm = umpire::ResourceManager::getInstance();
+   auto allocator = rm.getAllocator("DEV_POOL");
+   allocator.deallocate(dev_ptr);
+   return cudaSuccess;
+}
+// static cudaError_t gpuMallocManaged(void** dev_ptr, size_t size) {
+//    auto& rm = umpire::ResourceManager::getInstance();
+//    auto allocator = rm.getAllocator("UM_POOL");
+//    void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
+//    if (umpire_ptr != nullptr) {
+//       *dev_ptr = umpire_ptr;
+//       return cudaSuccess;
+//    } else {
+//       return cudaErrorMemoryAllocation;
+//    }
+// }
+// static cudaError_t gpuFreeManaged(void* dev_ptr) {
+//    auto& rm = umpire::ResourceManager::getInstance();
+//    auto allocator = rm.getAllocator("UM_POOL");
+//    allocator.deallocate(dev_ptr);
+//    return cudaSuccess;
+// }
+#define gpuFreeManaged cudaFree
+#define gpuMallocManaged cudaMallocManaged
 #else
-  #define gpuFree                          cudaFree
-  #define gpuFreeManaged                   cudaFree
-  #define gpuMalloc                        cudaMalloc
-  #define gpuMallocManaged                 cudaMallocManaged
+#define gpuFree cudaFree
+#define gpuFreeManaged cudaFree
+#define gpuMalloc cudaMalloc
+#define gpuMallocManaged cudaMallocManaged
 #endif
-#define gpuFreeHost                      cudaFreeHost
-#define gpuFreeAsync                     cudaFreeAsync
-#define gpuMallocHost                    cudaMallocHost
-#define gpuMallocAsync                   cudaMallocAsync
+#define gpuFreeHost cudaFreeHost
+#define gpuFreeAsync cudaFreeAsync
+#define gpuMallocHost cudaMallocHost
+#define gpuMallocAsync cudaMallocAsync
 // this goes to cudaMallocHost because we don't support flags
-#define gpuHostAlloc                     cudaMallocHost
-#define gpuHostAllocPortable             cudaHostAllocPortable
-#define gpuMemcpy                        cudaMemcpy
-#define gpuMemcpyAsync                   cudaMemcpyAsync
-#define gpuMemset                        cudaMemset
-#define gpuMemsetAsync                   cudaMemsetAsync
+#define gpuHostAlloc cudaMallocHost
+#define gpuHostAllocPortable cudaHostAllocPortable
+#define gpuMemcpy cudaMemcpy
+#define gpuMemcpyAsync cudaMemcpyAsync
+#define gpuMemset cudaMemset
+#define gpuMemsetAsync cudaMemsetAsync
 
-#define gpuMemAdviseSetAccessedBy        cudaMemAdviseSetAccessedBy
+#define gpuMemAdviseSetAccessedBy cudaMemAdviseSetAccessedBy
 #define gpuMemAdviseSetPreferredLocation cudaMemAdviseSetPreferredLocation
-#define gpuMemAttachSingle               cudaMemAttachSingle
-#define gpuMemAttachGlobal               cudaMemAttachGlobal
-#define gpuMemPrefetchAsync              cudaMemPrefetchAsync
+#define gpuMemAttachSingle cudaMemAttachSingle
+#define gpuMemAttachGlobal cudaMemAttachGlobal
+#define gpuMemPrefetchAsync cudaMemPrefetchAsync
 
-#define gpuStreamCreate                  cudaStreamCreate
-#define gpuStreamDestroy                 cudaStreamDestroy
-#define gpuStreamWaitEvent               cudaStreamWaitEvent
-#define gpuStreamSynchronize             cudaStreamSynchronize
-#define gpuStreamAttachMemAsync          cudaStreamAttachMemAsync
-#define gpuDeviceGetStreamPriorityRange  cudaDeviceGetStreamPriorityRange
-#define gpuStreamCreateWithPriority      cudaStreamCreateWithPriority
-#define gpuStreamDefault                 cudaStreamDefault
+#define gpuStreamCreate cudaStreamCreate
+#define gpuStreamDestroy cudaStreamDestroy
+#define gpuStreamWaitEvent cudaStreamWaitEvent
+#define gpuStreamSynchronize cudaStreamSynchronize
+#define gpuStreamAttachMemAsync cudaStreamAttachMemAsync
+#define gpuDeviceGetStreamPriorityRange cudaDeviceGetStreamPriorityRange
+#define gpuStreamCreateWithPriority cudaStreamCreateWithPriority
+#define gpuStreamDefault cudaStreamDefault
 
-#define gpuEventCreate                   cudaEventCreate
-#define gpuEventCreateWithFlags          cudaEventCreateWithFlags
-#define gpuEventDestroy                  cudaEventDestroy
-#define gpuEventQuery                    cudaEventQuery
-#define gpuEventRecord                   cudaEventRecord
-#define gpuEventSynchronize              cudaEventSynchronize
-#define gpuEventElapsedTime              cudaEventElapsedTime
+#define gpuEventCreate cudaEventCreate
+#define gpuEventCreateWithFlags cudaEventCreateWithFlags
+#define gpuEventDestroy cudaEventDestroy
+#define gpuEventQuery cudaEventQuery
+#define gpuEventRecord cudaEventRecord
+#define gpuEventSynchronize cudaEventSynchronize
+#define gpuEventElapsedTime cudaEventElapsedTime
 
 /* driver_types */
-#define gpuError_t                       cudaError_t
-#define gpuSuccess                       cudaSuccess
+#define gpuError_t cudaError_t
+#define gpuSuccess cudaSuccess
 
-#define gpuStream_t                      cudaStream_t
-#define gpuDeviceProp                    cudaDeviceProp
+#define gpuStream_t cudaStream_t
+#define gpuDeviceProp cudaDeviceProp
 
-#define gpuEvent_t                       cudaEvent_t
-#define gpuEventDefault                  cudaEventDefault
-#define gpuEventBlockingSync             cudaEventBlockingSync
-#define gpuEventDisableTiming            cudaEventDisableTiming
+#define gpuEvent_t cudaEvent_t
+#define gpuEventDefault cudaEventDefault
+#define gpuEventBlockingSync cudaEventBlockingSync
+#define gpuEventDisableTiming cudaEventDisableTiming
 
-#define gpuMemcpyKind                    cudaMemcpyKind
-#define gpuMemcpyDeviceToHost            cudaMemcpyDeviceToHost
-#define gpuMemcpyHostToDevice            cudaMemcpyHostToDevice
-#define gpuMemcpyDeviceToDevice          cudaMemcpyDeviceToDevice
-#define gpuMemcpyToSymbol                cudaMemcpyToSymbol
+#define gpuMemcpyKind cudaMemcpyKind
+#define gpuMemcpyDeviceToHost cudaMemcpyDeviceToHost
+#define gpuMemcpyHostToDevice cudaMemcpyHostToDevice
+#define gpuMemcpyDeviceToDevice cudaMemcpyDeviceToDevice
+#define gpuMemcpyToSymbol cudaMemcpyToSymbol
 
-#define gpuKernelBallot(mask, input)     __ballot_sync(mask, input)
-#define gpuKernelAny(mask, input)        __any_sync(mask, input)
+#define gpuKernelBallot(mask, input) __ballot_sync(mask, input)
+#define gpuKernelAny(mask, input) __any_sync(mask, input)
 
 /* Define architecture-specific macros */
 #define ARCH_LOOP_LAMBDA [=] __host__ __device__
@@ -142,7 +144,7 @@
 
 /* GPU blocksize used by Vlasov solvers */
 #ifndef GPUBLOCKS
-#  define GPUBLOCKS (108)
+#define GPUBLOCKS (108)
 #endif
 
 /* values used by kernels */
@@ -155,7 +157,7 @@ extern cudaStream_t gpuStreamList[];
 
 /* Define the CUDA error checking macro */
 #define CHK_ERR(err) (cuda_error(err, __FILE__, __LINE__))
-inline static void cuda_error(cudaError_t err, const char *file, int line) {
+inline static void cuda_error(cudaError_t err, const char* file, int line) {
    if (err != cudaSuccess) {
       printf("\n\n%s in %s at line %d\n", cudaGetErrorString(err), file, line);
       exit(1);
@@ -163,378 +165,385 @@ inline static void cuda_error(cudaError_t err, const char *file, int line) {
 }
 
 /* Create auxiliary max atomic function for double types */
-__device__ __forceinline__ static void atomicMax(double *address, double val2) {
+__device__ __forceinline__ static void atomicMax(double* address, double val2) {
    unsigned long long ret = __double_as_longlong(*address);
-   while(val2 > __longlong_as_double(ret)) {
+   while (val2 > __longlong_as_double(ret)) {
       unsigned long long old = ret;
-      if((ret = atomicCAS((unsigned long long *)address, old, __double_as_longlong(val2))) == old)
+      if ((ret = atomicCAS((unsigned long long*)address, old, __double_as_longlong(val2))) == old)
          break;
    }
 }
 
 /* Create auxiliary min atomic function for double types */
-__device__ __forceinline__ static void atomicMin(double *address, double val2) {
+__device__ __forceinline__ static void atomicMin(double* address, double val2) {
    unsigned long long ret = __double_as_longlong(*address);
-   while(val2 < __longlong_as_double(ret)) {
+   while (val2 < __longlong_as_double(ret)) {
       unsigned long long old = ret;
-      if((ret = atomicCAS((unsigned long long *)address, old, __double_as_longlong(val2))) == old)
+      if ((ret = atomicCAS((unsigned long long*)address, old, __double_as_longlong(val2))) == old)
          break;
    }
 }
 
 /* Namespace for architecture-specific functions */
-namespace arch{
+namespace arch {
 
 /* Buffer class for making data available on device */
-   template <typename T>
-   class buf {
-   private:
-      T *ptr;
-      T *d_ptr;
-      uint bytes;
-      uint is_copy = 0;
-      uint thread_id = 0;
+template <typename T> class buf {
+private:
+   T* ptr;
+   T* d_ptr;
+   uint bytes;
+   uint is_copy = 0;
+   uint thread_id = 0;
 
-   public:
+public:
+   void syncDeviceData(void) {
+      CHK_ERR(cudaMemcpyAsync(d_ptr, ptr, bytes, cudaMemcpyHostToDevice, gpuStreamList[thread_id]));
+   }
 
-      void syncDeviceData(void){
-         CHK_ERR(cudaMemcpyAsync(d_ptr, ptr, bytes, cudaMemcpyHostToDevice, gpuStreamList[thread_id]));
-      }
+   void syncHostData(void) {
+      CHK_ERR(cudaMemcpyAsync(ptr, d_ptr, bytes, cudaMemcpyDeviceToHost, gpuStreamList[thread_id]));
+   }
 
-      void syncHostData(void){
-         CHK_ERR(cudaMemcpyAsync(ptr, d_ptr, bytes, cudaMemcpyDeviceToHost, gpuStreamList[thread_id]));
-      }
-
-      buf(T * const _ptr, uint _bytes) : ptr(_ptr), bytes(_bytes) {
+   buf(T* const _ptr, uint _bytes) : ptr(_ptr), bytes(_bytes) {
 #ifdef _OPENMP
-         const uint thread_id = omp_get_thread_num();
+      const uint thread_id = omp_get_thread_num();
 #else
-         const uint thread_id = 0;
+      const uint thread_id = 0;
 #endif
-         CHK_ERR(cudaMallocAsync(&d_ptr, bytes, gpuStreamList[thread_id]));
-         syncDeviceData();
-      }
+      CHK_ERR(cudaMallocAsync(&d_ptr, bytes, gpuStreamList[thread_id]));
+      syncDeviceData();
+   }
 
-      __host__ __device__ buf(const buf& u) :
-         ptr(u.ptr), d_ptr(u.d_ptr), bytes(u.bytes), is_copy(1), thread_id(u.thread_id) {}
+   __host__ __device__ buf(const buf& u)
+       : ptr(u.ptr), d_ptr(u.d_ptr), bytes(u.bytes), is_copy(1), thread_id(u.thread_id) {}
 
-      __host__ ~buf(void){
-         if(!is_copy){
-            // syncHostData();
+   __host__ ~buf(void) {
+      if (!is_copy) {
+         // syncHostData();
 #ifdef __CUDA_ARCH__
-            cudaFreeAsync(d_ptr, gpuStreamList[thread_id]);
+         cudaFreeAsync(d_ptr, gpuStreamList[thread_id]);
 #endif
-         }
       }
+   }
 
-      __host__ __device__ T &operator [] (uint i) const {
+   __host__ __device__ T& operator[](uint i) const {
 #ifdef __CUDA_ARCH__
-         return d_ptr[i];
+      return d_ptr[i];
 #else
-         return ptr[i];
+      return ptr[i];
 #endif
-      }
-   };
+   }
+};
 
 /* A function to check and set the device mempool settings */
-   __host__ __forceinline__ static void device_mempool_check(uint64_t threshold_new) {
-      int device_id;
-      CHK_ERR(cudaGetDevice(&device_id));
-      cudaMemPool_t mempool;
-      CHK_ERR(cudaDeviceGetDefaultMemPool(&mempool, device_id));
-      uint64_t threshold_old;
-      CHK_ERR(cudaMemPoolGetAttribute(mempool, cudaMemPoolAttrReleaseThreshold, &threshold_old));
-      if(threshold_new != threshold_old)
-         CHK_ERR(cudaMemPoolSetAttribute(mempool, cudaMemPoolAttrReleaseThreshold, &threshold_new));
-   }
+__host__ __forceinline__ static void device_mempool_check(uint64_t threshold_new) {
+   int device_id;
+   CHK_ERR(cudaGetDevice(&device_id));
+   cudaMemPool_t mempool;
+   CHK_ERR(cudaDeviceGetDefaultMemPool(&mempool, device_id));
+   uint64_t threshold_old;
+   CHK_ERR(cudaMemPoolGetAttribute(mempool, cudaMemPoolAttrReleaseThreshold, &threshold_old));
+   if (threshold_new != threshold_old)
+      CHK_ERR(cudaMemPoolSetAttribute(mempool, cudaMemPoolAttrReleaseThreshold, &threshold_new));
+}
 
 /* Device function for memory allocation */
-   __host__ __forceinline__ static void* allocate(size_t bytes) {
-      void* ptr;
+__host__ __forceinline__ static void* allocate(size_t bytes) {
+   void* ptr;
 #ifdef _OPENMP
-      const uint thread_id = omp_get_thread_num();
+   const uint thread_id = omp_get_thread_num();
 #else
-      const uint thread_id = 0;
+   const uint thread_id = 0;
 #endif
-      device_mempool_check(UINT64_MAX);
-      CHK_ERR(cudaMallocAsync(&ptr, bytes, gpuStreamList[thread_id]));
-      return ptr;
-   }
+   device_mempool_check(UINT64_MAX);
+   CHK_ERR(cudaMallocAsync(&ptr, bytes, gpuStreamList[thread_id]));
+   return ptr;
+}
 
-   __host__ __forceinline__ static void* allocate(size_t bytes, cudaStream_t stream) {
-      void* ptr;
-      device_mempool_check(UINT64_MAX);
-      CHK_ERR(cudaMallocAsync(&ptr, bytes, stream));
-      return ptr;
-   }
+__host__ __forceinline__ static void* allocate(size_t bytes, cudaStream_t stream) {
+   void* ptr;
+   device_mempool_check(UINT64_MAX);
+   CHK_ERR(cudaMallocAsync(&ptr, bytes, stream));
+   return ptr;
+}
 
 /* Device function for memory deallocation */
-   template <typename T>
-   __host__ __forceinline__ static void free(T* ptr) {
+template <typename T> __host__ __forceinline__ static void free(T* ptr) {
 #ifdef _OPENMP
-      const uint thread_id = omp_get_thread_num();
+   const uint thread_id = omp_get_thread_num();
 #else
-      const uint thread_id = 0;
+   const uint thread_id = 0;
 #endif
-      CHK_ERR(cudaFreeAsync(ptr, gpuStreamList[thread_id]));
-   }
+   CHK_ERR(cudaFreeAsync(ptr, gpuStreamList[thread_id]));
+}
 
-   template <typename T>
-   __host__ __forceinline__ static void free(T* ptr, cudaStream_t stream) {
-      CHK_ERR(cudaFreeAsync(ptr, stream));
-   }
+template <typename T> __host__ __forceinline__ static void free(T* ptr, cudaStream_t stream) {
+   CHK_ERR(cudaFreeAsync(ptr, stream));
+}
 /* Host-to-device memory copy */
-   template <typename T>
-   __forceinline__ static void memcpy_h2d(T* dst, T* src, size_t bytes){
+template <typename T> __forceinline__ static void memcpy_h2d(T* dst, T* src, size_t bytes) {
 #ifdef _OPENMP
-      const uint thread_id = omp_get_thread_num();
+   const uint thread_id = omp_get_thread_num();
 #else
-      const uint thread_id = 0;
+   const uint thread_id = 0;
 #endif
-      CHK_ERR(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyHostToDevice, gpuStreamList[thread_id]));
-   }
+   CHK_ERR(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyHostToDevice, gpuStreamList[thread_id]));
+}
 
-   template <typename T>
-   __forceinline__ static void memcpy_h2d(T* dst, T* src, size_t bytes, cudaStream_t stream){
-      CHK_ERR(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyHostToDevice, stream));
-   }
+template <typename T> __forceinline__ static void memcpy_h2d(T* dst, T* src, size_t bytes, cudaStream_t stream) {
+   CHK_ERR(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyHostToDevice, stream));
+}
 
 /* Device-to-host memory copy */
-   template <typename T>
-   __forceinline__ static void memcpy_d2h(T* dst, T* src, size_t bytes){
+template <typename T> __forceinline__ static void memcpy_d2h(T* dst, T* src, size_t bytes) {
 #ifdef _OPENMP
-      const uint thread_id = omp_get_thread_num();
+   const uint thread_id = omp_get_thread_num();
 #else
-      const uint thread_id = 0;
+   const uint thread_id = 0;
 #endif
-      CHK_ERR(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyDeviceToHost, gpuStreamList[thread_id]));
-   }
+   CHK_ERR(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyDeviceToHost, gpuStreamList[thread_id]));
+}
 
-   template <typename T>
-   __forceinline__ static void memcpy_d2h(T* dst, T* src, size_t bytes, cudaStream_t stream){
-      CHK_ERR(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyDeviceToHost, stream));
-   }
+template <typename T> __forceinline__ static void memcpy_d2h(T* dst, T* src, size_t bytes, cudaStream_t stream) {
+   CHK_ERR(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyDeviceToHost, stream));
+}
 
 /* Register, ie, page-lock existing host allocations */
-   template <typename T>
-   __forceinline__ static void host_register(T* ptr, size_t bytes){
-      CHK_ERR(cudaHostRegister(ptr, bytes, cudaHostRegisterDefault));
-   }
+template <typename T> __forceinline__ static void host_register(T* ptr, size_t bytes) {
+   CHK_ERR(cudaHostRegister(ptr, bytes, cudaHostRegisterDefault));
+}
 
 /* Unregister page-locked host allocations */
-   template <typename T>
-   __forceinline__ static void host_unregister(T* ptr){
-      CHK_ERR(cudaHostUnregister(ptr));
-   }
+template <typename T> __forceinline__ static void host_unregister(T* ptr) { CHK_ERR(cudaHostUnregister(ptr)); }
 
 /* Specializations for lambda calls depending on the templated dimension */
-   template <typename Lambda, typename T>
-   __device__ __forceinline__ static void lambda_eval(const uint (&idx)[1], T * __restrict__ thread_data, Lambda loop_body) { loop_body(idx[0], thread_data); }
+template <typename Lambda, typename T>
+__device__ __forceinline__ static void lambda_eval(const uint (&idx)[1], T* __restrict__ thread_data,
+                                                   Lambda loop_body) {
+   loop_body(idx[0], thread_data);
+}
 
-   template <typename Lambda, typename T>
-   __device__ __forceinline__ static void lambda_eval(const uint (&idx)[2], T * __restrict__ thread_data, Lambda loop_body) { loop_body(idx[0], idx[1], thread_data); }
+template <typename Lambda, typename T>
+__device__ __forceinline__ static void lambda_eval(const uint (&idx)[2], T* __restrict__ thread_data,
+                                                   Lambda loop_body) {
+   loop_body(idx[0], idx[1], thread_data);
+}
 
-   template <typename Lambda, typename T>
-   __device__ __forceinline__ static void lambda_eval(const uint (&idx)[3], T * __restrict__ thread_data, Lambda loop_body) { loop_body(idx[0], idx[1], idx[2], thread_data); }
+template <typename Lambda, typename T>
+__device__ __forceinline__ static void lambda_eval(const uint (&idx)[3], T* __restrict__ thread_data,
+                                                   Lambda loop_body) {
+   loop_body(idx[0], idx[1], idx[2], thread_data);
+}
 
-   template <typename Lambda, typename T>
-   __device__ __forceinline__ static void lambda_eval(const uint (&idx)[4], T * __restrict__ thread_data, Lambda loop_body) { loop_body(idx[0], idx[1], idx[2], idx[3], thread_data); }
+template <typename Lambda, typename T>
+__device__ __forceinline__ static void lambda_eval(const uint (&idx)[4], T* __restrict__ thread_data,
+                                                   Lambda loop_body) {
+   loop_body(idx[0], idx[1], idx[2], idx[3], thread_data);
+}
 
 /* Get the index for the underlying dimension, and call the respective lambda wrapper */
-   template <uint NDim, typename Lambda, typename T>
-   __device__ __forceinline__ static void loop_eval(const uint idx_glob, const uint * __restrict__ lims, T * __restrict__ thread_data, Lambda loop_body) {
-      uint idx[NDim];
-      switch (NDim)
-      {
-         case 4:
-            idx[3] = (idx_glob / (lims[0] * lims[1] * lims[2])) % lims[3];
-         case 3:
-            idx[2] = (idx_glob / (lims[0] * lims[1])) % lims[2];
-         case 2:
-            idx[1] = (idx_glob / lims[0]) % lims[1];
-         case 1:
-            idx[0] = idx_glob % lims[0];
-      }
-      lambda_eval(idx, thread_data, loop_body);
+template <uint NDim, typename Lambda, typename T>
+__device__ __forceinline__ static void loop_eval(const uint idx_glob, const uint* __restrict__ lims,
+                                                 T* __restrict__ thread_data, Lambda loop_body) {
+   uint idx[NDim];
+   switch (NDim) {
+   case 4:
+      idx[3] = (idx_glob / (lims[0] * lims[1] * lims[2])) % lims[3];
+   case 3:
+      idx[2] = (idx_glob / (lims[0] * lims[1])) % lims[2];
+   case 2:
+      idx[1] = (idx_glob / lims[0]) % lims[1];
+   case 1:
+      idx[0] = idx_glob % lims[0];
    }
+   lambda_eval(idx, thread_data, loop_body);
+}
 
 /* A general device kernel for reductions */
-   template <uint Blocksize, reduce_op Op, uint NDim, uint NReduStatic, typename Lambda, typename T>
-   __global__ static void __launch_bounds__(ARCH_BLOCKSIZE_R)
-      reduction_kernel(Lambda loop_body, const T * __restrict__ init_val, T * __restrict__ rslt, const uint * __restrict__ lims, const uint n_total, const uint n_redu_dynamic, T *thread_data_dynamic)
-   {
-      /* Specialize BlockReduce for a 1D block of Blocksize threads of type `T` */
-      typedef cub::BlockReduce<T, Blocksize, cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1> BlockReduce;
+template <uint Blocksize, reduce_op Op, uint NDim, uint NReduStatic, typename Lambda, typename T>
+__global__ static void __launch_bounds__(ARCH_BLOCKSIZE_R)
+    reduction_kernel(Lambda loop_body, const T* __restrict__ init_val, T* __restrict__ rslt,
+                     const uint* __restrict__ lims, const uint n_total, const uint n_redu_dynamic,
+                     T* thread_data_dynamic) {
+   /* Specialize BlockReduce for a 1D block of Blocksize threads of type `T` */
+   typedef cub::BlockReduce<T, Blocksize, cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1> BlockReduce;
 
-      /* Dynamic shared memory declaration */
-      extern __shared__ char temp_storage_dynamic[];
+   /* Dynamic shared memory declaration */
+   extern __shared__ char temp_storage_dynamic[];
 
-      /* Static shared memory declaration */
-      constexpr uint size = NReduStatic ? NReduStatic : 1;
-      __shared__ typename BlockReduce::TempStorage temp_storage_static[size];
+   /* Static shared memory declaration */
+   constexpr uint size = NReduStatic ? NReduStatic : 1;
+   __shared__ typename BlockReduce::TempStorage temp_storage_static[size];
 
-      /* Assign a pointer to the shared memory (dynamic or static case) */
-      typename BlockReduce::TempStorage *temp_storage = NReduStatic ? temp_storage_static : (typename BlockReduce::TempStorage*) temp_storage_dynamic;
+   /* Assign a pointer to the shared memory (dynamic or static case) */
+   typename BlockReduce::TempStorage* temp_storage =
+       NReduStatic ? temp_storage_static : (typename BlockReduce::TempStorage*)temp_storage_dynamic;
 
-      /* Get the global 1D thread index*/
-      const uint idx_glob = blockIdx.x * blockDim.x + threadIdx.x;
+   /* Get the global 1D thread index*/
+   const uint idx_glob = blockIdx.x * blockDim.x + threadIdx.x;
 
-      /* Static thread data declaration */
-      T thread_data_static[size];
+   /* Static thread data declaration */
+   T thread_data_static[size];
 
-      /* Assign a pointer to the thread data (dynamic or static case)*/
-      T *thread_data = NReduStatic ? thread_data_static : &thread_data_dynamic[n_redu_dynamic * idx_glob];
+   /* Assign a pointer to the thread data (dynamic or static case)*/
+   T* thread_data = NReduStatic ? thread_data_static : &thread_data_dynamic[n_redu_dynamic * idx_glob];
 
-      /* Get the number of reductions (may be known at compile time or not) */
-      const uint n_reductions = NReduStatic ? NReduStatic : n_redu_dynamic;
+   /* Get the number of reductions (may be known at compile time or not) */
+   const uint n_reductions = NReduStatic ? NReduStatic : n_redu_dynamic;
 
-      /* Set initial values */
-      for(uint i = 0; i < n_reductions; i++){
-         if (Op == reduce_op::sum)
-            thread_data[i] = 0;
-         else
-            thread_data[i] = init_val[i];
-      }
-
-      /* Check the loop limits and evaluate the loop body */
-      if (idx_glob < n_total)
-         loop_eval<NDim>(idx_glob, lims, thread_data, loop_body);
-
-      /* Perform reductions */
-      for(uint i = 0; i < n_reductions; i++){
-         /* Compute the block-wide sum for thread 0 which stores it */
-         if(Op == reduce_op::sum){
-            T aggregate = BlockReduce(temp_storage[i]).Sum(thread_data[i]);
-            /* The first thread of each block stores the block-wide aggregate atomically */
-            if(threadIdx.x == 0)
-               atomicAdd(&rslt[i], aggregate);
-         }
-         else if(Op == reduce_op::max){
-            T aggregate = BlockReduce(temp_storage[i]).Reduce(thread_data[i], cub::Max());
-            if(threadIdx.x == 0)
-               atomicMax(&rslt[i], aggregate);
-         }
-         else if(Op == reduce_op::min){
-            T aggregate = BlockReduce(temp_storage[i]).Reduce(thread_data[i], cub::Min());
-            if(threadIdx.x == 0)
-               atomicMin(&rslt[i], aggregate);
-         }
-         else
-            /* Other reduction operations are not supported - print an error message */
-            if(threadIdx.x == 0)
-               printf("ERROR at %s:%d: Invalid reduction identifier \"Op\".", __FILE__, __LINE__);
-      }
+   /* Set initial values */
+   for (uint i = 0; i < n_reductions; i++) {
+      if (Op == reduce_op::sum)
+         thread_data[i] = 0;
+      else
+         thread_data[i] = init_val[i];
    }
 
+   /* Check the loop limits and evaluate the loop body */
+   if (idx_glob < n_total)
+      loop_eval<NDim>(idx_glob, lims, thread_data, loop_body);
 
-
-/* Parallel reduce driver function for the CUDA reductions */
-   template <reduce_op Op, uint NReduStatic, uint NDim, typename Lambda, typename T>
-   __forceinline__ static void parallel_reduce_driver(const uint (&limits)[NDim], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
-
-      /* Get the number of reductions (may be known at compile time or not) */
-      const uint n_reductions = NReduStatic ? NReduStatic : n_redu_dynamic;
-
-      /* Calculate the required size for the 1D kernel */
-      uint n_total = 1;
-      for(uint i = 0; i < NDim; i++)
-         n_total *= limits[i];
-
-      /* Check the CUDA default mempool settings and correct if wrong */
-      device_mempool_check(UINT64_MAX);
-
-      /* Get the CPU thread id */
-#ifdef _OPENMP
-      const uint thread_id = omp_get_thread_num();
-#else
-      const uint thread_id = 0;
-#endif
-
-      /* Create a device buffer for the reduction results */
-      T* d_buf;
-      CHK_ERR(cudaMallocAsync(&d_buf, n_reductions*sizeof(T), gpuStreamList[thread_id]));
-      CHK_ERR(cudaMemcpyAsync(d_buf, sum, n_reductions*sizeof(T), cudaMemcpyHostToDevice, gpuStreamList[thread_id]));
-
-      /* Create a device buffer to transfer the initial values to device */
-      T* d_const_buf;
-      CHK_ERR(cudaMallocAsync(&d_const_buf, n_reductions*sizeof(T), gpuStreamList[thread_id]));
-      CHK_ERR(cudaMemcpyAsync(d_const_buf, d_buf, n_reductions*sizeof(T), cudaMemcpyDeviceToDevice, gpuStreamList[thread_id]));
-
-      /* Create a device buffer to transfer the loop limits of each dimension to device */
-      uint* d_limits;
-      CHK_ERR(cudaMallocAsync(&d_limits, NDim*sizeof(uint), gpuStreamList[thread_id]));
-      CHK_ERR(cudaMemcpyAsync(d_limits, limits, NDim*sizeof(uint), cudaMemcpyHostToDevice,gpuStreamList[thread_id]));
-
-      /* Call the reduction kernel with different arguments depending
-       * on if the number of reductions is known at the compile time
-       */
-      T* d_thread_data_dynamic = 0; // declared zero to suppress unitialized use warning
-      if(NReduStatic == 0) {
-         /* Get the cub temp storage sizes for the dynamic shared memory kernel argument */
-         constexpr auto cub_temp_storage_type_size = sizeof(typename cub::BlockReduce<T, ARCH_BLOCKSIZE_R, cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1>::TempStorage);
-         constexpr auto cub_temp_storage_type_size_small = sizeof(typename cub::BlockReduce<T, ARCH_BLOCKSIZE_R_SMALL, cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1>::TempStorage);
-         /* Query device properties */
-         int device_id;
-         CHK_ERR(cudaGetDevice(&device_id));
-         cudaDeviceProp deviceProp;
-         CHK_ERR(cudaGetDeviceProperties(&deviceProp, device_id));
-         /* Make sure there is enough shared memory for the used block size */
-         uint blocksize;
-         size_t shared_mem_bytes_per_block_request;
-         if(n_reductions * cub_temp_storage_type_size <= deviceProp.sharedMemPerBlock){
-           blocksize = ARCH_BLOCKSIZE_R;
-           shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size;
-         }
-         else if(n_reductions * cub_temp_storage_type_size_small <= deviceProp.sharedMemPerBlock){
-           blocksize = ARCH_BLOCKSIZE_R_SMALL;
-           shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size_small;
-         }
-         else{
-           printf("The device %d (%s) does not have enough shared memory even for the small blocksize (%d)! The error occurred in %s at line %d\n", device_id, deviceProp.name, ARCH_BLOCKSIZE_R_SMALL, __FILE__, __LINE__);
-           exit(1);
-         }
-         /* Set the kernel grid dimensions */
-         const uint gridsize = (n_total - 1 + blocksize) / blocksize;
-         /* Allocate memory for the thread data values */
-         CHK_ERR(cudaMallocAsync(&d_thread_data_dynamic, n_reductions * blocksize * gridsize * sizeof(T), gpuStreamList[thread_id]));
-         /* Call the kernel (the number of reductions not known at compile time) */
-         if(gridsize > 0){
-            if(blocksize == ARCH_BLOCKSIZE_R){
-               reduction_kernel<ARCH_BLOCKSIZE_R, Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
-            }
-            else if(blocksize == ARCH_BLOCKSIZE_R_SMALL){
-               reduction_kernel<ARCH_BLOCKSIZE_R_SMALL, Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
-            }
-            else{
-               printf("The blocksize (%u) does not match with any of the predetermined block sizes! The error occurred in %s at line %d\n", blocksize, __FILE__, __LINE__);
-               exit(1);
-            }
-         }      
-         /* Check for kernel launch errors */
-         CHK_ERR(cudaPeekAtLastError());
-         /* Synchronize and free the thread data allocation */
-         CHK_ERR(cudaStreamSynchronize(gpuStreamList[thread_id]));
-         CHK_ERR(cudaFreeAsync(d_thread_data_dynamic, gpuStreamList[thread_id]));
-      }
-      else{
-         /* Set the kernel dimensions */
-         const uint blocksize = ARCH_BLOCKSIZE_R;
-         const uint gridsize = (n_total - 1 + blocksize) / blocksize;
-         /* Call the kernel (the number of reductions known at compile time) */
-         if(gridsize > 0)
-            reduction_kernel<ARCH_BLOCKSIZE_R, Op, NDim, NReduStatic><<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
-         /* Check for kernel launch errors */
-         CHK_ERR(cudaPeekAtLastError());
-         /* Synchronize after kernel call */
-         CHK_ERR(cudaStreamSynchronize(gpuStreamList[thread_id]));
-      }
-      /* Copy the results back to host and free the allocated memory back to pool*/
-      CHK_ERR(cudaMemcpyAsync(sum, d_buf, n_reductions*sizeof(T), cudaMemcpyDeviceToHost, gpuStreamList[thread_id]));
-      CHK_ERR(cudaFreeAsync(d_buf, gpuStreamList[thread_id]));
-      CHK_ERR(cudaFreeAsync(d_const_buf, gpuStreamList[thread_id]));
-      CHK_ERR(cudaFreeAsync(d_limits, gpuStreamList[thread_id]));
+   /* Perform reductions */
+   for (uint i = 0; i < n_reductions; i++) {
+      /* Compute the block-wide sum for thread 0 which stores it */
+      if (Op == reduce_op::sum) {
+         T aggregate = BlockReduce(temp_storage[i]).Sum(thread_data[i]);
+         /* The first thread of each block stores the block-wide aggregate atomically */
+         if (threadIdx.x == 0)
+            atomicAdd(&rslt[i], aggregate);
+      } else if (Op == reduce_op::max) {
+         T aggregate = BlockReduce(temp_storage[i]).Reduce(thread_data[i], cub::Max());
+         if (threadIdx.x == 0)
+            atomicMax(&rslt[i], aggregate);
+      } else if (Op == reduce_op::min) {
+         T aggregate = BlockReduce(temp_storage[i]).Reduce(thread_data[i], cub::Min());
+         if (threadIdx.x == 0)
+            atomicMin(&rslt[i], aggregate);
+      } else
+         /* Other reduction operations are not supported - print an error message */
+         if (threadIdx.x == 0)
+            printf("ERROR at %s:%d: Invalid reduction identifier \"Op\".", __FILE__, __LINE__);
    }
 }
 
+/* Parallel reduce driver function for the CUDA reductions */
+template <reduce_op Op, uint NReduStatic, uint NDim, typename Lambda, typename T>
+__forceinline__ static void parallel_reduce_driver(const uint (&limits)[NDim], Lambda loop_body, T* sum,
+                                                   const uint n_redu_dynamic) {
+
+   /* Get the number of reductions (may be known at compile time or not) */
+   const uint n_reductions = NReduStatic ? NReduStatic : n_redu_dynamic;
+
+   /* Calculate the required size for the 1D kernel */
+   uint n_total = 1;
+   for (uint i = 0; i < NDim; i++)
+      n_total *= limits[i];
+
+   /* Check the CUDA default mempool settings and correct if wrong */
+   device_mempool_check(UINT64_MAX);
+
+   /* Get the CPU thread id */
+#ifdef _OPENMP
+   const uint thread_id = omp_get_thread_num();
+#else
+   const uint thread_id = 0;
+#endif
+
+   /* Create a device buffer for the reduction results */
+   T* d_buf;
+   CHK_ERR(cudaMallocAsync(&d_buf, n_reductions * sizeof(T), gpuStreamList[thread_id]));
+   CHK_ERR(cudaMemcpyAsync(d_buf, sum, n_reductions * sizeof(T), cudaMemcpyHostToDevice, gpuStreamList[thread_id]));
+
+   /* Create a device buffer to transfer the initial values to device */
+   T* d_const_buf;
+   CHK_ERR(cudaMallocAsync(&d_const_buf, n_reductions * sizeof(T), gpuStreamList[thread_id]));
+   CHK_ERR(cudaMemcpyAsync(d_const_buf, d_buf, n_reductions * sizeof(T), cudaMemcpyDeviceToDevice,
+                           gpuStreamList[thread_id]));
+
+   /* Create a device buffer to transfer the loop limits of each dimension to device */
+   uint* d_limits;
+   CHK_ERR(cudaMallocAsync(&d_limits, NDim * sizeof(uint), gpuStreamList[thread_id]));
+   CHK_ERR(cudaMemcpyAsync(d_limits, limits, NDim * sizeof(uint), cudaMemcpyHostToDevice, gpuStreamList[thread_id]));
+
+   /* Call the reduction kernel with different arguments depending
+    * on if the number of reductions is known at the compile time
+    */
+   T* d_thread_data_dynamic = 0; // declared zero to suppress unitialized use warning
+   if (NReduStatic == 0) {
+      /* Get the cub temp storage sizes for the dynamic shared memory kernel argument */
+      constexpr auto cub_temp_storage_type_size = sizeof(
+          typename cub::BlockReduce<T, ARCH_BLOCKSIZE_R, cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1>::TempStorage);
+      constexpr auto cub_temp_storage_type_size_small =
+          sizeof(typename cub::BlockReduce<T, ARCH_BLOCKSIZE_R_SMALL, cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1,
+                                           1>::TempStorage);
+      /* Query device properties */
+      int device_id;
+      CHK_ERR(cudaGetDevice(&device_id));
+      cudaDeviceProp deviceProp;
+      CHK_ERR(cudaGetDeviceProperties(&deviceProp, device_id));
+      /* Make sure there is enough shared memory for the used block size */
+      uint blocksize;
+      size_t shared_mem_bytes_per_block_request;
+      if (n_reductions * cub_temp_storage_type_size <= deviceProp.sharedMemPerBlock) {
+         blocksize = ARCH_BLOCKSIZE_R;
+         shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size;
+      } else if (n_reductions * cub_temp_storage_type_size_small <= deviceProp.sharedMemPerBlock) {
+         blocksize = ARCH_BLOCKSIZE_R_SMALL;
+         shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size_small;
+      } else {
+         printf("The device %d (%s) does not have enough shared memory even for the small blocksize (%d)! The error "
+                "occurred in %s at line %d\n",
+                device_id, deviceProp.name, ARCH_BLOCKSIZE_R_SMALL, __FILE__, __LINE__);
+         exit(1);
+      }
+      /* Set the kernel grid dimensions */
+      const uint gridsize = (n_total - 1 + blocksize) / blocksize;
+      /* Allocate memory for the thread data values */
+      CHK_ERR(cudaMallocAsync(&d_thread_data_dynamic, n_reductions * blocksize * gridsize * sizeof(T),
+                              gpuStreamList[thread_id]));
+      /* Call the kernel (the number of reductions not known at compile time) */
+      if (gridsize > 0) {
+         if (blocksize == ARCH_BLOCKSIZE_R) {
+            reduction_kernel<ARCH_BLOCKSIZE_R, Op, NDim, 0>
+                <<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(
+                    loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+         } else if (blocksize == ARCH_BLOCKSIZE_R_SMALL) {
+            reduction_kernel<ARCH_BLOCKSIZE_R_SMALL, Op, NDim, 0>
+                <<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(
+                    loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+         } else {
+            printf("The blocksize (%u) does not match with any of the predetermined block sizes! The error occurred in "
+                   "%s at line %d\n",
+                   blocksize, __FILE__, __LINE__);
+            exit(1);
+         }
+      }
+      /* Check for kernel launch errors */
+      CHK_ERR(cudaPeekAtLastError());
+      /* Synchronize and free the thread data allocation */
+      CHK_ERR(cudaStreamSynchronize(gpuStreamList[thread_id]));
+      CHK_ERR(cudaFreeAsync(d_thread_data_dynamic, gpuStreamList[thread_id]));
+   } else {
+      /* Set the kernel dimensions */
+      const uint blocksize = ARCH_BLOCKSIZE_R;
+      const uint gridsize = (n_total - 1 + blocksize) / blocksize;
+      /* Call the kernel (the number of reductions known at compile time) */
+      if (gridsize > 0)
+         reduction_kernel<ARCH_BLOCKSIZE_R, Op, NDim, NReduStatic>
+             <<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total,
+                                                                    n_reductions, d_thread_data_dynamic);
+      /* Check for kernel launch errors */
+      CHK_ERR(cudaPeekAtLastError());
+      /* Synchronize after kernel call */
+      CHK_ERR(cudaStreamSynchronize(gpuStreamList[thread_id]));
+   }
+   /* Copy the results back to host and free the allocated memory back to pool*/
+   CHK_ERR(cudaMemcpyAsync(sum, d_buf, n_reductions * sizeof(T), cudaMemcpyDeviceToHost, gpuStreamList[thread_id]));
+   CHK_ERR(cudaFreeAsync(d_buf, gpuStreamList[thread_id]));
+   CHK_ERR(cudaFreeAsync(d_const_buf, gpuStreamList[thread_id]));
+   CHK_ERR(cudaFreeAsync(d_limits, gpuStreamList[thread_id]));
+}
+} // namespace arch
 
 #endif // !ARCH_DEVICE_CUDA_H

--- a/arch/arch_device_cuda.h
+++ b/arch/arch_device_cuda.h
@@ -67,27 +67,23 @@ static cudaError_t gpuFreeHost(void* pinned_ptr) {
    allocator.deallocate(pinned_ptr);
    return cudaSuccess;
 }
-//  static cudaError_t gpuMallocManaged(void** dev_ptr, size_t size) {
-//     auto& rm = umpire::ResourceManager::getInstance();
-//     auto allocator = rm.getAllocator("UM_POOL");
-//     void* umpire_ptr = static_cast<void*>(allocator.allocate(size));
-//     if (umpire_ptr != nullptr) {
-//        *dev_ptr = umpire_ptr;
-//        printf("ManagedAlloc: %p\n", umpire_ptr);
-//        return cudaSuccess;
-//     } else {
-//        return cudaErrorMemoryAllocation;
-//     }
-//  }
-//  static cudaError_t gpuFreeManaged(void* dev_ptr) {
-//       printf("ManagedFree: %p\n", dev_ptr);
-//     auto& rm = umpire::ResourceManager::getInstance();
-//     auto allocator = rm.getAllocator("UM_POOL");
-//     allocator.deallocate(dev_ptr);
-//     return cudaSuccess;
-//  }
-#define gpuMallocManaged cudaMallocManaged
-#define gpuFreeManaged cudaFree
+static cudaError_t gpuMallocManaged(void** dev_ptr, size_t size) {
+   auto& rm = umpire::ResourceManager::getInstance();
+   auto allocator = rm.getAllocator("UM_POOL");
+   void* umpire_ptr = static_cast<void*>(allocator.allocate(size));
+   if (umpire_ptr != nullptr) {
+      *dev_ptr = umpire_ptr;
+      return cudaSuccess;
+   } else {
+      return cudaErrorMemoryAllocation;
+   }
+}
+static cudaError_t gpuFreeManaged(void* dev_ptr) {
+   auto& rm = umpire::ResourceManager::getInstance();
+   auto allocator = rm.getAllocator("UM_POOL");
+   allocator.deallocate(dev_ptr);
+   return cudaSuccess;
+}
 #else
 #define gpuMalloc cudaMalloc
 #define gpuFree cudaFree

--- a/arch/arch_device_cuda.h
+++ b/arch/arch_device_cuda.h
@@ -34,7 +34,7 @@
 static cudaError_t gpuMalloc(void** dev_ptr, size_t size, cudaStream_t stream = 0) {
    auto& rm = umpire::ResourceManager::getInstance();
    auto allocator = rm.getAllocator("DEV_POOL");
-   void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
+   void* umpire_ptr = static_cast<void*>(allocator.allocate(size));
    if (umpire_ptr != nullptr) {
       *dev_ptr = umpire_ptr;
       return cudaSuccess;
@@ -53,7 +53,7 @@ static cudaError_t gpuFree(void* dev_ptr, cudaStream_t stream = 0) {
 static cudaError_t gpuMallocHost(void** pinned_ptr, size_t size) {
    auto& rm = umpire::ResourceManager::getInstance();
    auto allocator = rm.getAllocator("PINNED_POOL");
-   void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
+   void* umpire_ptr = static_cast<void*>(allocator.allocate(size));
    if (umpire_ptr != nullptr) {
       *pinned_ptr = umpire_ptr;
       return cudaSuccess;
@@ -70,7 +70,7 @@ static cudaError_t gpuFreeHost(void* pinned_ptr) {
 //  static cudaError_t gpuMallocManaged(void** dev_ptr, size_t size) {
 //     auto& rm = umpire::ResourceManager::getInstance();
 //     auto allocator = rm.getAllocator("UM_POOL");
-//     void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
+//     void* umpire_ptr = static_cast<void*>(allocator.allocate(size));
 //     if (umpire_ptr != nullptr) {
 //        *dev_ptr = umpire_ptr;
 //        printf("ManagedAlloc: %p\n", umpire_ptr);

--- a/arch/arch_device_hip.h
+++ b/arch/arch_device_hip.h
@@ -32,7 +32,7 @@
 static hipError_t gpuMalloc(void** dev_ptr, size_t size, hipStream_t stream = 0) {
    auto& rm = umpire::ResourceManager::getInstance();
    auto allocator = rm.getAllocator("DEV_POOL");
-   void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
+   void* umpire_ptr = static_cast<void*>(allocator.allocate(size));
    if (umpire_ptr != nullptr) {
       *dev_ptr = umpire_ptr;
       return hipSuccess;
@@ -51,7 +51,7 @@ static hipError_t gpuFree(void* dev_ptr, hipStream_t stream = 0) {
 static hipError_t gpuMallocHost(void** pinned_ptr, size_t size) {
    auto& rm = umpire::ResourceManager::getInstance();
    auto allocator = rm.getAllocator("PINNED_POOL");
-   void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
+   void* umpire_ptr = static_cast<void*>(allocator.allocate(size));
    if (umpire_ptr != nullptr) {
       *pinned_ptr = umpire_ptr;
       return hipSuccess;
@@ -68,7 +68,7 @@ static hipError_t gpuFreeHost(void* pinned_ptr) {
 //  static hipError_t gpuMallocManaged(void** dev_ptr, size_t size) {
 //     auto& rm = umpire::ResourceManager::getInstance();
 //     auto allocator = rm.getAllocator("UM_POOL");
-//     void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
+//     void* umpire_ptr = static_cast<void*>(allocator.allocate(size));
 //     if (umpire_ptr != nullptr) {
 //        *dev_ptr = umpire_ptr;
 //        printf("ManagedAlloc: %p\n", umpire_ptr);

--- a/arch/arch_device_hip.h
+++ b/arch/arch_device_hip.h
@@ -65,27 +65,23 @@ static hipError_t gpuFreeHost(void* pinned_ptr) {
    allocator.deallocate(pinned_ptr);
    return hipSuccess;
 }
-//  static hipError_t gpuMallocManaged(void** dev_ptr, size_t size) {
-//     auto& rm = umpire::ResourceManager::getInstance();
-//     auto allocator = rm.getAllocator("UM_POOL");
-//     void* umpire_ptr = static_cast<void*>(allocator.allocate(size));
-//     if (umpire_ptr != nullptr) {
-//        *dev_ptr = umpire_ptr;
-//        printf("ManagedAlloc: %p\n", umpire_ptr);
-//        return hipSuccess;
-//     } else {
-//        return hipErrorMemoryAllocation;
-//     }
-//  }
-//  static hipError_t gpuFreeManaged(void* dev_ptr) {
-//       printf("ManagedFree: %p\n", dev_ptr);
-//     auto& rm = umpire::ResourceManager::getInstance();
-//     auto allocator = rm.getAllocator("UM_POOL");
-//     allocator.deallocate(dev_ptr);
-//     return hipSuccess;
-//  }
-#define gpuMallocManaged hipMallocManaged
-#define gpuFreeManaged hipFree
+static hipError_t gpuMallocManaged(void** dev_ptr, size_t size) {
+   auto& rm = umpire::ResourceManager::getInstance();
+   auto allocator = rm.getAllocator("UM_POOL");
+   void* umpire_ptr = static_cast<void*>(allocator.allocate(size));
+   if (umpire_ptr != nullptr) {
+      *dev_ptr = umpire_ptr;
+      return hipSuccess;
+   } else {
+      return hipErrorMemoryAllocation;
+   }
+}
+static hipError_t gpuFreeManaged(void* dev_ptr) {
+   auto& rm = umpire::ResourceManager::getInstance();
+   auto allocator = rm.getAllocator("UM_POOL");
+   allocator.deallocate(dev_ptr);
+   return hipSuccess;
+}
 #else
 #define gpuMalloc hipMalloc
 #define gpuFree hipFree

--- a/arch/arch_device_hip.h
+++ b/arch/arch_device_hip.h
@@ -96,11 +96,7 @@ static hipError_t gpuFreeHost(void* pinned_ptr) {
 #define gpuMallocManaged hipMallocManaged
 #define gpuFreeManaged hipFree
 #endif
-#define gpuFreeHost hipHostFree
-#define gpuFreeAsync hipFreeAsync
-#define gpuMallocHost hipHostMalloc
-#define gpuMallocAsync hipMallocAsync
-#define gpuMallocManaged hipMallocManaged
+// empty comment //
 #define gpuHostAlloc hipHostMalloc
 #define gpuHostAllocPortable hipHostAllocPortable
 #define gpuMemcpy hipMemcpy

--- a/arch/arch_device_hip.h
+++ b/arch/arch_device_hip.h
@@ -13,6 +13,7 @@
 #include "umpire/Allocator.hpp"
 #include "umpire/ResourceManager.hpp"
 #include "umpire/strategy/QuickPool.hpp"
+#include "umpire/strategy/ThreadSafeAllocator.hpp"
 #endif
 
 /* architecture-agnostic definitions for HIP */
@@ -42,7 +43,7 @@ static hipError_t gpuMalloc(void** dev_ptr, size_t size, hipStream_t stream = 0)
 }
 static hipError_t gpuFree(void* dev_ptr, hipStream_t stream = 0) {
    auto& rm = umpire::ResourceManager::getInstance();
-   auto allocator = rm.getAllocator("DEV_POOL");
+   auto allocator = rm.getAllocator(dev_ptr);
    allocator.deallocate(dev_ptr);
    return hipSuccess;
 }
@@ -59,31 +60,21 @@ static hipError_t gpuMallocHost(void** pinned_ptr, size_t size) {
       return hipErrorMemoryAllocation;
    }
 }
-static hipError_t gpuFreeHost(void* pinned_ptr) {
-   auto& rm = umpire::ResourceManager::getInstance();
-   auto allocator = rm.getAllocator("PINNED_POOL");
-   allocator.deallocate(pinned_ptr);
-   return hipSuccess;
-}
-//  static hipError_t gpuMallocManaged(void** dev_ptr, size_t size) {
-//     auto& rm = umpire::ResourceManager::getInstance();
-//     auto allocator = rm.getAllocator("UM_POOL");
-//     void* umpire_ptr = static_cast<void*>(allocator.allocate(size));
-//     if (umpire_ptr != nullptr) {
-//        *dev_ptr = umpire_ptr;
-//        printf("ManagedAlloc: %p\n", umpire_ptr);
-//        return hipSuccess;
-//     } else {
-//        return hipErrorMemoryAllocation;
-//     }
-//  }
-//  static hipError_t gpuFreeManaged(void* dev_ptr) {
-//       printf("ManagedFree: %p\n", dev_ptr);
-//     auto& rm = umpire::ResourceManager::getInstance();
-//     auto allocator = rm.getAllocator("UM_POOL");
-//     allocator.deallocate(dev_ptr);
-//     return hipSuccess;
-//  }
+#define gpuFreeHost gpuFree
+//static hipError_t gpuMallocManaged(void** dev_ptr, size_t size) {
+//   auto& rm = umpire::ResourceManager::getInstance();
+//   auto allocator = rm.getAllocator("UM_POOL");
+//   void* umpire_ptr = static_cast<void*>(allocator.allocate(size));
+//   if (umpire_ptr != nullptr) {
+//      *dev_ptr = umpire_ptr;
+//      printf("ManagedAlloc: %p\n", umpire_ptr);
+//      return hipSuccess;
+//   } else {
+//      return hipErrorMemoryAllocation;
+//   }
+//}
+//#define gpuFreeManaged gpuFree
+
 #define gpuMallocManaged hipMallocManaged
 #define gpuFreeManaged hipFree
 #else

--- a/arch/arch_device_hip.h
+++ b/arch/arch_device_hip.h
@@ -4,106 +4,128 @@
 
 /* Include required headers */
 #include <hip/hip_runtime.h>
-#include <hipcub/hipcub.hpp>
 #include <hipcub/device/device_radix_sort.hpp>
+#include <hipcub/hipcub.hpp>
 
 #include <omp.h>
 
 #if defined(USE_UMPIRE)
-  #include "umpire/Allocator.hpp"
-  #include "umpire/ResourceManager.hpp"
-  #include "umpire/strategy/QuickPool.hpp"
+#include "umpire/Allocator.hpp"
+#include "umpire/ResourceManager.hpp"
+#include "umpire/strategy/QuickPool.hpp"
 #endif
 
 /* architecture-agnostic definitions for HIP */
 
-#define gpuGetLastError                  hipGetLastError
-#define gpuGetErrorString                hipGetErrorString
-#define gpuPeekAtLastError               hipPeekAtLastError
+#define gpuGetLastError hipGetLastError
+#define gpuGetErrorString hipGetErrorString
+#define gpuPeekAtLastError hipPeekAtLastError
 
-#define gpuSetDevice                     hipSetDevice
-#define gpuGetDevice                     hipGetDevice
-#define gpuGetDeviceCount                hipGetDeviceCount
-#define gpuGetDeviceProperties           hipGetDeviceProperties
-#define gpuDeviceSynchronize             hipDeviceSynchronize
-#define gpuDeviceReset                   hipDeviceReset
+#define gpuSetDevice hipSetDevice
+#define gpuGetDevice hipGetDevice
+#define gpuGetDeviceCount hipGetDeviceCount
+#define gpuGetDeviceProperties hipGetDeviceProperties
+#define gpuDeviceSynchronize hipDeviceSynchronize
+#define gpuDeviceReset hipDeviceReset
+
 #if defined(USE_UMPIRE)
-  static hipError_t gpuMalloc(void** dev_ptr, size_t size) {
-      auto& rm = umpire::ResourceManager::getInstance();
-      auto allocator = rm.getAllocator("DEV_POOL");
-      void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
-      if (umpire_ptr != nullptr) {
-          *dev_ptr = umpire_ptr;
-          return hipSuccess;
-      } else {
-          return hipErrorMemoryAllocation;
-      }
-  }
-  static hipError_t gpuFree(void* dev_ptr) {
-        auto& rm = umpire::ResourceManager::getInstance();
-        auto allocator = rm.getAllocator("DEV_POOL");
-        allocator.deallocate(dev_ptr);
-        return hipSuccess;
-  }
+static hipError_t gpuMalloc(void** dev_ptr, size_t size) {
+   auto& rm = umpire::ResourceManager::getInstance();
+   auto allocator = rm.getAllocator("DEV_POOL");
+   void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
+   if (umpire_ptr != nullptr) {
+      *dev_ptr = umpire_ptr;
+      return hipSuccess;
+   } else {
+      return hipErrorMemoryAllocation;
+   }
+}
+static hipError_t gpuFree(void* dev_ptr) {
+   auto& rm = umpire::ResourceManager::getInstance();
+   auto allocator = rm.getAllocator("DEV_POOL");
+   allocator.deallocate(dev_ptr);
+   return hipSuccess;
+}
+// static hipError_t gpuMallocManaged(void** dev_ptr, size_t size) {
+//    auto& rm = umpire::ResourceManager::getInstance();
+//    auto allocator = rm.getAllocator("UM_POOL");
+//    void* umpire_ptr = static_cast<int*>(allocator.allocate(size * sizeof(int)));
+//    if (umpire_ptr != nullptr) {
+//       *dev_ptr = umpire_ptr;
+//       return hipSuccess;
+//    } else {
+//       return hipErrorMemoryAllocation;
+//    }
+// }
+// static hipError_t gpuFreeManaged(void* dev_ptr) {
+//    auto& rm = umpire::ResourceManager::getInstance();
+//    auto allocator = rm.getAllocator("UM_POOL");
+//    allocator.deallocate(dev_ptr);
+//    return hipSuccess;
+// }
+#define gpuFreeManaged hipFree
+#define gpuMallocManaged hipMallocManaged
 #else
-  #define gpuFree                          hipFree
-  #define gpuMalloc                        hipMalloc
+#define gpuFree hipFree
+#define gpuFreeManaged hipFree
+#define gpuMalloc hipMalloc
+#define gpuMallocManaged hipMallocManaged
 #endif
-#define gpuFreeHost                      hipHostFree
-#define gpuFreeAsync                     hipFreeAsync
-#define gpuMallocHost                    hipHostMalloc
-#define gpuMallocAsync                   hipMallocAsync
-#define gpuMallocManaged                 hipMallocManaged
-#define gpuHostAlloc                     hipHostMalloc
-#define gpuHostAllocPortable             hipHostAllocPortable
-#define gpuMemcpy                        hipMemcpy
-#define gpuMemcpyAsync                   hipMemcpyAsync
-#define gpuMemset                        hipMemset
-#define gpuMemsetAsync                   hipMemsetAsync
+#define gpuFreeHost hipHostFree
+#define gpuFreeAsync hipFreeAsync
+#define gpuMallocHost hipHostMalloc
+#define gpuMallocAsync hipMallocAsync
+#define gpuMallocManaged hipMallocManaged
+#define gpuHostAlloc hipHostMalloc
+#define gpuHostAllocPortable hipHostAllocPortable
+#define gpuMemcpy hipMemcpy
+#define gpuMemcpyAsync hipMemcpyAsync
+#define gpuMemset hipMemset
+#define gpuMemsetAsync hipMemsetAsync
 
-#define gpuMemAdviseSetAccessedBy        hipMemAdviseSetAccessedBy
+#define gpuMemAdviseSetAccessedBy hipMemAdviseSetAccessedBy
 #define gpuMemAdviseSetPreferredLocation hipMemAdviseSetPreferredLocation
-#define gpuMemAttachSingle               hipMemAttachSingle
-#define gpuMemAttachGlobal               hipMemAttachGlobal
-#define gpuMemPrefetchAsync              hipMemPrefetchAsync
+#define gpuMemAttachSingle hipMemAttachSingle
+#define gpuMemAttachGlobal hipMemAttachGlobal
+#define gpuMemPrefetchAsync hipMemPrefetchAsync
 
-#define gpuStreamCreate                  hipStreamCreate
-#define gpuStreamDestroy                 hipStreamDestroy
-#define gpuStreamWaitEvent               hipStreamWaitEvent
-#define gpuStreamSynchronize             hipStreamSynchronize
-#define gpuStreamAttachMemAsync          hipStreamAttachMemAsync
-#define gpuDeviceGetStreamPriorityRange  hipDeviceGetStreamPriorityRange
-#define gpuStreamCreateWithPriority      hipStreamCreateWithPriority
-#define gpuStreamDefault                 hipStreamDefault
+#define gpuStreamCreate hipStreamCreate
+#define gpuStreamDestroy hipStreamDestroy
+#define gpuStreamWaitEvent hipStreamWaitEvent
+#define gpuStreamSynchronize hipStreamSynchronize
+#define gpuStreamAttachMemAsync hipStreamAttachMemAsync
+#define gpuDeviceGetStreamPriorityRange hipDeviceGetStreamPriorityRange
+#define gpuStreamCreateWithPriority hipStreamCreateWithPriority
+#define gpuStreamDefault hipStreamDefault
 
-#define gpuEventCreate                   hipEventCreate
-#define gpuEventCreateWithFlags          hipEventCreateWithFlags
-#define gpuEventDestroy                  hipEventDestroy
-#define gpuEventQuery                    hipEventQuery
-#define gpuEventRecord                   hipEventRecord
-#define gpuEventSynchronize              hipEventSynchronize
-#define gpuEventElapsedTime              hipEventElapsedTime
+#define gpuEventCreate hipEventCreate
+#define gpuEventCreateWithFlags hipEventCreateWithFlags
+#define gpuEventDestroy hipEventDestroy
+#define gpuEventQuery hipEventQuery
+#define gpuEventRecord hipEventRecord
+#define gpuEventSynchronize hipEventSynchronize
+#define gpuEventElapsedTime hipEventElapsedTime
 
 /* driver_types */
-#define gpuError_t                       hipError_t
-#define gpuSuccess                       hipSuccess
+#define gpuError_t hipError_t
+#define gpuSuccess hipSuccess
 
-#define gpuStream_t                      hipStream_t
-#define gpuDeviceProp                    hipDeviceProp_t
+#define gpuStream_t hipStream_t
+#define gpuDeviceProp hipDeviceProp_t
 
-#define gpuEvent_t                       hipEvent_t
-#define gpuEventDefault                  hipEventDefault
-#define gpuEventBlockingSync             hipEventBlockingSync
-#define gpuEventDisableTiming            hipEventDisableTiming
+#define gpuEvent_t hipEvent_t
+#define gpuEventDefault hipEventDefault
+#define gpuEventBlockingSync hipEventBlockingSync
+#define gpuEventDisableTiming hipEventDisableTiming
 
-#define gpuMemcpyKind                    hipMemcpyKind
-#define gpuMemcpyDeviceToHost            hipMemcpyDeviceToHost
-#define gpuMemcpyHostToDevice            hipMemcpyHostToDevice
-#define gpuMemcpyDeviceToDevice          hipMemcpyDeviceToDevice
-#define gpuMemcpyToSymbol                hipMemcpyToSymbol
+#define gpuMemcpyKind hipMemcpyKind
+#define gpuMemcpyDeviceToHost hipMemcpyDeviceToHost
+#define gpuMemcpyHostToDevice hipMemcpyHostToDevice
+#define gpuMemcpyDeviceToDevice hipMemcpyDeviceToDevice
+#define gpuMemcpyToSymbol hipMemcpyToSymbol
 
-#define gpuKernelBallot(mask, input)     __ballot(input)
-#define gpuKernelAny(mask, input)        __any(input)
+#define gpuKernelBallot(mask, input) __ballot(input)
+#define gpuKernelAny(mask, input) __any(input)
 
 /* Define architecture-specific macros */
 #define ARCH_LOOP_LAMBDA [=] __host__ __device__
@@ -120,7 +142,7 @@
 
 /* GPU blocksize used by Vlasov solvers */
 #ifndef GPUBLOCKS
-#  define GPUBLOCKS (108)
+#define GPUBLOCKS (108)
 #endif
 
 /* values used by kernels */
@@ -133,362 +155,370 @@ extern hipStream_t gpuStreamList[];
 
 /* Define the HIP error checking macro */
 #define CHK_ERR(err) (hip_error(err, __FILE__, __LINE__))
-  inline static void hip_error(hipError_t err, const char *file, int line) {
-  	if (err != hipSuccess) {
-  		printf("\n\n%s in %s at line %d\n", hipGetErrorString(err), file, line);
-  		exit(1);
-  	}
+inline static void hip_error(hipError_t err, const char* file, int line) {
+   if (err != hipSuccess) {
+      printf("\n\n%s in %s at line %d\n", hipGetErrorString(err), file, line);
+      exit(1);
+   }
 }
 
 /* Namespace for architecture-specific functions */
-namespace arch{
+namespace arch {
 
 /* Create auxiliary max atomic function for double types */
-__device__ __forceinline__ static void atomicMax(double *address, double val2) {
-  unsigned long long ret = __double_as_longlong(*address);
-  while(val2 > __longlong_as_double(ret)) {
-    unsigned long long old = ret;
-    if((ret = atomicCAS((unsigned long long *)address, old, __double_as_longlong(val2))) == old)
-    break;
-  }
+__device__ __forceinline__ static void atomicMax(double* address, double val2) {
+   unsigned long long ret = __double_as_longlong(*address);
+   while (val2 > __longlong_as_double(ret)) {
+      unsigned long long old = ret;
+      if ((ret = atomicCAS((unsigned long long*)address, old, __double_as_longlong(val2))) == old)
+         break;
+   }
 }
 
 /* Create auxiliary min atomic function for double types */
-__device__ __forceinline__ static void atomicMin(double *address, double val2) {
-  unsigned long long ret = __double_as_longlong(*address);
-  while(val2 < __longlong_as_double(ret)) {
-    unsigned long long old = ret;
-    if((ret = atomicCAS((unsigned long long *)address, old, __double_as_longlong(val2))) == old)
-    break;
-  }
+__device__ __forceinline__ static void atomicMin(double* address, double val2) {
+   unsigned long long ret = __double_as_longlong(*address);
+   while (val2 < __longlong_as_double(ret)) {
+      unsigned long long old = ret;
+      if ((ret = atomicCAS((unsigned long long*)address, old, __double_as_longlong(val2))) == old)
+         break;
+   }
 }
 
 /* Buffer class for making data available on device */
-template <typename T>
-class buf {
-  private:
-  T *ptr;
-  T *d_ptr;
-  uint bytes;
-  uint is_copy = 0;
-  uint thread_id = 0;
+template <typename T> class buf {
+private:
+   T* ptr;
+   T* d_ptr;
+   uint bytes;
+   uint is_copy = 0;
+   uint thread_id = 0;
 
-  public:
+public:
+   void syncDeviceData(void) {
+      CHK_ERR(hipMemcpyAsync(d_ptr, ptr, bytes, hipMemcpyHostToDevice, gpuStreamList[thread_id]));
+   }
 
-  void syncDeviceData(void){
-    CHK_ERR(hipMemcpyAsync(d_ptr, ptr, bytes, hipMemcpyHostToDevice, gpuStreamList[thread_id]));
-  }
+   void syncHostData(void) {
+      CHK_ERR(hipMemcpyAsync(ptr, d_ptr, bytes, hipMemcpyDeviceToHost, gpuStreamList[thread_id]));
+   }
 
-  void syncHostData(void){
-    CHK_ERR(hipMemcpyAsync(ptr, d_ptr, bytes, hipMemcpyDeviceToHost, gpuStreamList[thread_id]));
-  }
+   buf(T* const _ptr, uint _bytes) : ptr(_ptr), bytes(_bytes) {
+      thread_id = omp_get_thread_num();
+      CHK_ERR(hipMallocAsync(&d_ptr, bytes, gpuStreamList[thread_id]));
+      syncDeviceData();
+   }
 
-  buf(T * const _ptr, uint _bytes) : ptr(_ptr), bytes(_bytes) {
-    thread_id = omp_get_thread_num();
-    CHK_ERR(hipMallocAsync(&d_ptr, bytes, gpuStreamList[thread_id]));
-    syncDeviceData();
-  }
+   __host__ __device__ buf(const buf& u)
+       : ptr(u.ptr), d_ptr(u.d_ptr), bytes(u.bytes), is_copy(1), thread_id(u.thread_id) {}
 
-  __host__ __device__ buf(const buf& u) :
-    ptr(u.ptr), d_ptr(u.d_ptr), bytes(u.bytes), is_copy(1), thread_id(u.thread_id) {}
+   __host__ ~buf(void) {
+      if (!is_copy) {
+// syncHostData();
+#ifdef __HIP_DEVICE_COMPILE__
+         hipFreeAsync(d_ptr, gpuStreamList[thread_id]);
+#endif
+      }
+   }
 
-  __host__ ~buf(void){
-    if(!is_copy){
-      // syncHostData();
-      #ifdef __HIP_DEVICE_COMPILE__
-        hipFreeAsync(d_ptr, gpuStreamList[thread_id]);
-      #endif
-    }
-  }
-
-  __host__ __device__ T &operator [] (uint i) const {
-   #ifdef __HIP_DEVICE_COMPILE__
+   __host__ __device__ T& operator[](uint i) const {
+#ifdef __HIP_DEVICE_COMPILE__
       return d_ptr[i];
-   #else
+#else
       return ptr[i];
-   #endif
-  }
+#endif
+   }
 };
 
 /* A function to check and set the device mempool settings */
 __host__ __forceinline__ static void device_mempool_check(uint64_t threshold_new) {
-  int device_id;
-  CHK_ERR(hipGetDevice(&device_id));
-  hipMemPool_t mempool;
-  CHK_ERR(hipDeviceGetDefaultMemPool(&mempool, device_id));
-  uint64_t threshold_old;
-  CHK_ERR(hipMemPoolGetAttribute(mempool, hipMemPoolAttrReleaseThreshold, &threshold_old));
-  if(threshold_new != threshold_old)
-    CHK_ERR(hipMemPoolSetAttribute(mempool, hipMemPoolAttrReleaseThreshold, &threshold_new));
+   int device_id;
+   CHK_ERR(hipGetDevice(&device_id));
+   hipMemPool_t mempool;
+   CHK_ERR(hipDeviceGetDefaultMemPool(&mempool, device_id));
+   uint64_t threshold_old;
+   CHK_ERR(hipMemPoolGetAttribute(mempool, hipMemPoolAttrReleaseThreshold, &threshold_old));
+   if (threshold_new != threshold_old)
+      CHK_ERR(hipMemPoolSetAttribute(mempool, hipMemPoolAttrReleaseThreshold, &threshold_new));
 }
 
 /* Device function for memory allocation */
 __host__ __forceinline__ static void* allocate(size_t bytes) {
-  void* ptr;
-  const uint thread_id = omp_get_thread_num();
-  device_mempool_check(UINT64_MAX);
-  CHK_ERR(hipMallocAsync(&ptr, bytes, gpuStreamList[thread_id]));
-  return ptr;
+   void* ptr;
+   const uint thread_id = omp_get_thread_num();
+   device_mempool_check(UINT64_MAX);
+   CHK_ERR(hipMallocAsync(&ptr, bytes, gpuStreamList[thread_id]));
+   return ptr;
 }
 
 __host__ __forceinline__ static void* allocate(size_t bytes, hipStream_t stream) {
-  void* ptr;
-  device_mempool_check(UINT64_MAX);
-  CHK_ERR(hipMallocAsync(&ptr, bytes, stream));
-  return ptr;
+   void* ptr;
+   device_mempool_check(UINT64_MAX);
+   CHK_ERR(hipMallocAsync(&ptr, bytes, stream));
+   return ptr;
 }
 
 /* Device function for memory deallocation */
-template <typename T>
-__host__ __forceinline__ static void free(T* ptr) {
-  const uint thread_id = omp_get_thread_num();
-  CHK_ERR(hipFreeAsync(ptr, gpuStreamList[thread_id]));
+template <typename T> __host__ __forceinline__ static void free(T* ptr) {
+   const uint thread_id = omp_get_thread_num();
+   CHK_ERR(hipFreeAsync(ptr, gpuStreamList[thread_id]));
 }
 
-template <typename T>
-__host__ __forceinline__ static void free(T* ptr, hipStream_t stream) {
-  CHK_ERR(hipFreeAsync(ptr, stream));
+template <typename T> __host__ __forceinline__ static void free(T* ptr, hipStream_t stream) {
+   CHK_ERR(hipFreeAsync(ptr, stream));
 }
 /* Host-to-device memory copy */
-template <typename T>
-__forceinline__ static void memcpy_h2d(T* dst, T* src, size_t bytes){
-  const uint thread_id = omp_get_thread_num();
-  CHK_ERR(hipMemcpyAsync(dst, src, bytes, hipMemcpyHostToDevice, gpuStreamList[thread_id]));
+template <typename T> __forceinline__ static void memcpy_h2d(T* dst, T* src, size_t bytes) {
+   const uint thread_id = omp_get_thread_num();
+   CHK_ERR(hipMemcpyAsync(dst, src, bytes, hipMemcpyHostToDevice, gpuStreamList[thread_id]));
 }
 
-template <typename T>
-__forceinline__ static void memcpy_h2d(T* dst, T* src, size_t bytes, hipStream_t stream){
-  CHK_ERR(hipMemcpyAsync(dst, src, bytes, hipMemcpyHostToDevice, stream));
+template <typename T> __forceinline__ static void memcpy_h2d(T* dst, T* src, size_t bytes, hipStream_t stream) {
+   CHK_ERR(hipMemcpyAsync(dst, src, bytes, hipMemcpyHostToDevice, stream));
 }
 
 /* Device-to-host memory copy */
-template <typename T>
-__forceinline__ static void memcpy_d2h(T* dst, T* src, size_t bytes){
-  const uint thread_id = omp_get_thread_num();
-  CHK_ERR(hipMemcpyAsync(dst, src, bytes, hipMemcpyDeviceToHost, gpuStreamList[thread_id]));
+template <typename T> __forceinline__ static void memcpy_d2h(T* dst, T* src, size_t bytes) {
+   const uint thread_id = omp_get_thread_num();
+   CHK_ERR(hipMemcpyAsync(dst, src, bytes, hipMemcpyDeviceToHost, gpuStreamList[thread_id]));
 }
 
-template <typename T>
-__forceinline__ static void memcpy_d2h(T* dst, T* src, size_t bytes, hipStream_t stream){
-  CHK_ERR(hipMemcpyAsync(dst, src, bytes, hipMemcpyDeviceToHost, stream));
+template <typename T> __forceinline__ static void memcpy_d2h(T* dst, T* src, size_t bytes, hipStream_t stream) {
+   CHK_ERR(hipMemcpyAsync(dst, src, bytes, hipMemcpyDeviceToHost, stream));
 }
 
 /* Register, ie, page-lock existing host allocations */
-template <typename T>
-__forceinline__ static void host_register(T* ptr, size_t bytes){
-  CHK_ERR(hipHostRegister(ptr, bytes, hipHostRegisterDefault));
+template <typename T> __forceinline__ static void host_register(T* ptr, size_t bytes) {
+   CHK_ERR(hipHostRegister(ptr, bytes, hipHostRegisterDefault));
 }
 
 /* Unregister page-locked host allocations */
-template <typename T>
-__forceinline__ static void host_unregister(T* ptr){
-  CHK_ERR(hipHostUnregister(ptr));
-}
+template <typename T> __forceinline__ static void host_unregister(T* ptr) { CHK_ERR(hipHostUnregister(ptr)); }
 
 /* Specializations for lambda calls depending on the templated dimension */
 template <typename Lambda, typename T>
-__device__ __forceinline__ static void lambda_eval(const uint (&idx)[1], T * __restrict__ thread_data, Lambda loop_body) { loop_body(idx[0], thread_data); }
+__device__ __forceinline__ static void lambda_eval(const uint (&idx)[1], T* __restrict__ thread_data,
+                                                   Lambda loop_body) {
+   loop_body(idx[0], thread_data);
+}
 
 template <typename Lambda, typename T>
-__device__ __forceinline__ static void lambda_eval(const uint (&idx)[2], T * __restrict__ thread_data, Lambda loop_body) { loop_body(idx[0], idx[1], thread_data); }
+__device__ __forceinline__ static void lambda_eval(const uint (&idx)[2], T* __restrict__ thread_data,
+                                                   Lambda loop_body) {
+   loop_body(idx[0], idx[1], thread_data);
+}
 
 template <typename Lambda, typename T>
-__device__ __forceinline__ static void lambda_eval(const uint (&idx)[3], T * __restrict__ thread_data, Lambda loop_body) { loop_body(idx[0], idx[1], idx[2], thread_data); }
+__device__ __forceinline__ static void lambda_eval(const uint (&idx)[3], T* __restrict__ thread_data,
+                                                   Lambda loop_body) {
+   loop_body(idx[0], idx[1], idx[2], thread_data);
+}
 
 template <typename Lambda, typename T>
-__device__ __forceinline__ static void lambda_eval(const uint (&idx)[4], T * __restrict__ thread_data, Lambda loop_body) { loop_body(idx[0], idx[1], idx[2], idx[3], thread_data); }
+__device__ __forceinline__ static void lambda_eval(const uint (&idx)[4], T* __restrict__ thread_data,
+                                                   Lambda loop_body) {
+   loop_body(idx[0], idx[1], idx[2], idx[3], thread_data);
+}
 
 /* Get the index for the underlying dimension, and call the respective lambda wrapper */
 template <uint NDim, typename Lambda, typename T>
-__device__ __forceinline__ static void loop_eval(const uint idx_glob, const uint * __restrict__ lims, T * __restrict__ thread_data, Lambda loop_body) {
-  uint idx[NDim];
-  switch (NDim)
-  {
-    case 4:
+__device__ __forceinline__ static void loop_eval(const uint idx_glob, const uint* __restrict__ lims,
+                                                 T* __restrict__ thread_data, Lambda loop_body) {
+   uint idx[NDim];
+   switch (NDim) {
+   case 4:
       idx[3] = (idx_glob / (lims[0] * lims[1] * lims[2])) % lims[3];
-    case 3:
+   case 3:
       idx[2] = (idx_glob / (lims[0] * lims[1])) % lims[2];
-    case 2:
+   case 2:
       idx[1] = (idx_glob / lims[0]) % lims[1];
-    case 1:
+   case 1:
       idx[0] = idx_glob % lims[0];
-  }
-  lambda_eval(idx, thread_data, loop_body);
+   }
+   lambda_eval(idx, thread_data, loop_body);
 }
 
 /* A general device kernel for reductions */
-   template <uint Blocksize, reduce_op Op, uint NDim, uint NReduStatic, typename Lambda, typename T>
+template <uint Blocksize, reduce_op Op, uint NDim, uint NReduStatic, typename Lambda, typename T>
 __global__ static void __launch_bounds__(ARCH_BLOCKSIZE_R)
-reduction_kernel(Lambda loop_body, const T * __restrict__ init_val, T * __restrict__ rslt, const uint * __restrict__ lims, const uint n_total, const uint n_redu_dynamic, T *thread_data_dynamic)
-{
-  /* Specialize BlockReduce for a 1D block of Blocksize threads of type `T` */
-  typedef hipcub::BlockReduce<T, Blocksize, hipcub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1> BlockReduce;
+    reduction_kernel(Lambda loop_body, const T* __restrict__ init_val, T* __restrict__ rslt,
+                     const uint* __restrict__ lims, const uint n_total, const uint n_redu_dynamic,
+                     T* thread_data_dynamic) {
+   /* Specialize BlockReduce for a 1D block of Blocksize threads of type `T` */
+   typedef hipcub::BlockReduce<T, Blocksize, hipcub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1> BlockReduce;
 
-  /* Dynamic shared memory declaration */
-  extern __shared__ char temp_storage_dynamic[];
+   /* Dynamic shared memory declaration */
+   extern __shared__ char temp_storage_dynamic[];
 
-  /* Static shared memory declaration */
-  constexpr uint size = NReduStatic ? NReduStatic : 1;
-  __shared__ typename BlockReduce::TempStorage temp_storage_static[size];
+   /* Static shared memory declaration */
+   constexpr uint size = NReduStatic ? NReduStatic : 1;
+   __shared__ typename BlockReduce::TempStorage temp_storage_static[size];
 
-  /* Assign a pointer to the shared memory (dynamic or static case) */
-  typename BlockReduce::TempStorage *temp_storage = NReduStatic ? temp_storage_static : (typename BlockReduce::TempStorage*) temp_storage_dynamic;
+   /* Assign a pointer to the shared memory (dynamic or static case) */
+   typename BlockReduce::TempStorage* temp_storage =
+       NReduStatic ? temp_storage_static : (typename BlockReduce::TempStorage*)temp_storage_dynamic;
 
-  /* Get the global 1D thread index*/
-  const uint idx_glob = blockIdx.x * blockDim.x + threadIdx.x;
+   /* Get the global 1D thread index*/
+   const uint idx_glob = blockIdx.x * blockDim.x + threadIdx.x;
 
-  /* Static thread data declaration */
-  T thread_data_static[size];
+   /* Static thread data declaration */
+   T thread_data_static[size];
 
-  /* Assign a pointer to the thread data (dynamic or static case)*/
-  T *thread_data = NReduStatic ? thread_data_static : &thread_data_dynamic[n_redu_dynamic * idx_glob];
+   /* Assign a pointer to the thread data (dynamic or static case)*/
+   T* thread_data = NReduStatic ? thread_data_static : &thread_data_dynamic[n_redu_dynamic * idx_glob];
 
-  /* Get the number of reductions (may be known at compile time or not) */
-  const uint n_reductions = NReduStatic ? NReduStatic : n_redu_dynamic;
+   /* Get the number of reductions (may be known at compile time or not) */
+   const uint n_reductions = NReduStatic ? NReduStatic : n_redu_dynamic;
 
-  /* Set initial values */
-  for(uint i = 0; i < n_reductions; i++){
-    if (Op == reduce_op::sum)
-      thread_data[i] = 0;
-    else
-      thread_data[i] = init_val[i];
-  }
+   /* Set initial values */
+   for (uint i = 0; i < n_reductions; i++) {
+      if (Op == reduce_op::sum)
+         thread_data[i] = 0;
+      else
+         thread_data[i] = init_val[i];
+   }
 
-  /* Check the loop limits and evaluate the loop body */
-  if (idx_glob < n_total)
-    loop_eval<NDim>(idx_glob, lims, thread_data, loop_body);
+   /* Check the loop limits and evaluate the loop body */
+   if (idx_glob < n_total)
+      loop_eval<NDim>(idx_glob, lims, thread_data, loop_body);
 
-  /* Perform reductions */
-  for(uint i = 0; i < n_reductions; i++){
-    /* Compute the block-wide sum for thread 0 which stores it */
-    if(Op == reduce_op::sum){
-      T aggregate = BlockReduce(temp_storage[i]).Sum(thread_data[i]);
-      /* The first thread of each block stores the block-wide aggregate atomically */
-      if(threadIdx.x == 0)
-        atomicAdd(&rslt[i], aggregate);
-    }
-    else if(Op == reduce_op::max){
-      T aggregate = BlockReduce(temp_storage[i]).Reduce(thread_data[i], hipcub::Max());
-      if(threadIdx.x == 0)
-        atomicMax(&rslt[i], aggregate);
-    }
-    else if(Op == reduce_op::min){
-      T aggregate = BlockReduce(temp_storage[i]).Reduce(thread_data[i], hipcub::Min());
-      if(threadIdx.x == 0)
-        atomicMin(&rslt[i], aggregate);
-    }
-    else
-      /* Other reduction operations are not supported - print an error message */
-      if(threadIdx.x == 0)
-        printf("ERROR at %s:%d: Invalid reduction identifier \"Op\".", __FILE__, __LINE__);
-  }
+   /* Perform reductions */
+   for (uint i = 0; i < n_reductions; i++) {
+      /* Compute the block-wide sum for thread 0 which stores it */
+      if (Op == reduce_op::sum) {
+         T aggregate = BlockReduce(temp_storage[i]).Sum(thread_data[i]);
+         /* The first thread of each block stores the block-wide aggregate atomically */
+         if (threadIdx.x == 0)
+            atomicAdd(&rslt[i], aggregate);
+      } else if (Op == reduce_op::max) {
+         T aggregate = BlockReduce(temp_storage[i]).Reduce(thread_data[i], hipcub::Max());
+         if (threadIdx.x == 0)
+            atomicMax(&rslt[i], aggregate);
+      } else if (Op == reduce_op::min) {
+         T aggregate = BlockReduce(temp_storage[i]).Reduce(thread_data[i], hipcub::Min());
+         if (threadIdx.x == 0)
+            atomicMin(&rslt[i], aggregate);
+      } else
+         /* Other reduction operations are not supported - print an error message */
+         if (threadIdx.x == 0)
+            printf("ERROR at %s:%d: Invalid reduction identifier \"Op\".", __FILE__, __LINE__);
+   }
 }
-
-
 
 /* Parallel reduce driver function for the HIP reductions */
 template <reduce_op Op, uint NReduStatic, uint NDim, typename Lambda, typename T>
-__forceinline__ static void parallel_reduce_driver(const uint (&limits)[NDim], Lambda loop_body, T *sum, const uint n_redu_dynamic) {
+__forceinline__ static void parallel_reduce_driver(const uint (&limits)[NDim], Lambda loop_body, T* sum,
+                                                   const uint n_redu_dynamic) {
 
-  /* Get the number of reductions (may be known at compile time or not) */
-  const uint n_reductions = NReduStatic ? NReduStatic : n_redu_dynamic;
+   /* Get the number of reductions (may be known at compile time or not) */
+   const uint n_reductions = NReduStatic ? NReduStatic : n_redu_dynamic;
 
-  /* Calculate the required size for the 1D kernel */
-  uint n_total = 1;
-  for(uint i = 0; i < NDim; i++)
-    n_total *= limits[i];
+   /* Calculate the required size for the 1D kernel */
+   uint n_total = 1;
+   for (uint i = 0; i < NDim; i++)
+      n_total *= limits[i];
 
-  /* Check the HIP default mempool settings and correct if wrong */
-  device_mempool_check(UINT64_MAX);
+   /* Check the HIP default mempool settings and correct if wrong */
+   device_mempool_check(UINT64_MAX);
 
-  /* Get the CPU thread id */
-  const uint thread_id = omp_get_thread_num();
+   /* Get the CPU thread id */
+   const uint thread_id = omp_get_thread_num();
 
-  /* Create a device buffer for the reduction results */
-  T* d_buf;
-  CHK_ERR(hipMallocAsync(&d_buf, n_reductions*sizeof(T), gpuStreamList[thread_id]));
-  CHK_ERR(hipMemcpyAsync(d_buf, sum, n_reductions*sizeof(T), hipMemcpyHostToDevice, gpuStreamList[thread_id]));
+   /* Create a device buffer for the reduction results */
+   T* d_buf;
+   CHK_ERR(hipMallocAsync(&d_buf, n_reductions * sizeof(T), gpuStreamList[thread_id]));
+   CHK_ERR(hipMemcpyAsync(d_buf, sum, n_reductions * sizeof(T), hipMemcpyHostToDevice, gpuStreamList[thread_id]));
 
-  /* Create a device buffer to transfer the initial values to device */
-  T* d_const_buf;
-  CHK_ERR(hipMallocAsync(&d_const_buf, n_reductions*sizeof(T), gpuStreamList[thread_id]));
-  CHK_ERR(hipMemcpyAsync(d_const_buf, d_buf, n_reductions*sizeof(T), hipMemcpyDeviceToDevice, gpuStreamList[thread_id]));
+   /* Create a device buffer to transfer the initial values to device */
+   T* d_const_buf;
+   CHK_ERR(hipMallocAsync(&d_const_buf, n_reductions * sizeof(T), gpuStreamList[thread_id]));
+   CHK_ERR(
+       hipMemcpyAsync(d_const_buf, d_buf, n_reductions * sizeof(T), hipMemcpyDeviceToDevice, gpuStreamList[thread_id]));
 
-  /* Create a device buffer to transfer the loop limits of each dimension to device */
-  uint* d_limits;
-  CHK_ERR(hipMallocAsync(&d_limits, NDim*sizeof(uint), gpuStreamList[thread_id]));
-  CHK_ERR(hipMemcpyAsync(d_limits, limits, NDim*sizeof(uint), hipMemcpyHostToDevice,gpuStreamList[thread_id]));
+   /* Create a device buffer to transfer the loop limits of each dimension to device */
+   uint* d_limits;
+   CHK_ERR(hipMallocAsync(&d_limits, NDim * sizeof(uint), gpuStreamList[thread_id]));
+   CHK_ERR(hipMemcpyAsync(d_limits, limits, NDim * sizeof(uint), hipMemcpyHostToDevice, gpuStreamList[thread_id]));
 
-  /* Call the reduction kernel with different arguments depending
-   * on if the number of reductions is known at the compile time
-   */
-  T* d_thread_data_dynamic = 0; // declared zero to suppress unitialized use warning
-  if(NReduStatic == 0) {
-    /* Get the cub temp storage sizes for the dynamic shared memory kernel argument */
-    constexpr auto cub_temp_storage_type_size = sizeof(typename hipcub::BlockReduce<T, ARCH_BLOCKSIZE_R, hipcub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1>::TempStorage);
-    constexpr auto cub_temp_storage_type_size_small = sizeof(typename hipcub::BlockReduce<T, ARCH_BLOCKSIZE_R_SMALL, hipcub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1, 1>::TempStorage);
-    /* Query device properties */
-    int device_id;
-    CHK_ERR(hipGetDevice(&device_id));
-    hipDeviceProp_t deviceProp;
-    CHK_ERR(hipGetDeviceProperties(&deviceProp, device_id));
-    /* Make sure there is enough shared memory for the used block size */
-    uint blocksize;
-    size_t shared_mem_bytes_per_block_request;
-    if(n_reductions * cub_temp_storage_type_size <= deviceProp.sharedMemPerBlock){
-      blocksize = ARCH_BLOCKSIZE_R;
-      shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size;
-    }
-    else if(n_reductions * cub_temp_storage_type_size_small <= deviceProp.sharedMemPerBlock){
-      blocksize = ARCH_BLOCKSIZE_R_SMALL;
-      shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size_small;
-    }
-    else{
-      printf("The device %d (%s) does not have enough shared memory even for the small blocksize (%d)! The error occurred in %s at line %d\n", device_id, deviceProp.gcnArchName, ARCH_BLOCKSIZE_R_SMALL, __FILE__, __LINE__);
-      exit(1);
-    }
-    /* Set the kernel grid dimensions */
-    const uint gridsize = (n_total - 1 + blocksize) / blocksize;
-    /* Allocate memory for the thread data values */
-    CHK_ERR(hipMallocAsync(&d_thread_data_dynamic, n_reductions * blocksize * gridsize * sizeof(T), gpuStreamList[thread_id]));
-    /* Call the kernel (the number of reductions not known at compile time) */
-    if(gridsize > 0){
-       if(blocksize == ARCH_BLOCKSIZE_R){
-          reduction_kernel<ARCH_BLOCKSIZE_R, Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
-       }
-       else if(blocksize == ARCH_BLOCKSIZE_R_SMALL){
-          reduction_kernel<ARCH_BLOCKSIZE_R_SMALL, Op, NDim, 0><<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
-       }
-       else{
-          printf("The blocksize (%u) does not match with any of the predetermined block sizes! The error occurred in %s at line %d\n", blocksize, __FILE__, __LINE__);
-          exit(1);
-       }
-    }   
-    /* Check for kernel launch errors */
-    CHK_ERR(hipPeekAtLastError());
-    /* Synchronize and free the thread data allocation */
-    CHK_ERR(hipStreamSynchronize(gpuStreamList[thread_id]));
-    CHK_ERR(hipFreeAsync(d_thread_data_dynamic, gpuStreamList[thread_id]));
-  }
-  else{
-    /* Set the kernel dimensions */
-    const uint blocksize = ARCH_BLOCKSIZE_R;
-    const uint gridsize = (n_total - 1 + blocksize) / blocksize;
-    /* Call the kernel (the number of reductions known at compile time) */
-    if(gridsize > 0)
-      reduction_kernel<ARCH_BLOCKSIZE_R, Op, NDim, NReduStatic><<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
-    /* Check for kernel launch errors */
-    CHK_ERR(hipPeekAtLastError());
-    /* Synchronize after kernel call */
-    CHK_ERR(hipStreamSynchronize(gpuStreamList[thread_id]));
-  }
-  /* Copy the results back to host and free the allocated memory back to pool*/
-  CHK_ERR(hipMemcpyAsync(sum, d_buf, n_reductions*sizeof(T), hipMemcpyDeviceToHost, gpuStreamList[thread_id]));
-  CHK_ERR(hipFreeAsync(d_buf, gpuStreamList[thread_id]));
-  CHK_ERR(hipFreeAsync(d_const_buf, gpuStreamList[thread_id]));
-  CHK_ERR(hipFreeAsync(d_limits, gpuStreamList[thread_id]));
+   /* Call the reduction kernel with different arguments depending
+    * on if the number of reductions is known at the compile time
+    */
+   T* d_thread_data_dynamic = 0; // declared zero to suppress unitialized use warning
+   if (NReduStatic == 0) {
+      /* Get the cub temp storage sizes for the dynamic shared memory kernel argument */
+      constexpr auto cub_temp_storage_type_size =
+          sizeof(typename hipcub::BlockReduce<T, ARCH_BLOCKSIZE_R, hipcub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, 1,
+                                              1>::TempStorage);
+      constexpr auto cub_temp_storage_type_size_small =
+          sizeof(typename hipcub::BlockReduce<T, ARCH_BLOCKSIZE_R_SMALL, hipcub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY,
+                                              1, 1>::TempStorage);
+      /* Query device properties */
+      int device_id;
+      CHK_ERR(hipGetDevice(&device_id));
+      hipDeviceProp_t deviceProp;
+      CHK_ERR(hipGetDeviceProperties(&deviceProp, device_id));
+      /* Make sure there is enough shared memory for the used block size */
+      uint blocksize;
+      size_t shared_mem_bytes_per_block_request;
+      if (n_reductions * cub_temp_storage_type_size <= deviceProp.sharedMemPerBlock) {
+         blocksize = ARCH_BLOCKSIZE_R;
+         shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size;
+      } else if (n_reductions * cub_temp_storage_type_size_small <= deviceProp.sharedMemPerBlock) {
+         blocksize = ARCH_BLOCKSIZE_R_SMALL;
+         shared_mem_bytes_per_block_request = n_reductions * cub_temp_storage_type_size_small;
+      } else {
+         printf("The device %d (%s) does not have enough shared memory even for the small blocksize (%d)! The error "
+                "occurred in %s at line %d\n",
+                device_id, deviceProp.gcnArchName, ARCH_BLOCKSIZE_R_SMALL, __FILE__, __LINE__);
+         exit(1);
+      }
+      /* Set the kernel grid dimensions */
+      const uint gridsize = (n_total - 1 + blocksize) / blocksize;
+      /* Allocate memory for the thread data values */
+      CHK_ERR(hipMallocAsync(&d_thread_data_dynamic, n_reductions * blocksize * gridsize * sizeof(T),
+                             gpuStreamList[thread_id]));
+      /* Call the kernel (the number of reductions not known at compile time) */
+      if (gridsize > 0) {
+         if (blocksize == ARCH_BLOCKSIZE_R) {
+            reduction_kernel<ARCH_BLOCKSIZE_R, Op, NDim, 0>
+                <<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(
+                    loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+         } else if (blocksize == ARCH_BLOCKSIZE_R_SMALL) {
+            reduction_kernel<ARCH_BLOCKSIZE_R_SMALL, Op, NDim, 0>
+                <<<gridsize, blocksize, shared_mem_bytes_per_block_request, gpuStreamList[thread_id]>>>(
+                    loop_body, d_const_buf, d_buf, d_limits, n_total, n_reductions, d_thread_data_dynamic);
+         } else {
+            printf("The blocksize (%u) does not match with any of the predetermined block sizes! The error occurred in "
+                   "%s at line %d\n",
+                   blocksize, __FILE__, __LINE__);
+            exit(1);
+         }
+      }
+      /* Check for kernel launch errors */
+      CHK_ERR(hipPeekAtLastError());
+      /* Synchronize and free the thread data allocation */
+      CHK_ERR(hipStreamSynchronize(gpuStreamList[thread_id]));
+      CHK_ERR(hipFreeAsync(d_thread_data_dynamic, gpuStreamList[thread_id]));
+   } else {
+      /* Set the kernel dimensions */
+      const uint blocksize = ARCH_BLOCKSIZE_R;
+      const uint gridsize = (n_total - 1 + blocksize) / blocksize;
+      /* Call the kernel (the number of reductions known at compile time) */
+      if (gridsize > 0)
+         reduction_kernel<ARCH_BLOCKSIZE_R, Op, NDim, NReduStatic>
+             <<<gridsize, blocksize, 0, gpuStreamList[thread_id]>>>(loop_body, d_const_buf, d_buf, d_limits, n_total,
+                                                                    n_reductions, d_thread_data_dynamic);
+      /* Check for kernel launch errors */
+      CHK_ERR(hipPeekAtLastError());
+      /* Synchronize after kernel call */
+      CHK_ERR(hipStreamSynchronize(gpuStreamList[thread_id]));
+   }
+   /* Copy the results back to host and free the allocated memory back to pool*/
+   CHK_ERR(hipMemcpyAsync(sum, d_buf, n_reductions * sizeof(T), hipMemcpyDeviceToHost, gpuStreamList[thread_id]));
+   CHK_ERR(hipFreeAsync(d_buf, gpuStreamList[thread_id]));
+   CHK_ERR(hipFreeAsync(d_const_buf, gpuStreamList[thread_id]));
+   CHK_ERR(hipFreeAsync(d_limits, gpuStreamList[thread_id]));
 }
-}
-
+} // namespace arch
 
 #endif // !ARCH_DEVICE_HIP_H

--- a/arch/gpu_base.cpp
+++ b/arch/gpu_base.cpp
@@ -163,6 +163,13 @@ __host__ void gpu_init_device() {
    }
    #endif
 
+   // Init Umpire memory manager
+   #if defined(USE_UMPIRE)
+     auto& rm = umpire::ResourceManager::getInstance();
+     umpire::Allocator allocator = rm.getAllocator("DEVICE");
+     auto pooled_allocator = rm.makeAllocator<umpire::strategy::QuickPool>("DEV_POOL", allocator, 1024, 1024);
+   #endif
+
    // Pre-generate streams, allocate return pointers
    int *leastPriority = new int; // likely 0
    int *greatestPriority = new int; // likely -1

--- a/arch/gpu_base.cpp
+++ b/arch/gpu_base.cpp
@@ -168,6 +168,10 @@ __host__ void gpu_init_device() {
      auto& rm = umpire::ResourceManager::getInstance();
      umpire::Allocator allocator_dev = rm.getAllocator("DEVICE");
      rm.makeAllocator<umpire::strategy::QuickPool>("DEV_POOL", allocator_dev, 1024, 1024);
+
+     umpire::Allocator allocator_pinned = rm.getAllocator("PINNED");
+     rm.makeAllocator<umpire::strategy::QuickPool>("PINNED_POOL", allocator_pinned, 1024, 1024);
+
      umpire::Allocator allocator_um = rm.getAllocator("UM");
      rm.makeAllocator<umpire::strategy::QuickPool>("UM_POOL", allocator_um, 1024, 1024);
    #endif

--- a/arch/gpu_base.cpp
+++ b/arch/gpu_base.cpp
@@ -166,14 +166,15 @@ __host__ void gpu_init_device() {
    // Init Umpire memory manager
    #if defined(USE_UMPIRE)
      auto& rm = umpire::ResourceManager::getInstance();
-     umpire::Allocator allocator_dev = rm.getAllocator("DEVICE");
-     rm.makeAllocator<umpire::strategy::QuickPool>("DEV_POOL", allocator_dev, 1024, 1024);
 
-     umpire::Allocator allocator_pinned = rm.getAllocator("PINNED");
-     rm.makeAllocator<umpire::strategy::QuickPool>("PINNED_POOL", allocator_pinned, 1024, 1024);
+     auto non_thread_safe_dev_allocator = rm.makeAllocator<umpire::strategy::QuickPool>("NON_THREADSAFE_DEV_POOL", rm.getAllocator("DEVICE"));
+     rm.makeAllocator<umpire::strategy::ThreadSafeAllocator>("DEV_POOL", non_thread_safe_dev_allocator);
 
-     umpire::Allocator allocator_um = rm.getAllocator("UM");
-     rm.makeAllocator<umpire::strategy::QuickPool>("UM_POOL", allocator_um, 1024, 1024);
+     auto non_thread_safe_pinned_allocator = rm.makeAllocator<umpire::strategy::QuickPool>("NON_THREADSAFE_PINNED_POOL", rm.getAllocator("PINNED"));
+     rm.makeAllocator<umpire::strategy::ThreadSafeAllocator>("PINNED_POOL", non_thread_safe_pinned_allocator);
+
+     auto non_thread_safe_um_allocator = rm.makeAllocator<umpire::strategy::QuickPool>("NON_THREADSAFE_UM_POOL", rm.getAllocator("UM"));
+     rm.makeAllocator<umpire::strategy::ThreadSafeAllocator>("UM_POOL", non_thread_safe_um_allocator);
    #endif
 
    // Pre-generate streams, allocate return pointers

--- a/arch/gpu_base.cpp
+++ b/arch/gpu_base.cpp
@@ -166,8 +166,10 @@ __host__ void gpu_init_device() {
    // Init Umpire memory manager
    #if defined(USE_UMPIRE)
      auto& rm = umpire::ResourceManager::getInstance();
-     umpire::Allocator allocator = rm.getAllocator("DEVICE");
-     auto pooled_allocator = rm.makeAllocator<umpire::strategy::QuickPool>("DEV_POOL", allocator, 1024, 1024);
+     umpire::Allocator allocator_dev = rm.getAllocator("DEVICE");
+     rm.makeAllocator<umpire::strategy::QuickPool>("DEV_POOL", allocator_dev, 1024, 1024);
+     umpire::Allocator allocator_um = rm.getAllocator("UM");
+     rm.makeAllocator<umpire::strategy::QuickPool>("UM_POOL", allocator_um, 1024, 1024);
    #endif
 
    // Pre-generate streams, allocate return pointers

--- a/arch/gpu_base.cpp
+++ b/arch/gpu_base.cpp
@@ -166,15 +166,14 @@ __host__ void gpu_init_device() {
    // Init Umpire memory manager
    #if defined(USE_UMPIRE)
      auto& rm = umpire::ResourceManager::getInstance();
+     umpire::Allocator allocator_dev = rm.getAllocator("DEVICE");
+     rm.makeAllocator<umpire::strategy::QuickPool>("DEV_POOL", allocator_dev, 1024, 1024);
 
-     auto non_thread_safe_dev_allocator = rm.makeAllocator<umpire::strategy::QuickPool>("NON_THREADSAFE_DEV_POOL", rm.getAllocator("DEVICE"));
-     rm.makeAllocator<umpire::strategy::ThreadSafeAllocator>("DEV_POOL", non_thread_safe_dev_allocator);
+     umpire::Allocator allocator_pinned = rm.getAllocator("PINNED");
+     rm.makeAllocator<umpire::strategy::QuickPool>("PINNED_POOL", allocator_pinned, 1024, 1024);
 
-     auto non_thread_safe_pinned_allocator = rm.makeAllocator<umpire::strategy::QuickPool>("NON_THREADSAFE_PINNED_POOL", rm.getAllocator("PINNED"));
-     rm.makeAllocator<umpire::strategy::ThreadSafeAllocator>("PINNED_POOL", non_thread_safe_pinned_allocator);
-
-     auto non_thread_safe_um_allocator = rm.makeAllocator<umpire::strategy::QuickPool>("NON_THREADSAFE_UM_POOL", rm.getAllocator("UM"));
-     rm.makeAllocator<umpire::strategy::ThreadSafeAllocator>("UM_POOL", non_thread_safe_um_allocator);
+     umpire::Allocator allocator_um = rm.getAllocator("UM");
+     rm.makeAllocator<umpire::strategy::QuickPool>("UM_POOL", allocator_um, 1024, 1024);
    #endif
 
    // Pre-generate streams, allocate return pointers

--- a/arch/gpu_base.hpp
+++ b/arch/gpu_base.hpp
@@ -33,6 +33,12 @@
 #define SSYNC CHK_ERR( gpuStreamSynchronize(stream) )
 //#define SSYNC
 
+#if defined(USE_UMPIRE)
+  #include "umpire/Allocator.hpp"
+  #include "umpire/ResourceManager.hpp"
+  #include "umpire/strategy/QuickPool.hpp"
+#endif
+
 #include <stdio.h>
 #include "include/splitvector/splitvec.h"
 #include "include/hashinator/hashinator.h"

--- a/arch/gpu_base.hpp
+++ b/arch/gpu_base.hpp
@@ -81,26 +81,26 @@ class Managed {
 public:
    void *operator new(size_t len) {
       void *ptr;
-      gpuMallocManaged(&ptr, len);
-      gpuDeviceSynchronize();
+      CHK_ERR(gpuMallocManaged(&ptr, len));
+      CHK_ERR(gpuDeviceSynchronize());
       return ptr;
    }
 
    void operator delete(void *ptr) {
-      gpuDeviceSynchronize();
-      gpuFreeManaged(ptr);
+      CHK_ERR(gpuDeviceSynchronize());
+      CHK_ERR(gpuFreeManaged(ptr));
    }
 
    void* operator new[] (size_t len) {
       void *ptr;
-      gpuMallocManaged(&ptr, len);
-      gpuDeviceSynchronize();
+      CHK_ERR(gpuMallocManaged(&ptr, len));
+      CHK_ERR(gpuDeviceSynchronize());
       return ptr;
    }
 
    void operator delete[] (void* ptr) {
-      gpuDeviceSynchronize();
-      gpuFreeManaged(ptr);
+      CHK_ERR(gpuDeviceSynchronize());
+      CHK_ERR(gpuFreeManaged(ptr));
    }
 
 };

--- a/arch/gpu_base.hpp
+++ b/arch/gpu_base.hpp
@@ -33,12 +33,6 @@
 #define SSYNC CHK_ERR( gpuStreamSynchronize(stream) )
 //#define SSYNC
 
-#if defined(USE_UMPIRE)
-  #include "umpire/Allocator.hpp"
-  #include "umpire/ResourceManager.hpp"
-  #include "umpire/strategy/QuickPool.hpp"
-#endif
-
 #include <stdio.h>
 #include "include/splitvector/splitvec.h"
 #include "include/hashinator/hashinator.h"
@@ -94,7 +88,7 @@ public:
 
    void operator delete(void *ptr) {
       gpuDeviceSynchronize();
-      gpuFree(ptr);
+      gpuFreeManaged(ptr);
    }
 
    void* operator new[] (size_t len) {
@@ -106,7 +100,7 @@ public:
 
    void operator delete[] (void* ptr) {
       gpuDeviceSynchronize();
-      gpuFree(ptr);
+      gpuFreeManaged(ptr);
    }
 
 };


### PR DESCRIPTION
This PR adds Umpire memory manager for GPU pool memory allocation. However, the implementation crashes due to a silent error in the base version, see the below attached Zulip discussion. I mark this as draft, as it probably makes sense to fix the base version error first.

Zulip:

"Ok, I tried to figure out what is wrong, and it looks like the problem is not the Umpire implementation, but an already existing issue in the vlasiator_gpu branch, at least since 

```

commit f3bc0e44fcb0e763716784d3dcdfdc92f2ec20c7 (HEAD)

Author: Markus Battarbee <markus.battarbee@gmail.com>

Date:   Thu Mar 7 08:46:25 2024 +0200

    Comment out old prefetch

```

The reason the bug only shows up with the Umpire implementation is that the `Managed` class in `gpu_base.hpp` does not have error handling (ie, the gpuFree() just errors silently and execution continues):
```

// Unified memory class for inheritance

class Managed {

public:

   void *operator new(size_t len) {

      void *ptr;

      gpuMallocManaged(&ptr, len);

      gpuDeviceSynchronize();

      return ptr;

   }

   void operator delete(void *ptr) {

      gpuDeviceSynchronize();

      gpuFree(ptr);

   }

   void* operator new[] (size_t len) {

      void *ptr;

      gpuMallocManaged(&ptr, len);

      gpuDeviceSynchronize();

      return ptr;

   }

   void operator delete[] (void* ptr) {

      gpuDeviceSynchronize();

      gpuFree(ptr);

   }

};
```
If I add error handling, then the program fails exactly at the same location where Umpire implementation fails:
```

class Managed {

public:

   void *operator new(size_t len) {

      void *ptr;

      CHK_ERR(gpuMallocManaged(&ptr, len));

      CHK_ERR(gpuDeviceSynchronize());

      return ptr;

   }

   void operator delete(void *ptr) {

      CHK_ERR(gpuDeviceSynchronize());

      CHK_ERR(gpuFree(ptr));

   }

   void* operator new[] (size_t len) {

      void *ptr;

      CHK_ERR(gpuMallocManaged(&ptr, len));

      CHK_ERR(gpuDeviceSynchronize());

      return ptr;

   }

   void operator delete[] (void* ptr) {

      CHK_ERR(gpuDeviceSynchronize());

      CHK_ERR(gpuFree(ptr));

   }

};

```
with the following output (on Mahti):
```

(Grid) rank 0 is noderank 0 of 1

Done setting all 62 instances of device mesh wrapper handler!

(MAIN): Completed grid initialization.

(MAIN): Starting main simulation loop.

(MAIN): Completed requested simulation. Exiting.

driver shutting down in arch/gpu_base.hpp at line 90

srun: error: g1101: task 0: Exited with exit code 1
```
"