### PR TITLE
Fix check vlasiator cfg script

### DIFF
--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -164,7 +164,7 @@ void SysBoundary::initSysBoundaries(Project& project, creal& t) {
    }
 
    for (it = sysBoundaryCondList.begin(); it != sysBoundaryCondList.end(); it++) {
-      if (*it == "Outflow") {
+      if (*it == "Outflow" || *it == "outflow") {
          this->addSysBoundary(new SBC::Outflow, project, t);
 
          anyDynamic = anyDynamic | this->getSysBoundary(sysboundarytype::OUTFLOW)->isDynamic();
@@ -191,15 +191,15 @@ void SysBoundary::initSysBoundaries(Project& project, creal& t) {
 
          if ((faces[4] || faces[5]) && P::zcells_ini < 5)
             abort_mpi("Outflow condition loaded on z- or z+ face but not enough cells in z!");
-      } else if (*it == "Ionosphere") {
+      } else if (*it == "Ionosphere" || *it == "ionosphere") {
          this->addSysBoundary(new SBC::Ionosphere, project, t);
          this->addSysBoundary(new SBC::DoNotCompute, project, t);
          anyDynamic = anyDynamic | this->getSysBoundary(sysboundarytype::IONOSPHERE)->isDynamic();
-      } else if(*it == "Copysphere") {
+      } else if(*it == "Copysphere" || *it == "copysphere") {
          this->addSysBoundary(new SBC::Copysphere, project, t);
          this->addSysBoundary(new SBC::DoNotCompute, project, t);
          anyDynamic = anyDynamic | this->getSysBoundary(sysboundarytype::COPYSPHERE)->isDynamic();
-      } else if (*it == "Maxwellian") {
+      } else if (*it == "Maxwellian" || *it == "maxwellian") {
          this->addSysBoundary(new SBC::Maxwellian, project, t);
          anyDynamic = anyDynamic | this->getSysBoundary(sysboundarytype::MAXWELLIAN)->isDynamic();
          bool faces[6];

--- a/tools/check_vlasiator_cfg.sh
+++ b/tools/check_vlasiator_cfg.sh
@@ -42,21 +42,35 @@ fi
 # Extract the project name to filter out these options below.
 project=$( cat $cfg | grep "^project" | cut --delimiter="=" -f 2 | tr -d " " )
 
+# Check valid boundary names
+if [[ $( grep "^boundary" $cfg | grep -iv Ionosphere | grep -iv Maxwellian | grep -iv Outflow | grep -iv Copysphere | wc -l ) -gt 0 ]]
+then
+   echo "Invalid below boundary type(s) listed below, not checking further until these are fixed"
+   grep "^boundary" $cfg | grep -iv Ionosphere | grep -iv Maxwellian | grep -iv Outflow | grep -iv copysphere
+   retval=1
+   exit $retval
+fi
+
 # Extract the loaded system boundaries to filter out these options below.
 boundaries=""
-if [[ $( grep "^boundary" $cfg | grep Ionosphere | wc -l ) -eq 1 ]]
+if [[ $( grep "^boundary" $cfg | grep -i Ionosphere | wc -l ) -eq 1 ]]
 then
    boundaries=ionosphere
 fi
 
-if [[ $( grep "^boundary" $cfg | grep Maxwellian | wc -l ) -eq 1 ]]
+if [[ $( grep "^boundary" $cfg | grep -i Maxwellian | wc -l ) -eq 1 ]]
 then
    boundaries=$boundaries" maxwellian"
 fi
 
-if [[ $( grep "^boundary" $cfg | grep Outflow | wc -l ) -eq 1 ]]
+if [[ $( grep "^boundary" $cfg | grep -i Outflow | wc -l ) -eq 1 ]]
 then
    boundaries=$boundaries" outflow"
+fi
+
+if [[ $( grep "^boundary" $cfg | grep -i Copysphere | wc -l ) -eq 1 ]]
+then
+   boundaries=$boundaries" copysphere"
 fi
 
 # Extract the populations to filter out these options below.


### PR DESCRIPTION
Make cfg boundary = options case insensitive for the first letter
Maxwellian maxwellian Outflow outflow Ionosphere ionosphere Copysphere copysphere
Goes along with fixes in check_vlasiator_cfg.sh

Missing Copysphere in check_vlasiator_cfg.sh.
Also missing identification of incorrect boundary types loaded.
Also make them case insensitive.

Let's see if we had lurking buggy cfgs now in CI :).