### PR TITLE
Amr translation cleanup addon

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -646,10 +646,11 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
 
    // Prepare cellIDs and pencils for AMR translation
    if(P::amrMaxSpatialRefLevel > 0) {
-      phiprof::Timer timer {"GetSeedIdsAndBuildPencils"};
-      for (int dimension=0; dimension<3; dimension++) {
-         prepareSeedIdsAndPencils(mpiGrid,dimension);
-      }
+      prepareSeedIdsAndPencils(mpiGrid);
+      // phiprof::Timer timer {"GetSeedIdsAndBuildPencils"};
+      // for (int dimension=0; dimension<3; dimension++) {
+      //    prepareSeedIdsAndPencils(mpiGrid, dimension);
+      // }
    }
 }
 

--- a/grid.cpp
+++ b/grid.cpp
@@ -647,10 +647,6 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
    // Prepare cellIDs and pencils for AMR translation
    if(P::amrMaxSpatialRefLevel > 0) {
       prepareSeedIdsAndPencils(mpiGrid);
-      // phiprof::Timer timer {"GetSeedIdsAndBuildPencils"};
-      // for (int dimension=0; dimension<3; dimension++) {
-      //    prepareSeedIdsAndPencils(mpiGrid, dimension);
-      // }
    }
 }
 

--- a/vlasovsolver/cpu_trans_pencils.cpp
+++ b/vlasovsolver/cpu_trans_pencils.cpp
@@ -1097,8 +1097,6 @@ void prepareSeedIdsAndPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Ge
    }
 
    phiprof::Timer buildPencilsTimer {"buildPencils"};
-   // Clear previous set - moved to wrapper
-   // DimensionPencils[dimension].removeAllPencils();
 
 #pragma omp parallel
    {

--- a/vlasovsolver/cpu_trans_pencils.cpp
+++ b/vlasovsolver/cpu_trans_pencils.cpp
@@ -679,7 +679,7 @@ void getSeedIds(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGr
          }
       } // finish check A
       if ( addToSeedIds ) {
-#pragma omp critical
+#pragma omp critical (pencil_seedIds_push_back)
          seedIds.push_back(celli);
          continue;
       }
@@ -726,7 +726,7 @@ void getSeedIds(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGr
       } // Finish B check
 
       if ( addToSeedIds ) {
-         #pragma omp critical
+#pragma omp critical (pencil_seedIds_push_back)
          seedIds.push_back(celli);
          continue;
       }
@@ -755,7 +755,7 @@ void getSeedIds(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGr
       } // Finish C check
 
       if ( addToSeedIds ) {
-#pragma omp critical
+#pragma omp critical (pencil_seedIds_push_back)
          seedIds.push_back(celli);
       }
    }
@@ -1011,6 +1011,22 @@ void printPencilsFunc(const setOfPencils& pencils, const uint dimension, const i
    std::cout<<ss.str();
 }
 
+/* Wrapper function for calling seed ID selection and pencil generation, for all dimensions.
+ * Includes threading and gathering of pencils into thread-containers.
+ *
+ * @param [in] mpiGrid DCCRG grid object
+ */
+void prepareSeedIdsAndPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid) {
+      phiprof::Timer timer {"GetSeedIdsAndBuildPencils"};
+      // Remove all old pencils now
+      for (int dimension=0; dimension<3; dimension++) {
+         DimensionPencils[dimension].removeAllPencils();
+      }
+      for (int dimension=0; dimension<3; dimension++) {
+         prepareSeedIdsAndPencils(mpiGrid, dimension);
+      }
+}
+
 /* Wrapper function for calling seed ID selection and pencil generation, per dimension.
  * Includes threading and gathering of pencils into thread-containers.
  *
@@ -1081,8 +1097,8 @@ void prepareSeedIdsAndPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Ge
    }
 
    phiprof::Timer buildPencilsTimer {"buildPencils"};
-   // Clear previous set
-   DimensionPencils[dimension].removeAllPencils();
+   // Clear previous set - moved to wrapper
+   // DimensionPencils[dimension].removeAllPencils();
 
 #pragma omp parallel
    {

--- a/vlasovsolver/cpu_trans_pencils.cpp
+++ b/vlasovsolver/cpu_trans_pencils.cpp
@@ -679,7 +679,7 @@ void getSeedIds(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGr
          }
       } // finish check A
       if ( addToSeedIds ) {
-#pragma omp critical (pencil_seedIds_push_back)
+#pragma omp critical
          seedIds.push_back(celli);
          continue;
       }
@@ -726,7 +726,7 @@ void getSeedIds(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGr
       } // Finish B check
 
       if ( addToSeedIds ) {
-#pragma omp critical (pencil_seedIds_push_back)
+#pragma omp critical
          seedIds.push_back(celli);
          continue;
       }
@@ -755,7 +755,7 @@ void getSeedIds(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGr
       } // Finish C check
 
       if ( addToSeedIds ) {
-#pragma omp critical (pencil_seedIds_push_back)
+#pragma omp critical
          seedIds.push_back(celli);
       }
    }

--- a/vlasovsolver/cpu_trans_pencils.hpp
+++ b/vlasovsolver/cpu_trans_pencils.hpp
@@ -32,7 +32,7 @@ struct setOfPencils {
    uint N; // Number of pencils in the set
    uint sumOfLengths;
    std::vector< uint > lengthOfPencils; // Lengths of pencils (including stencil cells)
-   std::vector< CellID > ids; // List of pencil cells (incudingstencil cells)
+   std::vector< CellID > ids; // List of pencil cells (including stencil cells)
    std::vector< uint > idsStart; // List of where a pencil's CellIDs start in the ids array
    std::vector< Realf > sourceDZ; // Widths of source cells
    std::vector< Realf > targetRatios; // Pencil to target cell area ratios of target cells
@@ -64,12 +64,13 @@ struct setOfPencils {
       N++;
       // If necessary, add the zero cells to the beginning and end
       if (idsIn.front() != 0) {
-         idsIn.insert(idsIn.begin(),0);
-         idsIn.insert(idsIn.begin(),0);
+            idsIn.insert(idsIn.begin(),VLASOV_STENCIL_WIDTH,0);
       }
       if (idsIn.back() != 0) {
-         idsIn.push_back(0);
-         idsIn.push_back(0);
+         for (int i = 0; i < VLASOV_STENCIL_WIDTH; i++)
+         {
+            idsIn.push_back(0);
+         }
       }
       sumOfLengths += idsIn.size();
       lengthOfPencils.push_back(idsIn.size());
@@ -194,6 +195,8 @@ struct setOfPencils {
 
 bool do_translate_cell(spatial_cell::SpatialCell* SC);
 
+// grid.cpp calls this function to both find seed cells and build pencils for all dimensions
+void prepareSeedIdsAndPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid);
 // grid.cpp calls this function to both find seed cells and build pencils
 void prepareSeedIdsAndPencils(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                               const uint dimension);


### PR DESCRIPTION
A bit of restructuring the pencil creation - dimension-looping out of grid.cpp, old pencil removal to be done only once.

Not sure if we actually need those named criticals - while good to have, those may be a bit risky..