### PR TITLE
Concurrency check and trap to scancel testpackage_run if caught cancel signal

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -290,10 +290,10 @@ jobs:
         cd testpackage
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/libraries/lib
         #srun -M carrington -t 01:30:00 --job-name CI_testpackage --interactive --nodes=1 -c 4 -n 16 --mem-per-cpu=5G -p short ./small_test_carrington_github_ci.sh
-        jobspec=$(sbatch --parsable -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh)
-        jobspec=(${jobspec//\;/ })
-        trap "scancel -M ${jobspec[1]} ${jobspec[0]}" SIGINT
-        srun -M carrington --dependency afterany:${jobspec[0]} echo "Job finished, checking output."
+        VLASIATOR_CIRUNNER_JOBSPEC_TP=$(sbatch --parsable -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh)
+        VLASIATOR_CIRUNNER_JOBSPEC_TP=(${VLASIATOR_CIRUNNER_JOBSPEC_TP//\;/ })
+        trap "scancel -M ${VLASIATOR_CIRUNNER_JOBSPEC_TP[1]} ${VLASIATOR_CIRUNNER_JOBSPEC_TP[0]}" SIGINT
+        srun -M carrington --dependency afterany:${VLASIATOR_CIRUNNER_JOBSPEC_TP[0]} echo "Job finished, checking output."
         cat testpackage_run_output.txt
         cat $GITHUB_STEP_SUMMARY > $GITHUB_WORKSPACE/testpackage_check_description.txt
         cd $GITHUB_WORKSPACE

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -9,6 +9,10 @@ on:
   # ... or when the workflow is started manually
   workflow_dispatch:
 
+concurrency:
+   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+   cancel-in-progress: true
+
 jobs:
   build_libraries:
     # Build libraries for the current version of the docker image
@@ -286,7 +290,9 @@ jobs:
         cd testpackage
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/libraries/lib
         #srun -M carrington -t 01:30:00 --job-name CI_testpackage --interactive --nodes=1 -c 4 -n 16 --mem-per-cpu=5G -p short ./small_test_carrington_github_ci.sh
-        sbatch -W -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh
+        jobspec=$(sbatch --parsable -W -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh)
+        jobspec=(${jobspec//\;/ })
+        trap "scancel -M ${jobspec[1]} ${jobspec[0]}" 2
         cat testpackage_run_output.txt
         cat $GITHUB_STEP_SUMMARY > $GITHUB_WORKSPACE/testpackage_check_description.txt
         cd $GITHUB_WORKSPACE

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -293,7 +293,7 @@ jobs:
         jobspec=$(sbatch --parsable -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh)
         jobspec=(${jobspec//\;/ })
         trap "scancel -M ${jobspec[1]} ${jobspec[0]}" 2
-        srun --dependency afterany:${jobspec[0]} echo "Job finished, checking output."
+        srun -M carrington --dependency afterany:${jobspec[0]} echo "Job finished, checking output."
         cat testpackage_run_output.txt
         cat $GITHUB_STEP_SUMMARY > $GITHUB_WORKSPACE/testpackage_check_description.txt
         cd $GITHUB_WORKSPACE

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -293,7 +293,8 @@ jobs:
         jobspec=$(sbatch --parsable -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh)
         jobspec=(${jobspec//\;/ })
         trap "scancel -M ${jobspec[1]} ${jobspec[0]}" 2
-        srun --dependency afterany:${jobspec[0]} cat testpackage_run_output.txt
+        srun --dependency afterany:${jobspec[0]} echo "Job finished, checking output."
+        cat testpackage_run_output.txt
         cat $GITHUB_STEP_SUMMARY > $GITHUB_WORKSPACE/testpackage_check_description.txt
         cd $GITHUB_WORKSPACE
         tar -czvf testpackage-output.tar.gz testpackage_check_description.txt testpackage_output_variables.txt

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -292,7 +292,7 @@ jobs:
         #srun -M carrington -t 01:30:00 --job-name CI_testpackage --interactive --nodes=1 -c 4 -n 16 --mem-per-cpu=5G -p short ./small_test_carrington_github_ci.sh
         jobspec=$(sbatch --parsable -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh)
         jobspec=(${jobspec//\;/ })
-        trap "scancel -M ${jobspec[1]} ${jobspec[0]}" 2
+        trap "scancel -M ${jobspec[1]} ${jobspec[0]}" SIGINT
         srun -M carrington --dependency afterany:${jobspec[0]} echo "Job finished, checking output."
         cat testpackage_run_output.txt
         cat $GITHUB_STEP_SUMMARY > $GITHUB_WORKSPACE/testpackage_check_description.txt

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -290,10 +290,10 @@ jobs:
         cd testpackage
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/libraries/lib
         #srun -M carrington -t 01:30:00 --job-name CI_testpackage --interactive --nodes=1 -c 4 -n 16 --mem-per-cpu=5G -p short ./small_test_carrington_github_ci.sh
-        jobspec=$(sbatch --parsable -W -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh)
+        jobspec=$(sbatch --parsable -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh)
         jobspec=(${jobspec//\;/ })
         trap "scancel -M ${jobspec[1]} ${jobspec[0]}" 2
-        cat testpackage_run_output.txt
+        srun --dependency afterany:${jobspec[0]} cat testpackage_run_output.txt
         cat $GITHUB_STEP_SUMMARY > $GITHUB_WORKSPACE/testpackage_check_description.txt
         cd $GITHUB_WORKSPACE
         tar -czvf testpackage-output.tar.gz testpackage_check_description.txt testpackage_output_variables.txt


### PR DESCRIPTION
Two modifications:
1) Concurrency group definition: One github-ci workflow per PR / branch/tag reference, see https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre/72408109#72408109

2) Parse testpackage sbatch output and create a trap to cancel the job if Ctrl-C signal encountered. This is a bit hacky with a srun --dependency call to bypass the sbatch -W functionality.