### PR TITLE
Different trans thread guide

### DIFF
--- a/vlasovsolver/cpu_trans_map_amr.cpp
+++ b/vlasovsolver/cpu_trans_map_amr.cpp
@@ -337,7 +337,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartes
       std::vector<uint> pencilBlocksCount(DimensionPencils[dimension].N);
 
       // Loop over velocity space blocks (threaded).
-#pragma omp for schedule(guided,8)
+#pragma omp for schedule(dynamic,1)
       for(uint blocki = 0; blocki < unionOfBlocks.size(); blocki++) {
          // Get global id of the velocity block
          vmesh::GlobalID blockGID = unionOfBlocks[blocki];


### PR DESCRIPTION
Since each block is translated over all pencils, but a block might appear in only very few pencils, the computational cost per block can vary immensly. (guided,8) seems to result in large imbalances, so going to (dynamic,1) should results in better balance, even though it might be a bit overkill.