### PR TITLE
Make chunk data script use 5 GB chunks, for Allas

### DIFF
--- a/tools/fileHandling/chunkDataToTape.sh
+++ b/tools/fileHandling/chunkDataToTape.sh
@@ -19,7 +19,7 @@ path=$2
 start=$3
 end=$4
 
-chunkSize=$((50 * 1024*1024*1024))
+chunkSize=$((5 * 1024*1024*1024))
 fileSize=$( /bin/ls -la ${file} | gawk '{ print $5 }' )
 chunkNumber=$(( fileSize / chunkSize ))
 


### PR DESCRIPTION
Updated the chunkDataToTape script to use 5 GB chunks instead of 50, as Allas has a maximum file size of 5 GB.