### PR TITLE
Use curl instead of wget in build_libraries.sh

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -18,15 +18,11 @@ jobs:
     # Build libraries for the current version of the docker image
     # (to be used in any subsequent compilation and run jobs on said image)
     runs-on: ubuntu-latest
-    container: ursg/vlasiator_ci:20240131_1
+    container: ursg/vlasiator_ci:20241101_1
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-      - name: install curl
-        run: |
-          apt-get update
-          apt-get -y install curl
       - name: Run library build script
         run: ./build_libraries.sh
       - name: Build libraries tar
@@ -102,7 +98,7 @@ jobs:
   build_production:
     # Build Vlasiator with production flags
     runs-on: ubuntu-latest
-    container: ursg/vlasiator_ci:20240131_1
+    container: ursg/vlasiator_ci:20241101_1
     needs: build_libraries
 
     steps:
@@ -343,7 +339,7 @@ jobs:
   build_ionosphereTests:
     # Build IonosphereSolverTests miniApp
     runs-on: ubuntu-latest
-    container: ursg/vlasiator_ci:20240131_1
+    container: ursg/vlasiator_ci:20241101_1
     needs: build_libraries
     steps:
     - name: Checkout source
@@ -379,7 +375,7 @@ jobs:
 
   run_ionosphere_LFMtest:
     runs-on: ubuntu-latest
-    container: ursg/vlasiator_ci:20240131_1
+    container: ursg/vlasiator_ci:20241101_1
     needs: build_ionosphereTests
     steps:
     - name: Checkout source
@@ -424,7 +420,7 @@ jobs:
 
   check_cfg_files:
     runs-on: ubuntu-latest
-    container: ursg/vlasiator_ci:20240131_1
+    container: ursg/vlasiator_ci:20241101_1
     needs: [build_libraries, build_production]
     steps:
     - name: Checkout source

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+      - name: install curl
+        run: |
+          apt-get update
+          apt-get -y install curl
       - name: Run library build script
         run: ./build_libraries.sh
       - name: Build libraries tar

--- a/build_libraries.sh
+++ b/build_libraries.sh
@@ -57,7 +57,7 @@ if [[ $PLATFORM != "-arriesgado" && $PLATFORM != "-appleM1" ]]; then  # This fai
 fi
 
 # Build jemalloc
-wget https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2
+curl -O -L https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2
 tar xjf jemalloc-5.3.0.tar.bz2
 cd jemalloc-5.3.0
 ./configure --prefix=$WORKSPACE/libraries${PLATFORM} --with-jemalloc-prefix=je_ && make -j 4 && make install


### PR DESCRIPTION
Concretely, this is importint for systems that can only access the internet via a SOCKS proxy, which wget doesn't support.