### PR TITLE
Squelch two compiler warnings.

### DIFF
--- a/projects/KHB/KHB.cpp
+++ b/projects/KHB/KHB.cpp
@@ -118,7 +118,6 @@ namespace projects {
       Real Vx = profile(this->Vx[this->BOTTOM], this->Vx[this->TOP], x);
       Real Vy = profile(this->Vy[this->BOTTOM], this->Vy[this->TOP], x);
       Real Vz = profile(this->Vz[this->BOTTOM], this->Vz[this->TOP], x);
-      (void)y,z,popID;
 
       // add an initial velocity perturbation to Vx
       // initialize RNG for calculating random phases for the initial perturbation

--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -371,8 +371,8 @@ bool trans_map_1d_amr(const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartes
             // Transpose and copy block data from cells to source buffer
             Vec* blockDataSource = blockDataBuffer.data() + start*WID3/VECL;
             Realf** pencilBlockData = cellBlockData.data() + start;
-            bool pencil_has_data = copy_trans_block_data_amr(pencilBlockData, L, blockDataSource,
-                                                             cellid_transpose, popID);
+            copy_trans_block_data_amr(pencilBlockData, L, blockDataSource,
+                                      cellid_transpose, popID);
          }
          loadTimer.stop();
 


### PR DESCRIPTION
One was (maybe) a merge leftover in KHB? It contained a completely uneffective statement.

The other an old remnant boolen return value, that was never really used anywhere.