### PR TITLE
Test running github CI on carrington using srun --interactive

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -289,21 +289,17 @@ jobs:
         chmod +x $GITHUB_WORKSPACE/vlsv*_DP
         cd testpackage
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/libraries/lib
-        #srun -M carrington -t 01:30:00 --job-name CI_testpackage --interactive --nodes=1 -c 4 -n 16 --mem-per-cpu=5G -p short ./small_test_carrington_github_ci.sh
-        VLASIATOR_CIRUNNER_JOBSPEC_TP=$(sbatch --parsable -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh)
-        VLASIATOR_CIRUNNER_JOBSPEC_TP=(${VLASIATOR_CIRUNNER_JOBSPEC_TP//\;/ })
-        trap "scancel -M carrington ${VLASIATOR_CIRUNNER_JOBSPEC_TP[0]}" SIGINT
-        trap "scancel -M carrington ${VLASIATOR_CIRUNNER_JOBSPEC_TP[0]}" SIGTERM
+        srun -M carrington -t 01:30:00 --dependency singleton --job-name CI_testpackage --interactive --nodes=1 -c 4 -n 16 --mem=0 -p short ./small_test_carrington_github_ci.sh | tee testpackage_run_output.txt
+        #sbatch --parsable -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh
         RUN_STRING=$( cat << MORO
         echo "Job finished, checking output."
-        cat testpackage_run_output.txt
         cat $GITHUB_STEP_SUMMARY > $GITHUB_WORKSPACE/testpackage_check_description.txt
         cd $GITHUB_WORKSPACE
         ls -halB testpackage_check_description.txt
         tar -czf testpackage-output.tar.gz testpackage_check_description.txt testpackage_output_variables.txt
         MORO
         )
-        srun -M carrington --dependency afterany:${VLASIATOR_CIRUNNER_JOBSPEC_TP[0]} bash -c "$RUN_STRING"
+        srun -M carrington bash -c "$RUN_STRING"
         if [ -f $GITHUB_WORKSPACE/testpackage_failed ]; then
           # Fail this step if any test failed.
           exit 1

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -299,7 +299,7 @@ jobs:
         tar -czf testpackage-output.tar.gz testpackage_check_description.txt testpackage_output_variables.txt
         MORO
         )
-        srun -M carrington bash -c "$RUN_STRING"
+        srun -M carrington bash --job-name "CI_gatherresults" -c "$RUN_STRING"
         if [ -f $GITHUB_WORKSPACE/testpackage_failed ]; then
           # Fail this step if any test failed.
           exit 1

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -289,7 +289,8 @@ jobs:
         chmod +x $GITHUB_WORKSPACE/vlsv*_DP
         cd testpackage
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/libraries/lib
-        srun -M carrington -t 01:30:00 --dependency singleton --job-name CI_testpackage --pty --nodes=1 -c 4 -n 16 --mem=0 -p short ./small_test_carrington_github_ci.sh | tee testpackage_run_output.txt
+        ./small_test_carrington_github_ci.sh | tee testpackage_run_output.txt
+        #srun -M carrington -t 01:30:00 --dependency singleton --job-name CI_testpackage --pty --nodes=1 -c 4 -n 16 --mem=0 -p short ./small_test_carrington_github_ci.sh | tee testpackage_run_output.txt
         #sbatch --parsable -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh
         RUN_STRING=$( cat << MORO
         echo "Job finished, checking output."

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -289,7 +289,7 @@ jobs:
         chmod +x $GITHUB_WORKSPACE/vlsv*_DP
         cd testpackage
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/libraries/lib
-        srun -M carrington -t 01:30:00 --dependency singleton --job-name CI_testpackage --interactive --nodes=1 -c 4 -n 16 --mem=0 -p short ./small_test_carrington_github_ci.sh | tee testpackage_run_output.txt
+        srun -M carrington -t 01:30:00 --dependency singleton --job-name CI_testpackage --pty --nodes=1 -c 4 -n 16 --mem=0 -p short ./small_test_carrington_github_ci.sh | tee testpackage_run_output.txt
         #sbatch --parsable -o testpackage_run_output.txt ./small_test_carrington_github_ci.sh
         RUN_STRING=$( cat << MORO
         echo "Job finished, checking output."

--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
-#SBATCH -t 01:30:00        # Run time (hh:mm:ss)
-#SBATCH --job-name=CI_testpackage
-##SBATCH -A spacephysics
-#SBATCH -M carrington
-# test short medium 20min1d 3d
-#SBATCH -p short
-#SBATCH --exclusive
-#SBATCH --nodes=1
-#SBATCH -c 4                 # CPU cores per task
-#SBATCH -n 16                  # number of tasks
-#SBATCH --mem=0
-##SBATCH -x carrington-[801-808]
+# (SBATCH headers are removed from this file, as this is dispatched directly from the github actions script)
 
 #If 1, the reference vlsv files are generated
 # if 0 then we check the v1
@@ -56,11 +45,12 @@ export OMP_NUM_THREADS=$t
 
 # With this the code won't print the warning, so we have a shorter report
 export OMPI_MCA_io="^ompio"
+export UCX_NET_DEVICES="eth0"
 
 #command for running stuff
-run_command="mpirun --mca btl self -mca pml ^vader,tcp,openib,uct,yalla -x UCX_NET_DEVICES=mlx5_0:1 -x UCX_TLS=rc,sm -x UCX_IB_ADDR_TYPE=ib_global -np $tasks"
-small_run_command="mpirun --mca btl self -mca pml ^vader,tcp,openib,uct,yalla -x UCX_NET_DEVICES=mlx5_0:1 -x UCX_TLS=rc,sm -x UCX_IB_ADDR_TYPE=ib_global -n 1 -N 1"
-run_command_tools="mpirun -np 1 "
+run_command="srun --job-name 'CI_run' -M carrington --nodes=1 -n 16 -c 4 --mem=0 -p short -t 0:30:00 --mpi=pmix -n $tasks"
+small_run_command="srun --job-name 'CI_smallrun' -M carrington --nodes=1 -n 1 -c 4 --mem=0 -p short -t 0:30:00 --mpi=pmix -n 1"
+run_command_tools="srun --job-name 'CI_tool' -M carrington --nodes=1 -n 1 -c 4 --mem=0 -p short -t 0:30:00 --mpi=pmix -n 1"
 
 umask 007
 # Launch the OpenMP job to the allocated compute node


### PR DESCRIPTION
That way, we should have immediate stdout output, and action run kills should result in the slurm job being automatically reapt, too.