### PR TITLE
Only proc boundary cells in one trans loop

### DIFF
--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -484,7 +484,7 @@ void update_remote_mapping_contribution_amr(
    int direction,
    const uint popID) {
 
-   const vector<CellID>& local_cells = getLocalCells();
+   const vector<CellID> local_cells = mpiGrid.get_local_cells_on_process_boundary(VLASOV_SOLVER_NEIGHBORHOOD_ID);
    const vector<CellID> remote_cells = mpiGrid.get_remote_cells_on_process_boundary(VLASOV_SOLVER_NEIGHBORHOOD_ID);
    vector<CellID> receive_cells;
    set<CellID> send_cells;


### PR DESCRIPTION
In my hunt for the memory issue... I found this, and it ran without hideously crashing so can't be *that* wrong a change. Let's see with the CI diffs...