### PR TITLE
Fix ig_rhon units incorrectly being a mass density

### DIFF
--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -3207,7 +3207,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
 
                      return retval;
                      }));
-         outputReducer->addMetadata(outputReducer->size()-1, "kg m^-3", "$\\mathrm{kg m^{-3}}$", "$\\rho_m$", "1.0");
+         outputReducer->addMetadata(outputReducer->size()-1, "m^-3", "$\\mathrm{m^{-3}}$", "$\\n_e$", "1.0");
          if(!P::systemWriteAllDROs) {
             continue;
          }


### PR DESCRIPTION
Found when scratching my head about the colorbars of plots for the ionosphere paper.