### PR TITLE
Add SIGTERM signal handler, for slurm preemption.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ COMPFLAGS += -DACC_SEMILAG_PQM -DTRANS_SEMILAG_PPM
 #May cause problems
 #COMPFLAGS += -DCATCH_FPE
 
+#Add -DCATCH_SIGTERM to make the simulation bail out gracefully on SIGTERM (for
+# example on slurm preemption)
+COMPFLAGS += -DCATCH_SIGTERM
+
 #//////////////////////////////////////////////////////
 # The rest of this file users shouldn't need to change
 #//////////////////////////////////////////////////////

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -94,9 +94,9 @@ bool globalflags::ionosphereJustSolved = false;
 // This implementation instead attempts to write a restart file and then quit,
 // to work nicely with slurm's job preemption mechanism.
 void termhandler(int sig_num) {
-   logFile << "Caught SIGTERM. Initiating bailout." << endl << flush;
+   logFile << "Caught SIGTERM. Writing recover and initiating bailout." << endl << flush;
    globalflags::bailingOut = 1;
-   globalflags::writeRestart = 1;
+   globalflags::writeRecover = 1;
 }
 #endif
 


### PR DESCRIPTION
When preempting, slurm sends a SIGTERM signal and gives the process two minutes time to gracefully terminate itself. Writing a restart immediately might work in that situation.

If the university IT department actually wants to take slurm preemption into use, we better be prepared. :)

Tested (by hand) with a small testpackage job.