### PR TITLE
Chop off cells in x

### DIFF
--- a/parameters.cpp
+++ b/parameters.cpp
@@ -61,6 +61,8 @@ uint P::xcells_ini = numeric_limits<uint>::max();
 uint P::ycells_ini = numeric_limits<uint>::max();
 uint P::zcells_ini = numeric_limits<uint>::max();
 
+uint P::chopOffNCellsInX = 0;
+
 Real P::t = 0;
 Real P::t_min = 0;
 Real P::t_max = LARGE_REAL;
@@ -310,6 +312,8 @@ bool P::addParameters() {
    RP::add("gridbuilder.x_length", "Number of cells in x-direction in initial grid.", 0);
    RP::add("gridbuilder.y_length", "Number of cells in y-direction in initial grid.", 0);
    RP::add("gridbuilder.z_length", "Number of cells in z-direction in initial grid.", 0);
+
+   RP::add("gridbuilder.chop_off_n_cells_in_x", "Number of cells to chop off in +x direction.", 0);
 
    RP::add("gridbuilder.dt", "Initial timestep in seconds.", 0.0);
 
@@ -755,6 +759,7 @@ void Parameters::getParameters() {
    RP::get("gridbuilder.x_length", P::xcells_ini);
    RP::get("gridbuilder.y_length", P::ycells_ini);
    RP::get("gridbuilder.z_length", P::zcells_ini);
+   RP::get("gridbuilder.chop_off_n_cells_in_x", P::chopOffNCellsInX);
 
    RP::get("VAMR.max_velocity_level", P::vamrMaxVelocityRefLevel);
    RP::get("VAMR.vel_refinement_criterion", P::vamrVelRefCriterion);

--- a/parameters.h
+++ b/parameters.h
@@ -51,6 +51,8 @@ struct Parameters {
    static uint ycells_ini; /*!< Initial number of spatial cells in y-direction. */
    static uint zcells_ini; /*!< Initial number of spatial cells in z-direction. */
 
+   static uint chopOffNCellsInX;
+
    static Real t;     /*!< Current simulation time. */
    static Real t_min; /*!< Initial simulation time. */
    static Real t_max; /*!< Maximum simulation time. */

--- a/sysboundary/inflow.cpp
+++ b/sysboundary/inflow.cpp
@@ -99,6 +99,9 @@ void Inflow::assignSysBoundary(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geomet
 
       isThisCellOnAFace.fill(false);
       determineFace(isThisCellOnAFace.data(), x, y, z, dx, dy, dz);
+      if(x > Parameters::xmax - dx * Parameters::chopOffNCellsInX) {
+         mpiGrid[id]->sysBoundaryFlag = sysboundarytype::DO_NOT_COMPUTE;
+      }
       // Comparison of the array defining which faces to use and the array telling on which faces this cell is
       doAssign = false;
       for (int j = 0; j < 6; j++) {

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -538,10 +538,13 @@ void SysBoundary::classifyCells(dccrg::Dccrg<spatial_cell::SpatialCell, dccrg::C
    for (FsGridTools::FsIndex_t z = 0; z < localSize[2]; ++z) {
       for (FsGridTools::FsIndex_t y = 0; y < localSize[1]; ++y) {
          for (FsGridTools::FsIndex_t x = 0; x < localSize[0]; ++x) {
-            if (technicalGrid.get(x,y,z)->sysBoundaryLayer == 0 && (
-                technicalGrid.get(x,y,z)->sysBoundaryFlag == sysboundarytype::IONOSPHERE ||
-                technicalGrid.get(x,y,z)->sysBoundaryFlag == sysboundarytype::COPYSPHERE)) {
-               technicalGrid.get(x, y, z)->sysBoundaryFlag = sysboundarytype::DO_NOT_COMPUTE;
+            if (technicalGrid.get(x,y,z)->sysBoundaryLayer == 0) {
+               if (technicalGrid.get(x,y,z)->sysBoundaryFlag == sysboundarytype::IONOSPHERE ||
+                   technicalGrid.get(x,y,z)->sysBoundaryFlag == sysboundarytype::COPYSPHERE) {
+                  technicalGrid.get(x, y, z)->sysBoundaryFlag = sysboundarytype::DO_NOT_COMPUTE;
+               } else if (technicalGrid.get(x,y,z)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY) {
+                  technicalGrid.get(x, y, z)->sysBoundaryFlag = sysboundarytype::OUTER_BOUNDARY_PADDING;
+               }
             }
          }
       }

--- a/sysboundary/sysboundarycondition.cpp
+++ b/sysboundary/sysboundarycondition.cpp
@@ -66,9 +66,6 @@ namespace SBC {
       for(uint i=0; i<6; i++) {
          isThisCellOnAFace[i] = false;
       }
-      if(x > Parameters::xmax - dx * 2) {
-         isThisCellOnAFace[0] = true;
-      }
       if(x < Parameters::xmin + dx * 2) {
          isThisCellOnAFace[1] = true;
       }
@@ -84,6 +81,18 @@ namespace SBC {
       if(z < Parameters::zmin + dz * 2) {
          isThisCellOnAFace[5] = true;
       }
+      if(x > Parameters::xmax - dx * 2 - dx * Parameters::chopOffNCellsInX) {
+         if(x <= Parameters::xmax - dx * Parameters::chopOffNCellsInX) {
+            isThisCellOnAFace[0] = true;
+         } else {
+            isThisCellOnAFace[1] = false;
+            isThisCellOnAFace[2] = false;
+            isThisCellOnAFace[3] = false;
+            isThisCellOnAFace[4] = false;
+            isThisCellOnAFace[5] = false;
+         }
+      }
+
       if(excludeSlicesAndPeriodicDimensions == true) {
          if (Parameters::xcells_ini == 1 || this->periodic[0]) {
             isThisCellOnAFace[0] = false;


### PR DESCRIPTION
This introduces a parameter giving a number of +x base-grid cells that get shoved into DO_NOT_COMPUTE, effectively reducing the size of the computed domain by a certain slab of cells.

We have operational need for this and it seems to work for the very specific purpose at hand (no refinement nearby, only this wall of the domain, no particular resetting of cells or so). Anything more general is going to require a lot more work, and we don't want to ever have to reuse this. But I suppose we want to keep a trace of it as it'll likely enter production in the next days.

If nothing else, a couple :eyes: for cross-checking before said production would be nice.