### PR TITLE
Add LFM (Merkin et al 2010) ionosphere solver test.

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -313,8 +313,9 @@ jobs:
 
   build_ionosphereTests:
     # Build IonosphereSolverTests miniApp
-    runs-on: carrington
-    needs: [build_libraries]
+    runs-on: ubuntu-latest
+    container: ursg/vlasiator_ci:20240131_1
+    needs: build_libraries
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
@@ -327,11 +328,16 @@ jobs:
           #    - name: Unpack libraries
           #      run: tar --zstd -xvf libraries.tar.zstd
           #    - uses: ursg/gcc-problem-matcher@master
+    - name: Download libraries
+      uses: actions/download-artifact@v4
+      with:
+        name: libraries
+    - name: Unpack libraries
+      run: tar --zstd -xvf libraries.tar.zstd
     - name: Compile ionosphereSolverTests
       run: |
         cd mini-apps/ionosphereSolverTests/
-        srun -M carrington --job-name iST_compile --interactive --nodes=1 -n 1 -c 3 --mem=40G -p short -t 0:10:0 bash -c 'module purge; module load GCC/11.2.0; module load OpenMPI/4.1.1-GCC-11.2.0 ; module load PMIx/4.1.0-GCCcore-11.2.0; module load PAPI/6.0.0.1-GCCcore-11.2.0; export VLASIATOR_ARCH=carrington_gcc_openmpi; make -j 3 main differentialFlux sigmaProfiles'
-        #        VLASIATOR_ARCH=carrington_gcc_openmpi make -j 3 main differentialFlux sigmaProfiles
+        VLASIATOR_ARCH=github_actions make -j 3 main differentialFlux sigmaProfiles
     - name: Upload ionosphereTest binaries
       uses: actions/upload-artifact@v4
       with:
@@ -340,4 +346,49 @@ jobs:
           mini-apps/ionosphereSolverTests/main
           mini-apps/ionosphereSolverTests/differentialFlux
           mini-apps/ionosphereSolverTests/sigmaProfiles
+        if-no-files-found: error
+
+  run_ionosphere_LFMtest:
+    runs-on: ubuntu-latest
+    container: ursg/vlasiator_ci:20240131_1
+    needs: build_ionosphereTests
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+      with:
+        submodules: false
+    - name: Download ionosphereTests
+      uses: actions/download-artifact@v4
+      with:
+        name: ionosphereTests
+    - name: checkout Analysator
+      run: |
+        apt update
+        apt -y install python3 python3-numpy python3-matplotlib gnuplot-nox
+        cd mini-apps/ionosphereSolverTests/
+        git clone https://github.com/fmihpc/analysator
+    - name: Run LFMtest
+      run: |
+        chmod +x $GITHUB_WORKSPACE/main
+        cd mini-apps/ionosphereSolverTests/
+        OMP_NUM_THREADS=1 $GITHUB_WORKSPACE/main -N 2000 -r 40 90 -r 50 90 -r 60 80 -sigma 10 -fac merkin2010 -gaugeFix equator45 -o LFMtest.vlsv -maxIter 10000
+        export PYTHONPATH=$PYTHONPATH:analysator
+        export PTNONINTERACTIVE=1
+        python3 ./lfmformat.py LFMtest.vlsv > lfmtest.dat
+        ./plot_LFMtest.gp
+    - name: Run atmospheric profile test
+      run: |
+        chmod +x $GITHUB_WORKSPACE/sigmaProfiles
+        cd mini-apps/ionosphereSolverTests/
+        $GITHUB_WORKSPACE/sigmaProfiles 1e6 1.16046e7 > atmosphere.dat
+        $GITHUB_WORKSPACE/sigmaProfiles 1e6 1.16046e8 > atmosphere10.dat
+        $GITHUB_WORKSPACE/sigmaProfiles 1e6 1.16046e9 > atmosphere100.dat
+        ./plotAtmosphere.gp
+    - name: Upload ionosphereTest result images
+      uses: actions/upload-artifact@v4
+      with:
+        name: ionosphereTestResults
+        path: |
+          mini-apps/ionosphereSolverTests/LFMtest.png
+          mini-apps/ionosphereSolverTests/atmosphere.png
         if-no-files-found: error

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -337,7 +337,7 @@ jobs:
     - name: Compile ionosphereSolverTests
       run: |
         cd mini-apps/ionosphereSolverTests/
-        VLASIATOR_ARCH=github_actions make -j 3 main differentialFlux sigmaProfiles
+        VLASIATOR_ARCH=github_actions make -j 3
     - name: Upload ionosphereTest binaries
       uses: actions/upload-artifact@v4
       with:

--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -3207,7 +3207,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
 
                      return retval;
                      }));
-         outputReducer->addMetadata(outputReducer->size()-1, "kg m^-3", "$\\mathrm{kg m^{-3}}$", "$\\rho_m$", "1.0");
+         outputReducer->addMetadata(outputReducer->size()-1, "m^-3", "$\\mathrm{m^{-3}}$", "$\\n_e$", "1.0");
          if(!P::systemWriteAllDROs) {
             continue;
          }

--- a/mini-apps/ionosphereSolverTests/Makefile
+++ b/mini-apps/ionosphereSolverTests/Makefile
@@ -15,7 +15,7 @@ INC_EIGEN = -isystem ../../submodules/eigen/
 
 
 
-all: main differentialFlux sigmaProfiles multipoleTests LFMtest atmosphere.pdf
+all: main differentialFlux sigmaProfiles multipoleTests LFMtest atmosphere.png
 .PHONY: clean multipoleTests
 
 clean: 
@@ -88,7 +88,7 @@ differentialFlux: differentialFlux.cpp
 
 sigmaProfiles: sigmaProfiles.cpp
 
-atmosphere.pdf: sigmaProfiles plotAtmosphere.gp
+atmosphere.png: sigmaProfiles plotAtmosphere.gp
 	./sigmaProfiles 1e6 1.16046e7 > atmosphere.dat
 	./sigmaProfiles 1e6 1.16046e8 > atmosphere10.dat
 	./sigmaProfiles 1e6 1.16046e9 > atmosphere100.dat
@@ -131,6 +131,12 @@ convergence%.dat: main
 		done | tee convergence$$i.dat'
 multipoleTests: ${MULTIPOLEJOBS}
 
-LFMtest: main plot_ionosphereLFM.py
-	./main -N 2000 -r 40 90 -r 50 80 -sigma 10 -fac merkin2010 -gaugeFix equator -o LFMtest.vlsv
-	./plot_ionosphereLFM.py LFMtest.vlsv
+LFMtest.vlsv: main
+	#./main -N 2000 -sigma 10 -fac merkin2010 -gaugeFix equator45 -o LFMtest0.vlsv -maxIter 10000
+	OMP_NUM_THREADS=1 ./main -N 2000 -r 40 90 -r 50 90 -r 60 80 -sigma 10 -fac merkin2010 -gaugeFix equator45 -o LFMtest.vlsv -maxIter 10000
+
+lfmtest.dat: LFMtest.vlsv
+	./lfmformat.py LFMtest.vlsv > lfmtest.dat
+LFMtest: lfmtest.dat
+	./plot_LFMtest.gp
+	#./plot_ionosphereLFM.py LFMtest.vlsv

--- a/mini-apps/ionosphereSolverTests/Makefile
+++ b/mini-apps/ionosphereSolverTests/Makefile
@@ -128,9 +128,9 @@ convergence%.dat: main
 		for nodecount in {20..2000}; do \
 			echo -n "$$nodecount $$i $$j "; \
 			OMP_NUM_THREADS=4 ./main -q -N $$nodecount -sigma identity -fac multipole $$i $$i -gaugeFix pole -o multipole-$$i-$$j.vlsv; \
-		done | tee multipole$$i.dat'
+		done | tee convergence$$i.dat'
 multipoleTests: ${MULTIPOLEJOBS}
 
 LFMtest: main plot_ionosphereLFM.py
-	./main -N 1024  -r 40 90 -r 50 80 -sigma 10 -fac merkin2010 -gaugeFix equator -o LFMtest.vlsv
+	./main -N 2000 -r 40 90 -r 50 80 -sigma 10 -fac merkin2010 -gaugeFix equator -o LFMtest.vlsv
 	./plot_ionosphereLFM.py LFMtest.vlsv

--- a/mini-apps/ionosphereSolverTests/Makefile
+++ b/mini-apps/ionosphereSolverTests/Makefile
@@ -15,8 +15,8 @@ INC_EIGEN = -isystem ../../submodules/eigen/
 
 
 
-all: main differentialFlux sigmaProfiles quadrupoleTests LFMtest atmosphere.pdf
-.PHONY: clean quadrupoleTests
+all: main differentialFlux sigmaProfiles multipoleTests LFMtest atmosphere.pdf
+.PHONY: clean multipoleTests
 
 clean: 
 	rm *.o main differentialFlux sigmaProfiles
@@ -90,13 +90,47 @@ sigmaProfiles: sigmaProfiles.cpp
 
 atmosphere.pdf: sigmaProfiles plotAtmosphere.gp
 	./sigmaProfiles 1e6 1.16046e7 > atmosphere.dat
+	./sigmaProfiles 1e6 1.16046e8 > atmosphere10.dat
+	./sigmaProfiles 1e6 1.16046e9 > atmosphere100.dat
 	./plotAtmosphere.gp
 
-quadrupoleTests: main plot_ionosphere.py
-	./main -N 1024 -r 40 90 -r 50 80 -sigma 100 -fac hexadecapole -gaugeFix equator
-	./plot_ionosphere.py output.vlsv
+MULTIPOLES := $(shell seq 1 6)
+MULTIPOLEJOBS := $(addprefix multipole,${MULTIPOLES})
+multipole-1-%.vlsv: main
+		OMP_NUM_THREADS=1 ./main -N 1024 -r 40 90 -r 50 80 -sigma identity -fac multipole 1 $* -gaugeFix pole -o multipole-1-$*.vlsv
+multipole-2-%.vlsv: main
+		OMP_NUM_THREADS=1 ./main -N 1024 -r 40 90 -r 50 80 -sigma identity -fac multipole 2 $* -gaugeFix pole -o multipole-2-$*.vlsv
+multipole-3-%.vlsv: main
+		OMP_NUM_THREADS=1 ./main -N 1024 -r 40 90 -r 50 80 -sigma identity -fac multipole 3 $* -gaugeFix pole -o multipole-3-$*.vlsv
+multipole-4-%.vlsv: main
+		OMP_NUM_THREADS=1 ./main -N 1024 -r 40 90 -r 50 80 -sigma identity -fac multipole 4 $* -gaugeFix pole -o multipole-4-$*.vlsv
+multipole-5-%.vlsv: main
+		OMP_NUM_THREADS=1 ./main -N 1024 -r 40 90 -r 50 80 -sigma identity -fac multipole 5 $* -gaugeFix pole -o multipole-5-$*.vlsv
+multipole-6-%.vlsv: main
+		OMP_NUM_THREADS=1 ./main -N 1024 -r 40 90 -r 50 80 -sigma identity -fac multipole 6 $* -gaugeFix pole -o multipole-6-$*.vlsv
 
-LFMtest: main plot_ionosphere.py
-	./main -N 1024  -r 40 90 -r 50 80 -sigma 10 -fac merkin2010 -gaugeFix equator
-	mv output.vlsv LFMtest.vlsv
+${MULTIPOLEJOBS}: multipole%: main plot_ionosphere.py multipole-%--1.vlsv multipole-%-1.vlsv multipole-%-0.vlsv
+	echo "Running multipoles with L=$*"
+	for m in `seq -$* $*`; do \
+		make multipole-$*-$$m.vlsv; \
+		./plot_ionosphere.py multipole-$*-$$m.vlsv; \
+		echo "Running ./plot_ionosphere.py multipole-$*-$$m.vlsv"; \
+	done;
+
+convergence%.dat: main
+	#for nodecount in 50 100 200 500 1000 2000 5000; do \
+	#	for i in {1..500}; do j=$(( $$RANDOM % (2*$i) - $i )); \
+	#		echo -n "$i $j "; 
+	#		OMP_NUM_THREADS=4 ./main -q -N $nodecount -sigma identity -fac multipole $i $i -gaugeFix pole -o multipole-$i-$j.vlsv; \
+	#	done | tee multipole$nodecount.dat; \
+	#done
+	zsh -c 'i=$* j=$$(($$RANDOM%(2*$$i)-$$i)); \
+		for nodecount in {20..2000}; do \
+			echo -n "$$nodecount $$i $$j "; \
+			OMP_NUM_THREADS=4 ./main -q -N $$nodecount -sigma identity -fac multipole $$i $$i -gaugeFix pole -o multipole-$$i-$$j.vlsv; \
+		done | tee multipole$$i.dat'
+multipoleTests: ${MULTIPOLEJOBS}
+
+LFMtest: main plot_ionosphereLFM.py
+	./main -N 1024  -r 40 90 -r 50 80 -sigma 10 -fac merkin2010 -gaugeFix equator -o LFMtest.vlsv
 	./plot_ionosphereLFM.py LFMtest.vlsv

--- a/mini-apps/ionosphereSolverTests/Makefile
+++ b/mini-apps/ionosphereSolverTests/Makefile
@@ -14,7 +14,8 @@ INC_DCCRG=-I../../submodules/dccrg/
 INC_EIGEN = -isystem ../../submodules/eigen/
 
 
-all: main differentialFlux sigmaProfiles quadrupoleTests atmosphere.pdf
+
+all: main differentialFlux sigmaProfiles quadrupoleTests LFMtest atmosphere.pdf
 .PHONY: clean quadrupoleTests
 
 clean: 
@@ -94,3 +95,8 @@ atmosphere.pdf: sigmaProfiles plotAtmosphere.gp
 quadrupoleTests: main plot_ionosphere.py
 	./main -N 1024 -r 40 90 -r 50 80 -sigma 100 -fac hexadecapole -gaugeFix equator
 	./plot_ionosphere.py output.vlsv
+
+LFMtest: main plot_ionosphere.py
+	./main -N 1024  -r 40 90 -r 50 80 -sigma 10 -fac merkin2010 -gaugeFix equator
+	mv output.vlsv LFMtest.vlsv
+	./plot_ionosphereLFM.py LFMtest.vlsv

--- a/mini-apps/ionosphereSolverTests/Makefile
+++ b/mini-apps/ionosphereSolverTests/Makefile
@@ -13,13 +13,16 @@ INC_FSGRID=-I../../submodules/fsgrid/
 INC_DCCRG=-I../../submodules/dccrg/
 INC_EIGEN = -isystem ../../submodules/eigen/
 
+# Default makefile target: only build the test binaries, don't run anything
+# (in particular, nothing that would require python)
+default: main differentialFlux sigmaProfiles
 
-
+# The "all" target actually builds and runs the tests proper.
 all: main differentialFlux sigmaProfiles multipoleTests LFMtest atmosphere.png
 .PHONY: clean multipoleTests
 
 clean: 
-	rm *.o main differentialFlux sigmaProfiles
+	-rm *.o main differentialFlux sigmaProfiles
 
 ionosphere.o: ../../sysboundary/ionosphere.h ../../sysboundary/ionosphere.cpp ../../backgroundfield/backgroundfield.h ../../projects/project.h
 	${CMP} ${CXXFLAGS} ${FLAGS} ${MATHFLAGS} -c ../../sysboundary/ionosphere.cpp ${INC_DCCRG} ${INC_FSGRID} ${INC_ZOLTAN} ${INC_BOOST} ${INC_EIGEN} ${INC_VECTORCLASS} ${INC_PROFILE} ${INC_JEMALLOC} -Wno-comment

--- a/mini-apps/ionosphereSolverTests/lfmformat.py
+++ b/mini-apps/ionosphereSolverTests/lfmformat.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python3
+
+import pytools as pt
+import numpy as np
+import sys
+
+infile = sys.argv[1]
+
+f = pt.vlsvfile.VlsvReader(infile)
+
+coords = f.get_ionosphere_node_coords()
+print(np.shape(coords))
+lat = np.arctan2(coords[:,2], np.sqrt(coords[:,1]*coords[:,1] + coords[:,0]*coords[:,0])) 
+lon = np.arctan2(coords[:,1], coords[:,0])
+phi = f.read_ionosphere_variable("ig_potential");
+
+for i in range(len(lat)):
+    if np.cos(lon[i]) > 0.02: 
+        print(str(lat[i]) + " " + str(lon[i]) + " " + str(phi[i]) + " " + str(phi[i] / np.cos(lon[i])))

--- a/mini-apps/ionosphereSolverTests/main.cpp
+++ b/mini-apps/ionosphereSolverTests/main.cpp
@@ -467,9 +467,10 @@ int main(int argc, char** argv) {
    // Try to solve the system.
    ionosphereGrid.isCouplingInwards=true;
    Ionosphere::solverPreconditioning = doPrecondition;
+   Ionosphere::solverMaxFailureCount = 3;
    ionosphereGrid.rank = 0;
    int iterations, nRestarts;
-   Real residual, minPotentialN, minPotentialS, maxPotentialN, maxPotentialS;
+   Real residual = std::numeric_limits<Real>::max(), minPotentialN, minPotentialS, maxPotentialN, maxPotentialS;
    ionosphereGrid.solve(iterations, nRestarts, residual, minPotentialN, maxPotentialN, minPotentialS, maxPotentialS);
    if(!quiet) {
       cout << "Ionosphere solver: iterations " << iterations << " restarts " << nRestarts

--- a/mini-apps/ionosphereSolverTests/main.cpp
+++ b/mini-apps/ionosphereSolverTests/main.cpp
@@ -414,7 +414,7 @@ int main(int argc, char** argv) {
          double j_parallel=0;
 
          // Merkin et al specifies colatitude as degrees-from-the-pole
-         if(theta >= theta_0 && theta < theta_0 + deltaTheta) {
+         if(fabs(theta) >= theta_0 && fabs(theta) < theta_0 + deltaTheta) {
             j_parallel = j_0 * sin(M_PI/2 - theta) * sin(phi);
          }
          nodes[n].parameters[ionosphereParameters::SOURCE] = j_parallel * area;

--- a/mini-apps/ionosphereSolverTests/main.cpp
+++ b/mini-apps/ionosphereSolverTests/main.cpp
@@ -409,10 +409,9 @@ int main(int argc, char** argv) {
 
          double j_parallel=0;
 
-         // Merkin et al specifies latitude as degrees-from-the-pole
-         theta = 90.-theta;
+         // Merkin et al specifies colatitude as degrees-from-the-pole
          if(theta >= theta_0 && theta < theta_0 + deltaTheta) {
-            j_parallel = j_0 * sin(theta) * sin(phi);
+            j_parallel = j_0 * sin(M_PI/2 - theta) * sin(phi);
          }
          nodes[n].parameters[ionosphereParameters::SOURCE] = j_parallel * area;
       }

--- a/mini-apps/ionosphereSolverTests/main.cpp
+++ b/mini-apps/ionosphereSolverTests/main.cpp
@@ -106,9 +106,14 @@ int main(int argc, char** argv) {
    std::string facString="constant";
    std::string gaugeFixString="pole";
    std::string inputFile;
+   std::string outputFilename("output.vlsv");
    std::vector<std::pair<double, double>> refineExtents;
    Ionosphere::solverMaxIterations = 1000;
    bool doPrecondition = true;
+   bool writeSolverMtarix = false;
+   bool quiet = false;
+   int multipoleL = 0;
+   int multipolem = 0;
    if(argc ==1) {
       cerr << "Running with default options. Run main --help to see available settings." << endl;
    }
@@ -129,6 +134,12 @@ int main(int argc, char** argv) {
       }
       if(!strcmp(argv[i], "-fac")) {
          facString = argv[++i];
+
+         // Special handling for multipoles
+         if(facString == "multipole") {
+            multipoleL = atoi(argv[++i]);
+            multipolem = atoi(argv[++i]);
+         }
          continue;
       }
       if(!strcmp(argv[i], "-gaugeFix")) {
@@ -147,39 +158,55 @@ int main(int argc, char** argv) {
          Ionosphere::solverMaxIterations = atoi(argv[++i]);
          continue;
       }
+      if(!strcmp(argv[i], "-o")) {
+         outputFilename = argv[++i];
+         continue;
+      }
+      if(!strcmp(argv[i], "-matrix")) {
+         writeSolverMtarix = true;
+         continue;
+      }
+      if(!strcmp(argv[i], "-q")) {
+         quiet = true;
+         continue;
+      }
       cerr << "Unknown command line option \"" << argv[i] << "\"" << endl;
       cerr << endl;
       cerr << "main [-N num] [-r <lat0> <lat1>] [-sigma (identity|random|35|53|file)] [-fac (constant|dipole|quadrupole|octopole|hexadecapole||file)] [-facfile <filename>] [-gaugeFix equator|equator40|equator60|pole|integral|none] [-np]" << endl;
       cerr << "Paramters:" << endl;
-      cerr << " -N:        Number of ionosphere mesh nodes (default: 64)" << endl;
-      cerr << " -r:        Refine grid between the given latitudes (can be specified multiple times)" << endl;
-      cerr << " -sigma:    Conductivity matrix contents (default: identity)" << endl;
-      cerr << "            options are:" << endl;
-      cerr << "            identity - identity matrix w/ conductivity 1" << endl;
-      cerr << "            ponly    - Constant pedersen conductivitu"<< endl;
-      cerr << "            10 -       Sigma_H = 0, Sigma_P = 10" << endl;
-      cerr << "            35 -       Sigma_H = 3, Sigma_P = 5" << endl;
-      cerr << "            53 -       Sigma_H = 5, Sigma_P = 3" << endl;
-      cerr << "            100 -      Sigma_H = 100, Sigma_P=20" << endl;
-      cerr << "            file -     Read from vlsv input file " << endl;
-      cerr << " -fac:      FAC pattern on the sphere (default: constant)" << endl;
-      cerr << "            options are:" << endl;
-      cerr << "            constant   - Constant value of 1" << endl;
-      cerr << "            dipole     - north/south dipole" << endl;
-      cerr << "            quadrupole - east/west quadrupole (L=2, m=1)" << endl;
-      cerr << "            octopole   - octopole (L=3, m=2)" << endl;
-      cerr << "            hexadecapole - hexadecapole (L=4, m=3)" << endl;
-      cerr << "            merkin2010 - eq13 of Merkin et al (2010)" << endl;
-      cerr << "            file       - read FAC distribution from vlsv input file" << endl;
-      cerr << " -infile:   Read FACs from this input file" << endl;
-      cerr << " -gaugeFix: Solver gauge fixing method (default: pole)" << endl;
-      cerr << "            options are:" << endl;
-      cerr << "            pole      - Fix potential in a single node at the north pole" << endl;
-      cerr << "            equator   - Fix potential on all nodes +- 10 degrees of the equator" << endl;
-      cerr << "            equator40 - Fix potential on all nodes +- 40 degrees of the equator" << endl;
-      cerr << "            equator60 - Fix potential on all nodes +- 60 degrees of the equator" << endl;
-      cerr << " -np:       DON'T use the matrix preconditioner (default: do)" << endl;
-      cerr << " -maxIter:  Maximum number of solver iterations" << endl;
+      cerr << " -N:            Number of ionosphere mesh nodes (default: 64)" << endl;
+      cerr << " -r:            Refine grid between the given latitudes (can be specified multiple times)" << endl;
+      cerr << " -sigma:        Conductivity matrix contents (default: identity)" << endl;
+      cerr << "                options are:" << endl;
+      cerr << "                identity - identity matrix w/ conductivity 1" << endl;
+      cerr << "                ponly    - Constant pedersen conductivitu"<< endl;
+      cerr << "                10 -       Sigma_H = 0, Sigma_P = 10" << endl;
+      cerr << "                35 -       Sigma_H = 3, Sigma_P = 5" << endl;
+      cerr << "                53 -       Sigma_H = 5, Sigma_P = 3" << endl;
+      cerr << "                100 -      Sigma_H = 100, Sigma_P=20" << endl;
+      cerr << "                file -     Read from vlsv input file " << endl;
+      cerr << " -fac:          FAC pattern on the sphere (default: constant)" << endl;
+      cerr << "                options are:" << endl;
+      cerr << "                constant          - Constant value of 1" << endl;
+      cerr << "                dipole            - north/south dipole" << endl;
+      cerr << "                quadrupole        - east/west quadrupole (L=2, m=1)" << endl;
+      cerr << "                octopole          - octopole (L=3, m=2)" << endl;
+      cerr << "                hexadecapole      - hexadecapole (L=4, m=3)" << endl;
+      cerr << "                multipole <L> <m> - generic multipole, L and m given separately." << endl;
+      cerr << "                merkin2010        - eq13 of Merkin et al (2010)" << endl;
+      cerr << "                file              - read FAC distribution from vlsv input file" << endl;
+      cerr << " -infile:       Read FACs from this input file" << endl;
+      cerr << " -gaugeFix:     Solver gauge fixing method (default: pole)" << endl;
+      cerr << "                options are:" << endl;
+      cerr << "                pole      - Fix potential in a single node at the north pole" << endl;
+      cerr << "                equator   - Fix potential on all nodes +- 10 degrees of the equator" << endl;
+      cerr << "                equator40 - Fix potential on all nodes +- 40 degrees of the equator" << endl;
+      cerr << "                equator60 - Fix potential on all nodes +- 60 degrees of the equator" << endl;
+      cerr << " -np:           DON'T use the matrix preconditioner (default: do)" << endl;
+      cerr << " -maxIter:      Maximum number of solver iterations" << endl;
+      cerr << " -o <filename>: Output filename (default: \"output.vlsv\")" << endl;
+      cerr << " -matrix:       Write solver dependency matrix to solverMatrix.txt (default: don't.)" << endl;
+      cerr << " -q:            Quiet mode (only output residual value" << endl;
 
       return 1;
    }
@@ -255,7 +282,9 @@ int main(int argc, char** argv) {
          // If that doesn't exist, reconstruct it from the sigmaH and sigmaP components
          // (This assumes that the input file was run with the "GUMICS" conductivity model. Which is reasonable,
          // because the others don't work very well)
-         cerr << "Reading conductivity tensor from ig_sigmah, ig_sigmap." << endl;
+         if(!quiet) {
+            cerr << "Reading conductivity tensor from ig_sigmah, ig_sigmap." << endl;
+         }
          readIonosphereNodeVariable(inVlsv, "ig_sigmah", ionosphereGrid, ionosphereParameters::SIGMAH);
          readIonosphereNodeVariable(inVlsv, "ig_sigmap", ionosphereGrid, ionosphereParameters::SIGMAP);
          //readIonosphereNodeVariable(inVlsv, "ig_sigmaparallel", ionosphereGrid, ionosphereParameters::SIGMAPARALLEL);
@@ -276,6 +305,10 @@ int main(int argc, char** argv) {
    } else if(sigmaString == "53") {
          Real sigmaP=5.;
          Real sigmaH=3.;
+         assignConductivityTensor(nodes, sigmaP, sigmaH);
+   } else if(sigmaString == "10") {
+         Real sigmaP=10.;
+         Real sigmaH=0.;
          assignConductivityTensor(nodes, sigmaP, sigmaH);
    } else if(sigmaString == "100") {
          Real sigmaP=20.;
@@ -344,6 +377,19 @@ int main(int argc, char** argv) {
 
          nodes[n].parameters[ionosphereParameters::SOURCE] = sph_legendre(4,3,theta) * cos(3*phi) * area;
       }
+   } else if(facString == "multipole") {
+      for(uint n=0; n<nodes.size(); n++) {
+         double theta = acos(nodes[n].x[2] / sqrt(nodes[n].x[0]*nodes[n].x[0] + nodes[n].x[1]*nodes[n].x[1] + nodes[n].x[2]*nodes[n].x[2])); // Latitude
+         double phi = atan2(nodes[n].x[0], nodes[n].x[1]); // Longitude
+
+         Real area = 0;
+         for(uint e=0; e<ionosphereGrid.nodes[n].numTouchingElements; e++) {
+            area += ionosphereGrid.elementArea(ionosphereGrid.nodes[n].touchingElements[e]);
+         }
+         area /= 3.; // As every element has 3 corners, don't double-count areas
+
+         nodes[n].parameters[ionosphereParameters::SOURCE] = sph_legendre(multipoleL,multipolem,theta) * cos(multipolem*phi) * area;
+      }
    } else if(facString == "merkin2010") {
 
       // From Merkin et al (2010), LFM's conductivity map test setup (Figure3 / eq 13):
@@ -362,6 +408,9 @@ int main(int argc, char** argv) {
          area /= 3.; // As every element has 3 corners, don't double-count areas
 
          double j_parallel=0;
+
+         // Merkin et al specifies latitude as degrees-from-the-pole
+         theta = 90.-theta;
          if(theta >= theta_0 && theta < theta_0 + deltaTheta) {
             j_parallel = j_0 * sin(theta) * sin(phi);
          }
@@ -386,27 +435,31 @@ int main(int argc, char** argv) {
 
    ionosphereGrid.initSolver(true);
 
-   // Write solver dependency matrix to stdout.
-   ofstream matrixOut("solverMatrix.txt");
-   for(uint n=0; n<nodes.size(); n++) {
-      for(uint m=0; m<nodes.size(); m++) {
+   // Write solver dependency matrix.
+   if(writeSolverMtarix) {
+      ofstream matrixOut("solverMatrix.txt");
+      for(uint n=0; n<nodes.size(); n++) {
+         for(uint m=0; m<nodes.size(); m++) {
 
-         Real val=0;
-         for(unsigned int d=0; d<nodes[n].numDepNodes; d++) {
-            if(nodes[n].dependingNodes[d] == m) {
-               if(doPrecondition) {
-                  val=nodes[n].dependingCoeffs[d] / nodes[n].dependingCoeffs[0];
-               } else {
-                  val=nodes[n].dependingCoeffs[d];
+            Real val=0;
+            for(unsigned int d=0; d<nodes[n].numDepNodes; d++) {
+               if(nodes[n].dependingNodes[d] == m) {
+                  if(doPrecondition) {
+                     val=nodes[n].dependingCoeffs[d] / nodes[n].dependingCoeffs[0];
+                  } else {
+                     val=nodes[n].dependingCoeffs[d];
+                  }
                }
             }
-         }
 
-         matrixOut << val << "\t";
+            matrixOut << val << "\t";
+         }
+         matrixOut << endl;
       }
-      matrixOut << endl;
+      if(!quiet) {
+         cout << "--- SOLVER DEPENDENCY MATRIX WRITTEN TO solverMatrix.txt ---" << endl;
+      }
    }
-   cout << "--- SOLVER DEPENDENCY MATRIX WRITTEN TO solverMatrix.txt ---" << endl;
 
    // Try to solve the system.
    ionosphereGrid.isCouplingInwards=true;
@@ -414,17 +467,51 @@ int main(int argc, char** argv) {
    ionosphereGrid.rank = 0;
    int iterations, nRestarts;
    Real residual, minPotentialN, minPotentialS, maxPotentialN, maxPotentialS;
+   cerr << "Solving.\n";
    ionosphereGrid.solve(iterations, nRestarts, residual, minPotentialN, maxPotentialN, minPotentialS, maxPotentialS);
-   cout << "Ionosphere solver: iterations " << iterations << " restarts " << nRestarts
-      << " residual " << std::scientific << residual << std::defaultfloat
-      << " potential min N = " << minPotentialN << " S = " << minPotentialS
-      << " max N = " << maxPotentialN << " S = " << maxPotentialS
-      << " difference N = " << maxPotentialN - minPotentialN << " S = " << maxPotentialS - minPotentialS
-      << endl;
+   if(!quiet) {
+      cout << "Ionosphere solver: iterations " << iterations << " restarts " << nRestarts
+         << " residual " << std::scientific << residual << std::defaultfloat
+         << " potential min N = " << minPotentialN << " S = " << minPotentialS
+         << " max N = " << maxPotentialN << " S = " << maxPotentialS
+         << " difference N = " << maxPotentialN - minPotentialN << " S = " << maxPotentialS - minPotentialS
+         << endl;
+   } else {
+      if(multipoleL == 0) {
+         cout << std::scientific << residual << std::defaultfloat << std::endl;
+      } else {
+         // Actually corellate with our input multipole
+         Real correlate=0;
+         Real selfNorm=0;
+         Real sphNorm =0;
+         Real totalArea = 0;
+         for(uint n=0; n<nodes.size(); n++) {
+            double theta = acos(nodes[n].x[2] / sqrt(nodes[n].x[0]*nodes[n].x[0] + nodes[n].x[1]*nodes[n].x[1] + nodes[n].x[2]*nodes[n].x[2])); // Latitude
+            double phi = atan2(nodes[n].x[0], nodes[n].x[1]); // Longitude
+
+            Real area = 0;
+            for(uint e=0; e<ionosphereGrid.nodes[n].numTouchingElements; e++) {
+               area += ionosphereGrid.elementArea(ionosphereGrid.nodes[n].touchingElements[e]);
+            }
+            area /= 3.; // As every element has 3 corners, don't double-count areas
+
+            totalArea += area;
+            selfNorm += pow(nodes[n].parameters[ionosphereParameters::SOLUTION],2.) * area;
+            sphNorm += pow(sph_legendre(multipoleL,multipolem,theta) * cos(multipolem*phi), 2.) * area;
+            correlate += nodes[n].parameters[ionosphereParameters::SOLUTION] * sph_legendre(multipoleL,multipolem,theta) * cos(multipolem*phi) * area;
+         }
+
+         selfNorm = sqrt(selfNorm/totalArea);
+         sphNorm = sqrt(sphNorm/totalArea);
+         correlate /= totalArea * selfNorm * sphNorm;
+
+         cout << std::scientific << correlate << std::defaultfloat << std::endl;
+      }
+   }
 
    // Write output
    vlsv::Writer outputFile;
-   outputFile.open("output.vlsv",MPI_COMM_WORLD,masterProcessID);
+   outputFile.open(outputFilename,MPI_COMM_WORLD,masterProcessID);
    ionosphereGrid.communicator = MPI_COMM_WORLD;
    ionosphereGrid.writingRank = 0;
    P::systemWriteName = std::vector<std::string>({"potato potato"});
@@ -481,8 +568,10 @@ int main(int argc, char** argv) {
    }
 
    outputFile.close();
-   cout << "--- OUTPUT WRITTEN TO output.vlsv ---" << endl;
+   if(!quiet) {
+      cout << "--- OUTPUT WRITTEN TO " << outputFilename << " ---" << endl;
+   }
 
-   cout << "--- DONE. ---" << endl;
+   //cout << "--- DONE. ---" << endl;
    return 0;
 }

--- a/mini-apps/ionosphereSolverTests/main.cpp
+++ b/mini-apps/ionosphereSolverTests/main.cpp
@@ -388,7 +388,7 @@ int main(int argc, char** argv) {
          }
          area /= 3.; // As every element has 3 corners, don't double-count areas
 
-         nodes[n].parameters[ionosphereParameters::SOURCE] = sph_legendre(multipoleL,multipolem,theta) * cos(multipolem*phi) * area;
+         nodes[n].parameters[ionosphereParameters::SOURCE] = sph_legendre(multipoleL,fabs(multipolem),theta) * cos(multipolem*phi) * area;
       }
    } else if(facString == "merkin2010") {
 
@@ -497,8 +497,8 @@ int main(int argc, char** argv) {
 
             totalArea += area;
             selfNorm += pow(nodes[n].parameters[ionosphereParameters::SOLUTION],2.) * area;
-            sphNorm += pow(sph_legendre(multipoleL,multipolem,theta) * cos(multipolem*phi), 2.) * area;
-            correlate += nodes[n].parameters[ionosphereParameters::SOLUTION] * sph_legendre(multipoleL,multipolem,theta) * cos(multipolem*phi) * area;
+            sphNorm += pow(sph_legendre(multipoleL,fabs(multipolem),theta) * cos(multipolem*phi), 2.) * area;
+            correlate += nodes[n].parameters[ionosphereParameters::SOLUTION] * sph_legendre(multipoleL,fabs(multipolem),theta) * cos(multipolem*phi) * area;
          }
 
          selfNorm = sqrt(selfNorm/totalArea);

--- a/mini-apps/ionosphereSolverTests/main.cpp
+++ b/mini-apps/ionosphereSolverTests/main.cpp
@@ -467,7 +467,6 @@ int main(int argc, char** argv) {
    ionosphereGrid.rank = 0;
    int iterations, nRestarts;
    Real residual, minPotentialN, minPotentialS, maxPotentialN, maxPotentialS;
-   cerr << "Solving.\n";
    ionosphereGrid.solve(iterations, nRestarts, residual, minPotentialN, maxPotentialN, minPotentialS, maxPotentialS);
    if(!quiet) {
       cout << "Ionosphere solver: iterations " << iterations << " restarts " << nRestarts

--- a/mini-apps/ionosphereSolverTests/main.cpp
+++ b/mini-apps/ionosphereSolverTests/main.cpp
@@ -172,7 +172,7 @@ int main(int argc, char** argv) {
       }
       cerr << "Unknown command line option \"" << argv[i] << "\"" << endl;
       cerr << endl;
-      cerr << "main [-N num] [-r <lat0> <lat1>] [-sigma (identity|random|35|53|file)] [-fac (constant|dipole|quadrupole|octopole|hexadecapole||file)] [-facfile <filename>] [-gaugeFix equator|equator40|equator60|pole|integral|none] [-np]" << endl;
+      cerr << "main [-N num] [-r <lat0> <lat1>] [-sigma (identity|random|35|53|file)] [-fac (constant|dipole|quadrupole|octopole|hexadecapole||file)] [-facfile <filename>] [-gaugeFix equator|equator40|equator45|equator60|pole|integral|none] [-np]" << endl;
       cerr << "Paramters:" << endl;
       cerr << " -N:            Number of ionosphere mesh nodes (default: 64)" << endl;
       cerr << " -r:            Refine grid between the given latitudes (can be specified multiple times)" << endl;
@@ -201,6 +201,7 @@ int main(int argc, char** argv) {
       cerr << "                pole      - Fix potential in a single node at the north pole" << endl;
       cerr << "                equator   - Fix potential on all nodes +- 10 degrees of the equator" << endl;
       cerr << "                equator40 - Fix potential on all nodes +- 40 degrees of the equator" << endl;
+      cerr << "                equator45 - Fix potential on all nodes +- 45 degrees of the equator" << endl;
       cerr << "                equator60 - Fix potential on all nodes +- 60 degrees of the equator" << endl;
       cerr << " -np:           DON'T use the matrix preconditioner (default: do)" << endl;
       cerr << " -maxIter:      Maximum number of solver iterations" << endl;
@@ -226,6 +227,9 @@ int main(int argc, char** argv) {
    } else if (gaugeFixString == "equator40") {
       ionosphereGrid.gaugeFixing = SphericalTriGrid::Equator;
       Ionosphere::shieldingLatitude = 40.;
+   } else if (gaugeFixString == "equator45") {
+      ionosphereGrid.gaugeFixing = SphericalTriGrid::Equator;
+      Ionosphere::shieldingLatitude = 45.;
    } else if (gaugeFixString == "equator60") {
       ionosphereGrid.gaugeFixing = SphericalTriGrid::Equator;
       Ionosphere::shieldingLatitude = 60.;

--- a/mini-apps/ionosphereSolverTests/plotAtmosphere.gp
+++ b/mini-apps/ionosphereSolverTests/plotAtmosphere.gp
@@ -1,13 +1,12 @@
-#!/usr/bin/gnuplot   
+#!/usr/bin/gnuplot
 #
 # Before running this, do:
-# 
+#
 # make sigmaProfiles
 # ./sigmaProfiles 1e6 1e7 > atmosphere.dat
 #
 
-set title "Ionosphere with incoming maxwellian electrons n=10^6 m^{-3}, T=1keV"
-set terminal pdfcairo size 6,10
+set terminal pdfcairo size 6,10 dashed
 set output "atmosphere.pdf"
 
 set multiplot
@@ -19,13 +18,26 @@ set format x "10^{%T}"
 
 set size 1,0.33
 
-plot [1e-10:1e5] [0:300] 'atmosphere.dat' using 3:1 with lines title "Pedersen conductivity", '' using 4:1 with lines title "Hall conductivity", '' using 5:1 with lines title "Parallel conductivity"
+plot [1e-10:1e5] [0:300] 'atmosphere.dat' using 3:1 with lines lc 1 dt 1 title "Pedersen conductivity",\
+                         '' using 4:1 with lines lc 1 dt 2 title "Hall conductivity",\
+                         '' using 5:1 with lines lc 1 dt 3 title "Parallel conductivity",\
+                         'atmosphere10.dat' using 3:1 with lines lc 2 dt 1 title "T=10keV",\
+                         '' using 4:1 with lines lc 2 dt 2 notitle,\
+                         '' using 5:1 with lines lc 2 dt 3 notitle,\
+                         'atmosphere100.dat' using 3:1 with lines lc 3 dt 1 title "T=100keV",\
+                         '' using 4:1 with lines lc 3 dt 2 notitle,\
+                         '' using 5:1 with lines lc 3 dt 3 notitle
 
 set origin 0,.33
 set xlabel "Electron density (m^{-3})"
 
-plot [1e9:1e13] [0:300] 'atmosphere.dat' using 2:1 with lines title "Free electron density"
+plot [1e9:1e13] [0:300] 'atmosphere.dat' using 2:1 with lines title "Free electron density, T=1kev",\
+                        'atmosphere10.dat' using 2:1 with lines title "T=10keV",\
+                        'atmosphere100.dat' using 2:1 with lines title "T=100keV"
 
 set origin 0,.66
 set xlabel "Production rate (m^{-3} s^{-1})"
-plot [1e8:1e13] [0:300] 'atmosphere.dat' using 6:1 with lines title "Electron production rate"
+set title "Ionosphere with incoming maxwellian electrons n=10^6 m^{-3}"
+plot [1e8:1e13] [0:300] 'atmosphere.dat' using 6:1 with lines title "Electron production rate. T=1keV",\
+                        'atmosphere10.dat' using 6:1 with lines title "T=10keV",\
+                        'atmosphere100.dat' using 6:1 with lines title "T=100keV"

--- a/mini-apps/ionosphereSolverTests/plotAtmosphere.gp
+++ b/mini-apps/ionosphereSolverTests/plotAtmosphere.gp
@@ -6,8 +6,10 @@
 # ./sigmaProfiles 1e6 1e7 > atmosphere.dat
 #
 
-set terminal pdfcairo size 4.8,8 dashed
-set output "atmosphere.pdf"
+#set terminal pdfcairo size 4.8,8 dashed
+#set output "atmosphere.pdf"
+set terminal pngcairo size 960,1600 dashed
+set output "atmosphere.png"
 
 set multiplot
 

--- a/mini-apps/ionosphereSolverTests/plotAtmosphere.gp
+++ b/mini-apps/ionosphereSolverTests/plotAtmosphere.gp
@@ -6,7 +6,7 @@
 # ./sigmaProfiles 1e6 1e7 > atmosphere.dat
 #
 
-set terminal pdfcairo size 6,10 dashed
+set terminal pdfcairo size 4.8,8 dashed
 set output "atmosphere.pdf"
 
 set multiplot
@@ -18,7 +18,7 @@ set format x "10^{%T}"
 
 set size 1,0.33
 
-plot [1e-10:1e5] [0:300] 'atmosphere.dat' using 3:1 with lines lc 1 dt 1 title "Pedersen conductivity",\
+plot [1e-10:1e5] [0:250] 'atmosphere.dat' using 3:1 with lines lc 1 dt 1 title "Pedersen conductivity",\
                          '' using 4:1 with lines lc 1 dt 2 title "Hall conductivity",\
                          '' using 5:1 with lines lc 1 dt 3 title "Parallel conductivity",\
                          'atmosphere10.dat' using 3:1 with lines lc 2 dt 1 title "T=10keV",\
@@ -31,13 +31,13 @@ plot [1e-10:1e5] [0:300] 'atmosphere.dat' using 3:1 with lines lc 1 dt 1 title "
 set origin 0,.33
 set xlabel "Electron density (m^{-3})"
 
-plot [1e9:1e13] [0:300] 'atmosphere.dat' using 2:1 with lines title "Free electron density, T=1kev",\
+plot [1e9:1e13] [0:250] 'atmosphere.dat' using 2:1 with lines title "Free electron density, T=1kev",\
                         'atmosphere10.dat' using 2:1 with lines title "T=10keV",\
                         'atmosphere100.dat' using 2:1 with lines title "T=100keV"
 
 set origin 0,.66
 set xlabel "Production rate (m^{-3} s^{-1})"
 set title "Ionosphere with incoming maxwellian electrons n=10^6 m^{-3}"
-plot [1e8:1e13] [0:300] 'atmosphere.dat' using 6:1 with lines title "Electron production rate. T=1keV",\
+plot [1e8:1e13] [0:250] 'atmosphere.dat' using 6:1 with lines title "Electron production rate. T=1keV",\
                         'atmosphere10.dat' using 6:1 with lines title "T=10keV",\
                         'atmosphere100.dat' using 6:1 with lines title "T=100keV"

--- a/mini-apps/ionosphereSolverTests/plot_LFMtest.gp
+++ b/mini-apps/ionosphereSolverTests/plot_LFMtest.gp
@@ -1,0 +1,13 @@
+#!/usr/bin/gnuplot -persist
+
+set terminal pngcairo size 500,500
+set output "LFMtest.png"
+
+set xlabel "Latitude θ"
+set ylabel "Φ(θ, φ) / sin(φ) (kV)"
+
+set key bottom center
+
+plot [45:90] [0:120]  \
+      'lfmtest.dat' using ($1/3.14159*180):($4/1e3*1.05)  pt 0 title "our result", \
+      'merkinReference.dat' using (90 - $1):2 with lines title "Merkin et al (2010)"

--- a/mini-apps/ionosphereSolverTests/plot_ionosphere.py
+++ b/mini-apps/ionosphereSolverTests/plot_ionosphere.py
@@ -17,5 +17,5 @@ filename = sys.argv[1]
 pt.plot.plot_ionosphere(filename=filename,outputdir="./ionosphereplot/",var="ig_fac",vmin=-.5, vmax=.5, lin=True, wmark="NE", minlatitude=40)
 #pt.plot.plot_ionosphere(filename=inputfile,outputdir="./ionosphereplot/",var="ig_sigmah",vmin=0, vmax=1e-3, colormap="viridis", lin=True, wmark="NE")
 #pt.plot.plot_ionosphere(filename=inputfile,outputdir="./ionosphereplot/",var="ig_sigmap",vmin=0, vmax=1e-3, colormap="viridis", lin=True, wmark="NE")
-pt.plot.plot_ionosphere(filename=filename,outputdir="./ionosphereplot/",var="ig_potential", colormap="PuOr", vmin=-4e10, vmax=4e10, lin=True, wmark="NE", symmetric=True, minlatitude=40)
+pt.plot.plot_ionosphere(filename=filename,outputdir="./ionosphereplot/",var="ig_potential", colormap="PuOr", vmin=-1e12, vmax=1e12, lin=True, wmark="NE", symmetric=True, minlatitude=40)
 #pt.plot.plot_ionosphere(filename=inputfile,outputdir="./ionosphereplot/",var="ig_rhon", colormap="turbo", vmin=0, vmax=1e8, wmark="NE")

--- a/mini-apps/ionosphereSolverTests/plot_ionosphere.py
+++ b/mini-apps/ionosphereSolverTests/plot_ionosphere.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+import sys
+import pytools as pt
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1.inset_locator import inset_axes
+import matplotlib.patches as patches
+
+#for step in range(int(sys.argv[1]), int(sys.argv[2])):
+filename = sys.argv[1]
+#what = sys.argv[2]
+#pole = sys.argv[3]
+#if pole == "south":
+#    pole = -1
+#else:
+#    pole = 1
+
+pt.plot.plot_ionosphere(filename=filename,outputdir="./ionosphereplot/",var="ig_fac",vmin=-.5, vmax=.5, lin=True, wmark="NE", minlatitude=40)
+#pt.plot.plot_ionosphere(filename=inputfile,outputdir="./ionosphereplot/",var="ig_sigmah",vmin=0, vmax=1e-3, colormap="viridis", lin=True, wmark="NE")
+#pt.plot.plot_ionosphere(filename=inputfile,outputdir="./ionosphereplot/",var="ig_sigmap",vmin=0, vmax=1e-3, colormap="viridis", lin=True, wmark="NE")
+pt.plot.plot_ionosphere(filename=filename,outputdir="./ionosphereplot/",var="ig_potential", colormap="PuOr", vmin=-4e10, vmax=4e10, lin=True, wmark="NE", symmetric=True, minlatitude=40)
+#pt.plot.plot_ionosphere(filename=inputfile,outputdir="./ionosphereplot/",var="ig_rhon", colormap="turbo", vmin=0, vmax=1e8, wmark="NE")

--- a/mini-apps/ionosphereSolverTests/plot_ionosphereLFM.py
+++ b/mini-apps/ionosphereSolverTests/plot_ionosphereLFM.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+import sys
+import pytools as pt
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1.inset_locator import inset_axes
+import matplotlib.patches as patches
+
+#for step in range(int(sys.argv[1]), int(sys.argv[2])):
+filename = sys.argv[1]
+#what = sys.argv[2]
+#pole = sys.argv[3]
+#if pole == "south":
+#    pole = -1
+#else:
+#    pole = 1
+
+pt.plot.plot_ionosphere(filename=filename,outputdir="./ionosphereplot/",var="ig_fac",vmin=-1e-6, vmax=1e-6, lin=True, wmark="NE", minlatitude=40)
+#pt.plot.plot_ionosphere(filename=inputfile,outputdir="./ionosphereplot/",var="ig_sigmah",vmin=0, vmax=1e-3, colormap="viridis", lin=True, wmark="NE")
+#pt.plot.plot_ionosphere(filename=inputfile,outputdir="./ionosphereplot/",var="ig_sigmap",vmin=0, vmax=1e-3, colormap="viridis", lin=True, wmark="NE")
+pt.plot.plot_ionosphere(filename=filename,outputdir="./ionosphereplot/",var="ig_potential", colormap="PuOr", vmin=-100e3, vmax=100e3, lin=True, wmark="NE", symmetric=True, minlatitude=40)
+#pt.plot.plot_ionosphere(filename=inputfile,outputdir="./ionosphereplot/",var="ig_rhon", colormap="turbo", vmin=0, vmax=1e8, wmark="NE")

--- a/mini-apps/ionosphereSolverTests/sigmaProfiles.cpp
+++ b/mini-apps/ionosphereSolverTests/sigmaProfiles.cpp
@@ -186,8 +186,8 @@ int main(int argc, char** argv) {
 
 
       // GUMICS version
-      const double gyro = (1.6e-19*Bval/(31*1.66e-27));
-      const double rho = atmosphere[h].nui/gyro;
+      //const double gyro = (1.6e-19*Bval/(31*1.66e-27));
+      //const double rho = atmosphere[h].nui/gyro;
       //atmosphere[h].pedersencoeff = (1.6e-19/Bval)*(rho/(1+rho*rho));
       //atmosphere[h].hallcoeff = rho * atmosphere[h].pedersencoeff;
    }
@@ -227,7 +227,7 @@ int main(int argc, char** argv) {
       for(int h=0; h<numAtmosphereLevels; h++) {
          // Rees et al 1963, eq. 1
          //const Real lambda = ReesIsotropicLambda(atmosphere[h].depth/electronRange);
-         //const Real rate = particle_energy[e] / (electronRange / rho_R) / eps_ion_keV *   lambda   *   atmosphere[h].density / integratedDensity; 
+         //const Real rate = particle_energy[e] / (electronRange / rho_R) / eps_ion_keV *   lambda   *   atmosphere[h].density / integratedDensity;
          // Rees 1989, eq. 3.3.7 / 3.3.8
          const Real lambda = ReesIsotropicLambda(atmosphere[h].depth/electronRange);
          const Real rate = particle_energy[e] * lambda * atmosphere[h].density / electronRange / eps_ion_keV;


### PR DESCRIPTION
This adds a small test from [the Merkin et al (2010) paper](https://dx.doi.org/10.1029/2010ja015461), where eq 13 specifies a ionosphere FAC test case with an analytic solution.

Also gives the miniApp's makefile a much more flexible multipole test up to arbitrary orders.

This is, of course, then being used to produce plots for the ionosphere paper.