### PR TITLE
AMR Filtering Update

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -1559,7 +1559,14 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
    }
 
    if (P::shouldFilter) {
-      project.filterRefined(mpiGrid);
+      // TODO: two loops potentially
+      // But make triangle filter here to avoid horrid overhead
+      for (int i = 0; i < P::filterPasses; ++i) {
+         phiprof::Timer timer {"transfer-and-filter"};
+         SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_DATA);
+         mpiGrid.update_copies_of_remote_neighbors(NEAREST_NEIGHBORHOOD_ID);
+         project.filterRefined(mpiGrid);
+      }
    }
    return true;
 }

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -161,6 +161,7 @@ bool P::adaptRefinement = false;
 bool P::refineOnRestart = false;
 bool P::forceRefinement = false;
 bool P::shouldFilter = false;
+int P::filterPasses = 0;
 bool P::useAlpha1 = true;
 Real P::alpha1RefineThreshold = 0.5;
 Real P::alpha1CoarsenThreshold = -1.0;
@@ -478,6 +479,7 @@ bool P::addParameters() {
    RP::add("AMR.refine_on_restart","If true, re-refine vlasov grid on restart. DEPRECATED, consider using the DOMR command", false);
    RP::add("AMR.force_refinement","If true, refine/unrefine the vlasov grid to match the config on restart", false);
    RP::add("AMR.should_filter","If true, filter vlasov grid with boxcar filter on restart",false);
+   RP::add("AMR.filter_passes","AMR filtering passes", 1);
    RP::add("AMR.use_alpha1","Use the maximum of dimensionless gradients alpha_1 as a refinement index", true);
    RP::add("AMR.alpha1_refine_threshold","Determines the minimum value of alpha_1 to refine cells", 0.5);
    RP::add("AMR.alpha1_coarsen_threshold","Determines the maximum value of alpha_1 to unrefine cells, default half of the refine threshold", -1.0);
@@ -776,6 +778,7 @@ void Parameters::getParameters() {
    RP::get("AMR.refine_on_restart",P::refineOnRestart);
    RP::get("AMR.force_refinement",P::forceRefinement);
    RP::get("AMR.should_filter",P::shouldFilter);
+   RP::get("AMR.filter_passes",P::filterPasses);
    RP::get("AMR.use_alpha1",P::useAlpha1);
    RP::get("AMR.alpha1_refine_threshold",P::alpha1RefineThreshold);
    RP::get("AMR.alpha1_coarsen_threshold",P::alpha1CoarsenThreshold);

--- a/parameters.h
+++ b/parameters.h
@@ -192,6 +192,7 @@ struct Parameters {
    static bool refineOnRestart;
    static bool forceRefinement;
    static bool shouldFilter;
+   static int filterPasses;
    static bool useAlpha1;
    static Real alpha1RefineThreshold;
    static Real alpha1CoarsenThreshold;

--- a/sysboundary/sysboundarycondition.cpp
+++ b/sysboundary/sysboundarycondition.cpp
@@ -472,18 +472,24 @@ namespace SBC {
     * \param cellList Vector of cells to copy from.
     * \param to Pointer to cell in which to set the averaged distribution.
     * \param popID ID of population to average the distribution of
-    * \param fluffiness Factor to replace data with from 0.0 (default, do nothing) to 1.0 (replace all destination data with source data)
+    * \param targetWeight weight of the target cell (to)
+    * \param weights weights of the cellList cells
     */
    void averageCellData(
          dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
          const vector<CellID> cellList,
          SpatialCell *to,
          const uint popID,
-         creal fluffiness /* default =0.0*/
+         std::vector<double> weights,
+         double targetWeight
    ) {
-      const size_t numberOfCells = cellList.size();
-      creal factor = fluffiness / convert<Real>(numberOfCells);
-      
+      // TODO vector<pair> perhaps?
+      assert(cellList.size() == weights.size());
+
+      // Normalize targetWeight and weights
+      double totalWeight {std::reduce(weights.cbegin(), weights.cend(), targetWeight)};
+      targetWeight /= totalWeight;
+      std::transform(weights.cbegin(), weights.cend(), weights.begin(), [totalWeight](double d) {return d / totalWeight;});
 
       // Rescale own vspace
       for (vmesh::LocalID toBlockLID=0; toBlockLID<to->get_number_of_velocity_blocks(popID); ++toBlockLID) {
@@ -492,13 +498,13 @@ namespace SBC {
          
          // Add values from source cells
          for (uint kc=0; kc<WID; ++kc) for (uint jc=0; jc<WID; ++jc) for (uint ic=0; ic<WID; ++ic) {
-            toData[cellIndex(ic,jc,kc)] *= 1.0 - fluffiness;
+            toData[cellIndex(ic,jc,kc)] *= targetWeight;
          }
          toData += SIZE_VELBLOCK;
       } // for-loop over velocity blocks
 
       
-      for (size_t i=0; i<numberOfCells; i++) {
+      for (size_t i = 0; i < cellList.size(); ++i) {
          const SpatialCell* incomingCell = mpiGrid[cellList[i]];
 
          const Realf* fromData = incomingCell->get_data(popID);
@@ -518,11 +524,22 @@ namespace SBC {
 
             // Add values from source cells
             for (uint kc=0; kc<WID; ++kc) for (uint jc=0; jc<WID; ++jc) for (uint ic=0; ic<WID; ++ic) {
-               toData[cellIndex(ic,jc,kc)] += factor*fromData[cellIndex(ic,jc,kc)];
+               toData[cellIndex(ic,jc,kc)] += weights[i] * fromData[cellIndex(ic,jc,kc)];
             }
             fromData += SIZE_VELBLOCK;
          } // for-loop over velocity blocks
       }
+   }
+
+   void averageCellData(
+         dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
+         const vector<CellID> cellList,
+         SpatialCell *to,
+         const uint popID,
+         creal fluffiness /* default =0.0*/
+   ) {
+      std::vector<double> weights {cellList.size(), fluffiness};
+      averageCellData(mpiGrid, cellList, to, popID, weights, 1.0 - fluffiness);
    }
 
    /*! Take neighboring distribution and reflect all parts going in the direction opposite to the normal vector given in.

--- a/sysboundary/sysboundarycondition.h
+++ b/sysboundary/sysboundarycondition.h
@@ -317,6 +317,15 @@ namespace SBC {
          /*! Array of bool telling which faces are going to be processed by the system boundary condition.*/
          bool facesToProcess[6];
    };
+
+   void averageCellData (
+      dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
+      std::vector<CellID> cellList,
+      SpatialCell *to,
+      const uint popID,
+      std::vector<double> weights,
+      double targetWeight = 1.0
+   );
    
    // Moved outside the class since it's a helper function that doesn't require member access
    void averageCellData (


### PR DESCRIPTION
Draft for an improved filtering scheme, to be brought in line with fsgrid filtering in order to avoid "banding" from refined cells dropping filtering passes on fsgrid.
TODO:
- Testing :)
- Implementation of triangle filter to minimize communication
- `P::filterPasses` is a temporary parameter for testing, ideally this should just be based on fsgrid filter passes