### PR TITLE
Don't checkout submodules in testpackage CI run.

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -273,7 +273,7 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v4
       with:
-        submodules: true
+        submodules: false
     - name: Download testpackage binary
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
Since they are all just header files 'n stuff, they are not needing for running the testpackage proper.

All we care about is the testpackage's own config file structure.

This might speed up CI runs a little bit.