### PR TITLE
Fix crash if OMPI_MCA_io is not set in environment.

### DIFF
--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -335,9 +335,11 @@ int main(int argn,char* args[]) {
    }
    if (myRank == MASTER_RANK) {
       const char* mpiioenv = std::getenv("OMPI_MCA_io");
-      std::string mpiioenvstr(mpiioenv);
-      if(mpiioenvstr.find("^ompio") == std::string::npos) {
-         cout << mpiioMessage.str();
+      if(mpiioenv != nullptr) {
+         std::string mpiioenvstr(mpiioenv);
+         if(mpiioenvstr.find("^ompio") == std::string::npos) {
+            cout << mpiioMessage.str();
+         }
       }
    }
 


### PR DESCRIPTION
geteniv returned a null pointer in this case, which caused std::string to throw an exception.
(This probably broke Vlasiator in all other MPI implementations apart from openmpi)