### PR TITLE
Removed block adjustment in initialization of donotcompute cells.

### DIFF
--- a/sysboundary/donotcompute.cpp
+++ b/sysboundary/donotcompute.cpp
@@ -76,12 +76,6 @@ namespace SBC {
          cell->parameters[CellParams::VY_DT2] = 0.0;
          cell->parameters[CellParams::VZ_DT2] = 0.0;
          cell->parameters[CellParams::RHOQ_DT2] = 0.0;
-         
-         //let's get rid of blocks not fulfilling the criteria here to save
-         //memory.
-         for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
-            cell->adjustSingleCellVelocityBlocks(popID,true);
-         }
       }
    }
    


### PR DESCRIPTION
This caused a segfault during restarting on LUMI-C. No idea why suddenly now and never before. Should be safe to remove, no?!