### PR TITLE
Limit tracing volume

### DIFF
--- a/fieldtracing/fieldtracing.cpp
+++ b/fieldtracing/fieldtracing.cpp
@@ -572,12 +572,12 @@ namespace FieldTracing {
                   }
                   
                   // If we map out of the box, this node is on an open field line.
-                  if(   x[0] > P::xmax - 4*P::dx_ini
-                     || x[0] < P::xmin + 4*P::dx_ini
-                     || x[1] > P::ymax - 4*P::dy_ini
-                     || x[1] < P::ymin + 4*P::dy_ini
-                     || x[2] > P::zmax - 4*P::dz_ini
-                     || x[2] < P::zmin + 4*P::dz_ini
+                  if(   x[0] > fieldTracingParameters.x_max
+                     || x[0] < fieldTracingParameters.x_min
+                     || x[1] > fieldTracingParameters.y_max
+                     || x[1] < fieldTracingParameters.y_min
+                     || x[2] > fieldTracingParameters.z_max
+                     || x[2] < fieldTracingParameters.z_min
                   ) {
                      nodeNeedsContinuedTracing[n] = 0;
                      nodeTracingCoordinates[n] = {0,0,0};
@@ -710,12 +710,12 @@ namespace FieldTracing {
          
          // If we map out of the box, discard this field line.
          if(
-               x[0] > P::xmax - 4*P::dx_ini
-            || x[0] < P::xmin + 4*P::dx_ini
-            || x[1] > P::ymax - 4*P::dy_ini
-            || x[1] < P::ymin + 4*P::dy_ini
-            || x[2] > P::zmax - 4*P::dz_ini
-            || x[2] < P::zmin + 4*P::dz_ini
+               x[0] > fieldTracingParameters.x_max
+            || x[0] < fieldTracingParameters.x_min
+            || x[1] > fieldTracingParameters.y_max
+            || x[1] < fieldTracingParameters.y_min
+            || x[2] > fieldTracingParameters.z_max
+            || x[2] < fieldTracingParameters.z_min
          ) {
             cellTracingCoordinates[n] = x;
             cellConnection[n] += TracingLineEndType::OPEN;
@@ -894,12 +894,12 @@ namespace FieldTracing {
          cellBWTracingCoordinates.at(n) = cellFWTracingCoordinates.at(n);
          if(mpiGrid.is_local(id)) {
             if((mpiGrid[id]->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY)
-               || cellFWTracingCoordinates[n][0] > P::xmax - 4*P::dx_ini
-               || cellFWTracingCoordinates[n][0] < P::xmin + 4*P::dx_ini
-               || cellFWTracingCoordinates[n][1] > P::ymax - 4*P::dy_ini
-               || cellFWTracingCoordinates[n][1] < P::ymin + 4*P::dy_ini
-               || cellFWTracingCoordinates[n][2] > P::zmax - 4*P::dz_ini
-               || cellFWTracingCoordinates[n][2] < P::zmin + 4*P::dz_ini
+               || cellFWTracingCoordinates[n][0] > fieldTracingParameters.x_max
+               || cellFWTracingCoordinates[n][0] < fieldTracingParameters.x_min
+               || cellFWTracingCoordinates[n][1] > fieldTracingParameters.y_max
+               || cellFWTracingCoordinates[n][1] < fieldTracingParameters.y_min
+               || cellFWTracingCoordinates[n][2] > fieldTracingParameters.z_max
+               || cellFWTracingCoordinates[n][2] < fieldTracingParameters.z_min
             ) {
                cellFWConnection[n] = TracingLineEndType::OUTSIDE;
                cellBWConnection[n] = TracingLineEndType::OUTSIDE;

--- a/fieldtracing/fieldtracing.h
+++ b/fieldtracing/fieldtracing.h
@@ -101,6 +101,12 @@ namespace FieldTracing {
       Real fluxrope_max_curvature_radii_to_trace;
       Real fluxrope_max_curvature_radii_extent;
       Real innerBoundaryRadius=0; /*!< If non-zero this will be used to determine CLOSED field lines. */
+      Real x_min; /*!< No tracing for x < this value. */
+      Real y_min; /*!< No tracing for y < this value. */
+      Real z_min; /*!< No tracing for z < this value. */
+      Real x_max; /*!< No tracing for x > this value. */
+      Real y_max; /*!< No tracing for y > this value. */
+      Real z_max; /*!< No tracing for z > this value. */
    };
    
    extern FieldTracingParameters fieldTracingParameters;

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -1031,12 +1031,12 @@ void Parameters::getParameters() {
    RP::get("fieldtracing.max_allowed_x", FieldTracing::fieldTracingParameters.x_max);
    RP::get("fieldtracing.max_allowed_y", FieldTracing::fieldTracingParameters.y_max);
    RP::get("fieldtracing.max_allowed_z", FieldTracing::fieldTracingParameters.z_max);
-   FieldTracing::fieldTracingParameters.x_min = max(FieldTracing::fieldTracingParameters.x_min, P::xmin + 4.0*P::dx_ini);
-   FieldTracing::fieldTracingParameters.y_min = max(FieldTracing::fieldTracingParameters.y_min, P::ymin + 4.0*P::dy_ini);
-   FieldTracing::fieldTracingParameters.z_min = max(FieldTracing::fieldTracingParameters.z_min, P::zmin + 4.0*P::dz_ini);
-   FieldTracing::fieldTracingParameters.x_max = min(FieldTracing::fieldTracingParameters.x_max, P::xmax - 4.0*P::dx_ini);
-   FieldTracing::fieldTracingParameters.y_max = min(FieldTracing::fieldTracingParameters.y_max, P::ymax - 4.0*P::dy_ini);
-   FieldTracing::fieldTracingParameters.z_max = min(FieldTracing::fieldTracingParameters.z_max, P::zmax - 4.0*P::dz_ini);
+   FieldTracing::fieldTracingParameters.x_min = max((double)FieldTracing::fieldTracingParameters.x_min, P::xmin + 4.0*P::dx_ini);
+   FieldTracing::fieldTracingParameters.y_min = max((double)FieldTracing::fieldTracingParameters.y_min, P::ymin + 4.0*P::dy_ini);
+   FieldTracing::fieldTracingParameters.z_min = max((double)FieldTracing::fieldTracingParameters.z_min, P::zmin + 4.0*P::dz_ini);
+   FieldTracing::fieldTracingParameters.x_max = min((double)FieldTracing::fieldTracingParameters.x_max, P::xmax - 4.0*P::dx_ini);
+   FieldTracing::fieldTracingParameters.y_max = min((double)FieldTracing::fieldTracingParameters.y_max, P::ymax - 4.0*P::dy_ini);
+   FieldTracing::fieldTracingParameters.z_max = min((double)FieldTracing::fieldTracingParameters.z_max, P::zmax - 4.0*P::dz_ini);
 
    if(tracerString == "Euler") {
       FieldTracing::fieldTracingParameters.tracingMethod = FieldTracing::Euler;

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -519,6 +519,12 @@ bool P::addParameters() {
    RP::add("fieldtracing.use_reconstruction_cache", "Use the cache to store reconstruction coefficients. (0: don't, 1: use)", 0);
    RP::add("fieldtracing.fluxrope_max_curvature_radii_to_trace", "Maximum number of seedpoint curvature radii to trace forward and backward from each DCCRG cell to find flux ropes", 10);
    RP::add("fieldtracing.fluxrope_max_curvature_radii_extent", "Maximum extent in seedpoint curvature radii from the seed a field line is allowed to extend to be counted as a flux rope", 2);
+   RP::add("fieldtracing.min_allowed_x", "Trace for x coordinates larger than this limit (in m).", -LARGE_REAL);
+   RP::add("fieldtracing.min_allowed_y", "Trace for y coordinates larger than this limit (in m).", -LARGE_REAL);
+   RP::add("fieldtracing.min_allowed_z", "Trace for z coordinates larger than this limit (in m).", -LARGE_REAL);
+   RP::add("fieldtracing.max_allowed_x", "Trace for x coordinates smaller than this limit (in m).", LARGE_REAL);
+   RP::add("fieldtracing.max_allowed_y", "Trace for y coordinates smaller than this limit (in m).", LARGE_REAL);
+   RP::add("fieldtracing.max_allowed_z", "Trace for z coordinates smaller than this limit (in m).", LARGE_REAL);
 
    return true;
 }
@@ -1019,6 +1025,18 @@ void Parameters::getParameters() {
    RP::get("fieldtracing.use_reconstruction_cache", FieldTracing::fieldTracingParameters.useCache);
    RP::get("fieldtracing.fluxrope_max_curvature_radii_to_trace", FieldTracing::fieldTracingParameters.fluxrope_max_curvature_radii_to_trace);
    RP::get("fieldtracing.fluxrope_max_curvature_radii_extent", FieldTracing::fieldTracingParameters.fluxrope_max_curvature_radii_extent);
+   RP::get("fieldtracing.min_allowed_x", FieldTracing::fieldTracingParameters.x_min);
+   RP::get("fieldtracing.min_allowed_y", FieldTracing::fieldTracingParameters.y_min);
+   RP::get("fieldtracing.min_allowed_z", FieldTracing::fieldTracingParameters.z_min);
+   RP::get("fieldtracing.max_allowed_x", FieldTracing::fieldTracingParameters.x_max);
+   RP::get("fieldtracing.max_allowed_y", FieldTracing::fieldTracingParameters.y_max);
+   RP::get("fieldtracing.max_allowed_z", FieldTracing::fieldTracingParameters.z_max);
+   FieldTracing::fieldTracingParameters.x_min = max(FieldTracing::fieldTracingParameters.x_min, P::xmin + 4.0*P::dx_ini);
+   FieldTracing::fieldTracingParameters.y_min = max(FieldTracing::fieldTracingParameters.y_min, P::ymin + 4.0*P::dy_ini);
+   FieldTracing::fieldTracingParameters.z_min = max(FieldTracing::fieldTracingParameters.z_min, P::zmin + 4.0*P::dz_ini);
+   FieldTracing::fieldTracingParameters.x_max = min(FieldTracing::fieldTracingParameters.x_max, P::xmax - 4.0*P::dx_ini);
+   FieldTracing::fieldTracingParameters.y_max = min(FieldTracing::fieldTracingParameters.y_max, P::ymax - 4.0*P::dy_ini);
+   FieldTracing::fieldTracingParameters.z_max = min(FieldTracing::fieldTracingParameters.z_max, P::zmax - 4.0*P::dz_ini);
 
    if(tracerString == "Euler") {
       FieldTracing::fieldTracingParameters.tracingMethod = FieldTracing::Euler;


### PR DESCRIPTION
Introduce cfg parameters to limit the volume of field tracing within x/y/z min/max. Needed to salvage tracing in certain production run.