### PR TITLE
Remove . /etc/profile from generate_version.sh

### DIFF
--- a/generate_version.sh
+++ b/generate_version.sh
@@ -19,8 +19,6 @@
 
 curdir=$(pwd)
 
-. /etc/profile
-
 # if you use client/server visit and have "cd /lustre/tmp/..." in your ~/.bashrc this workaround is needed
 cd $curdir
 


### PR DESCRIPTION
https://github.com/fmihpc/vlasiator/issues/959

As discussed in the above linked issue, this PR removes the sourcing of /etc/profile, as it's likely no longer needed and can potentially cause some minor issues on clusters that have a default module set (such as MN5)