### PR TITLE
Fsgrid testing and restructuring

### DIFF
--- a/backgroundfield/backgroundfield.cpp
+++ b/backgroundfield/backgroundfield.cpp
@@ -71,10 +71,7 @@ void setBackgroundField(
             for (FsGridTools::FsIndex_t x = 0; x < localSize[0]; ++x) {
                phiprof::Timer loopTopTimer {loopTopId};
                std::array<double, 3> start = BgBGrid.getPhysicalCoords(x, y, z);
-               double dx[3];
-               dx[0] = BgBGrid.DX;
-               dx[1] = BgBGrid.DY;
-               dx[2] = BgBGrid.DZ;
+               const auto& dx = BgBGrid.getGridSpacing();
                double end[3];
                end[0]=start[0]+dx[0];
                end[1]=start[1]+dx[1];

--- a/backgroundfield/backgroundfield.h
+++ b/backgroundfield/backgroundfield.h
@@ -108,10 +108,7 @@ template<long unsigned int numFields> void setPerturbedField(
       for (FsGridTools::FsIndex_t y = 0; y < localSize[1]; ++y) {
          for (FsGridTools::FsIndex_t x = 0; x < localSize[0]; ++x) {
             std::array<double, 3> start = BGrid.getPhysicalCoords(x, y, z);
-            double dx[3];
-            dx[0] = BGrid.DX;
-            dx[1] = BGrid.DY;
-            dx[2] = BGrid.DZ;
+            const auto dx = BGrid.getGridSpacing();
 
             //Face averages
             for(uint fComponent=0; fComponent<3; fComponent++){

--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -1019,7 +1019,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdy) / dPerBGrid.DY;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdy) / dPerBGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -1045,7 +1045,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdz) / dPerBGrid.DZ;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdz) / dPerBGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1071,7 +1071,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydx) / dPerBGrid.DX;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydx) / dPerBGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -1097,7 +1097,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydz) / dPerBGrid.DZ;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydz) / dPerBGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1123,7 +1123,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdx) / dPerBGrid.DX;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdx) / dPerBGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -1149,7 +1149,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdy) / dPerBGrid.DY;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdy) / dPerBGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -1175,7 +1175,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdyy) / dPerBGrid.DY / dPerBGrid.DY;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdyy) / dPerBGrid.getGridSpacing()[1] /
+                             dPerBGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -1201,7 +1202,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdzz) / dPerBGrid.DZ / dPerBGrid.DZ;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdzz) / dPerBGrid.getGridSpacing()[2] /
+                             dPerBGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1227,7 +1229,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdyz) / dPerBGrid.DY / dPerBGrid.DZ;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdyz) / dPerBGrid.getGridSpacing()[1] /
+                             dPerBGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1253,7 +1256,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydxx) / dPerBGrid.DX / dPerBGrid.DX;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydxx) / dPerBGrid.getGridSpacing()[0] /
+                             dPerBGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -1279,7 +1283,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydzz) / dPerBGrid.DZ / dPerBGrid.DZ;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydzz) / dPerBGrid.getGridSpacing()[2] /
+                             dPerBGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1305,7 +1310,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydxz) / dPerBGrid.DX / dPerBGrid.DZ;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydxz) / dPerBGrid.getGridSpacing()[0] /
+                             dPerBGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1331,7 +1337,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdxx) / dPerBGrid.DX / dPerBGrid.DX;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdxx) / dPerBGrid.getGridSpacing()[0] /
+                             dPerBGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -1357,7 +1364,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdyy) / dPerBGrid.DY / dPerBGrid.DY;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdyy) / dPerBGrid.getGridSpacing()[1] /
+                             dPerBGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -1383,7 +1391,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdxy) / dPerBGrid.DX / dPerBGrid.DY;
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdxy) / dPerBGrid.getGridSpacing()[0] /
+                             dPerBGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -1410,7 +1419,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhomdx) / dMomentsGrid.DX;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhomdx) /
+                             dMomentsGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -1436,7 +1446,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhomdy) / dMomentsGrid.DY;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhomdy) /
+                             dMomentsGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -1462,7 +1473,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhomdz) / dMomentsGrid.DZ;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhomdz) /
+                             dMomentsGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1488,7 +1500,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhoqdx) / dMomentsGrid.DX;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhoqdx) /
+                             dMomentsGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -1514,7 +1527,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhoqdy) / dMomentsGrid.DY;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhoqdy) /
+                             dMomentsGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -1540,7 +1554,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhoqdz) / dMomentsGrid.DZ;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhoqdz) /
+                             dMomentsGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1566,7 +1581,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp11dx) / dMomentsGrid.DX;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp11dx) /
+                             dMomentsGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -1592,7 +1608,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp11dy) / dMomentsGrid.DY;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp11dy) /
+                             dMomentsGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -1618,7 +1635,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp11dz) / dMomentsGrid.DZ;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp11dz) /
+                             dMomentsGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1644,7 +1662,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp22dx) / dMomentsGrid.DX;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp22dx) /
+                             dMomentsGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -1670,7 +1689,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp22dy) / dMomentsGrid.DY;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp22dy) /
+                             dMomentsGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -1696,7 +1716,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp22dz) / dMomentsGrid.DZ;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp22dz) /
+                             dMomentsGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1722,7 +1743,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp33dx) / dMomentsGrid.DX;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp33dx) /
+                             dMomentsGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -1748,7 +1770,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp33dy) / dMomentsGrid.DY;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp33dy) /
+                             dMomentsGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -1774,7 +1797,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp33dz) / dMomentsGrid.DZ;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp33dz) /
+                             dMomentsGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1800,7 +1824,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVxdx) / dMomentsGrid.DX;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVxdx) / dMomentsGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -1826,7 +1850,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVxdy) / dMomentsGrid.DY;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVxdy) / dMomentsGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -1852,7 +1876,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVxdz) / dMomentsGrid.DZ;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVxdz) / dMomentsGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1878,7 +1902,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVydx) / dMomentsGrid.DX;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVydx) / dMomentsGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -1904,7 +1928,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVydy) / dMomentsGrid.DY;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVydy) / dMomentsGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -1930,7 +1954,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVydz) / dMomentsGrid.DZ;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVydz) / dMomentsGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -1956,7 +1980,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVzdx) / dMomentsGrid.DX;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVzdx) / dMomentsGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -1982,7 +2006,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVzdy) / dMomentsGrid.DY;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVzdy) / dMomentsGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -2008,7 +2032,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVzdz) / dMomentsGrid.DZ;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVzdz) / dMomentsGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -2034,7 +2058,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dPedx) / dMomentsGrid.DX;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dPedx) / dMomentsGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -2060,7 +2084,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dPedy) / dMomentsGrid.DY;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dPedy) / dMomentsGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -2086,7 +2110,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dPedz) / dMomentsGrid.DZ;
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dPedz) / dMomentsGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -2113,7 +2137,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBXVOLdx) / BgBGrid.DX;
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBXVOLdx) / BgBGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -2139,7 +2163,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBXVOLdy) / BgBGrid.DY;
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBXVOLdy) / BgBGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -2165,7 +2189,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBXVOLdz) / BgBGrid.DZ;
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBXVOLdz) / BgBGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -2191,7 +2215,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBYVOLdx) / BgBGrid.DX;
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBYVOLdx) / BgBGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -2217,7 +2241,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBYVOLdy) / BgBGrid.DY;
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBYVOLdy) / BgBGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -2244,7 +2268,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBYVOLdz) / BgBGrid.DZ;
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBYVOLdz) / BgBGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -2270,7 +2294,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBZVOLdx) / BgBGrid.DX;
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBZVOLdx) / BgBGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -2296,7 +2320,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBZVOLdy) / BgBGrid.DY;
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBZVOLdy) / BgBGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -2322,7 +2346,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBZVOLdz) / BgBGrid.DZ;
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBZVOLdz) / BgBGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -2361,7 +2385,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBxdy) / technicalGrid.DY;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBxdy) / technicalGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -2388,7 +2412,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBxdz) / technicalGrid.DZ;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBxdz) / technicalGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -2415,7 +2439,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBydx) / technicalGrid.DX;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBydx) / technicalGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -2442,7 +2466,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBydz) / technicalGrid.DZ;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBydz) / technicalGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -2469,7 +2493,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBzdx) / technicalGrid.DX;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBzdx) / technicalGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -2496,7 +2520,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBzdy) / technicalGrid.DY;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBzdy) / technicalGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -2523,7 +2547,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBXVOLdx) / technicalGrid.DX;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBXVOLdx) /
+                             technicalGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -2550,7 +2575,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBXVOLdy) / technicalGrid.DY;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBXVOLdy) /
+                             technicalGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -2577,7 +2603,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBXVOLdz) / technicalGrid.DZ;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBXVOLdz) /
+                             technicalGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -2604,7 +2631,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBYVOLdx) / technicalGrid.DX;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBYVOLdx) /
+                             technicalGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -2631,7 +2659,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBYVOLdy) / technicalGrid.DY;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBYVOLdy) /
+                             technicalGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -2658,7 +2687,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBYVOLdz) / technicalGrid.DZ;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBYVOLdz) /
+                             technicalGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -2685,7 +2715,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBZVOLdx) / technicalGrid.DX;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBZVOLdx) /
+                             technicalGrid.getGridSpacing()[0];
                       }
                    }
                 }
@@ -2712,7 +2743,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBZVOLdy) / technicalGrid.DY;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBZVOLdy) /
+                             technicalGrid.getGridSpacing()[1];
                       }
                    }
                 }
@@ -2739,7 +2771,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                    for (int y = 0; y < gridSize[1]; y++) {
                       for (int x = 0; x < gridSize[0]; x++) {
                          retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
-                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBZVOLdz) / technicalGrid.DZ;
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBZVOLdz) /
+                             technicalGrid.getGridSpacing()[2];
                       }
                    }
                 }
@@ -2866,7 +2899,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                 FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
                 FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
                 const auto& gridSize = technicalGrid.getLocalSize();
-                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2], technicalGrid.DX);
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2], technicalGrid.getGridSpacing()[0]);
                 return retval;
              }));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$\\delta X_\\mathrm{fg}$","1.0");
@@ -2883,7 +2916,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                 FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
                 FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
                 const auto& gridSize = technicalGrid.getLocalSize();
-                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2], technicalGrid.DY);
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2], technicalGrid.getGridSpacing()[1]);
                 return retval;
              }));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$\\delta Y_\\mathrm{fg}$","1.0");
@@ -2900,7 +2933,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
                 FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
                 FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
                 const auto& gridSize = technicalGrid.getLocalSize();
-                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2], technicalGrid.DZ);
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2], technicalGrid.getGridSpacing()[2]);
                 return retval;
              }));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$\\delta Z_\\mathrm{fg}$","1.0");

--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -50,105 +50,108 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       for(auto& c : lowercase) c = tolower(c);
 
       if(P::systemWriteAllDROs || lowercase == "fg_b" || lowercase == "b") { // Bulk magnetic field at Yee-Lattice locations
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_b",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2] * 3);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
-
-               // Iterate through fsgrid cells and extract total magnetic field
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*BgBGrid.get(x,y,z))[fsgrids::BGBX]
-                           + (*perBGrid.get(x,y,z))[fsgrids::PERBX];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*BgBGrid.get(x,y,z))[fsgrids::BGBY]
-                           + (*perBGrid.get(x,y,z))[fsgrids::PERBY];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*BgBGrid.get(x,y,z))[fsgrids::BGBZ]
-                           + (*perBGrid.get(x,y,z))[fsgrids::PERBZ];
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                // Iterate through fsgrid cells and extract total magnetic field
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x)] =
+                             (*BgBGrid.get(x, y, z))[fsgrids::BGBX] + (*perBGrid.get(x, y, z))[fsgrids::PERBX];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 1] =
+                             (*BgBGrid.get(x, y, z))[fsgrids::BGBY] + (*perBGrid.get(x, y, z))[fsgrids::PERBY];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 2] =
+                             (*BgBGrid.get(x, y, z))[fsgrids::BGBZ] + (*perBGrid.get(x, y, z))[fsgrids::PERBZ];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T","$\\mathrm{T}$","$B_\\mathrm{fg}$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_backgroundb" || lowercase == "backgroundb" || lowercase == "fg_b_background") { // Static (typically dipole) magnetic field part
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_background",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_b_background",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2] * 3);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
-
-               // Iterate through fsgrid cells and extract background B
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*BgBGrid.get(x,y,z))[fsgrids::BGBX];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*BgBGrid.get(x,y,z))[fsgrids::BGBY];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*BgBGrid.get(x,y,z))[fsgrids::BGBZ];
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract background B
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x)] =
+                             (*BgBGrid.get(x, y, z))[fsgrids::BGBX];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 1] =
+                             (*BgBGrid.get(x, y, z))[fsgrids::BGBY];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 2] =
+                             (*BgBGrid.get(x, y, z))[fsgrids::BGBZ];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size() - 1, "T", "$\\mathrm{T}$", "$B_\\mathrm{bg,fg}$", "1.0");
          if(!P::systemWriteAllDROs) {
             continue;
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_backgroundbvol" || lowercase == "backgroundbvol" || lowercase == "fg_b_background_vol") { // Static (typically dipole) magnetic field part, volume-averaged
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_background_vol",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_b_background_vol",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2] * 3);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
-
-               // Iterate through fsgrid cells and extract total BVOL
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*BgBGrid.get(x,y,z))[fsgrids::BGBXVOL];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*BgBGrid.get(x,y,z))[fsgrids::BGBYVOL];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*BgBGrid.get(x,y,z))[fsgrids::BGBZVOL];
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                // Iterate through fsgrid cells and extract total BVOL
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x)] =
+                             (*BgBGrid.get(x, y, z))[fsgrids::BGBXVOL];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 1] =
+                             (*BgBGrid.get(x, y, z))[fsgrids::BGBYVOL];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 2] =
+                             (*BgBGrid.get(x, y, z))[fsgrids::BGBZVOL];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T","$\\mathrm{T}$","$B_\\mathrm{bg,vol,fg}$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -156,68 +159,72 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
 
       if(P::systemWriteAllDROs || lowercase == "fg_perturbedb" || lowercase == "perturbedb" || lowercase == "fg_b_perturbed") { // Fluctuating magnetic field part
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_perturbed",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_b_perturbed",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2] * 3);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
-
-               // Iterate through fsgrid cells and extract values
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*perBGrid.get(x,y,z))[fsgrids::PERBX];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*perBGrid.get(x,y,z))[fsgrids::PERBY];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*perBGrid.get(x,y,z))[fsgrids::PERBZ];
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract values
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x)] =
+                             (*perBGrid.get(x, y, z))[fsgrids::PERBX];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 1] =
+                             (*perBGrid.get(x, y, z))[fsgrids::PERBY];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 2] =
+                             (*perBGrid.get(x, y, z))[fsgrids::PERBZ];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T","$\\mathrm{T}$","$B_\\mathrm{per,fg}$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_e" || lowercase == "e") { // Bulk electric field at Yee-lattice locations
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_e",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_e",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2] * 3);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
-
-               // Iterate through fsgrid cells and extract E values
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*EGrid.get(x,y,z))[fsgrids::EX];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*EGrid.get(x,y,z))[fsgrids::EY];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*EGrid.get(x,y,z))[fsgrids::EZ];
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract E values
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x)] =
+                             (*EGrid.get(x, y, z))[fsgrids::EX];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 1] =
+                             (*EGrid.get(x, y, z))[fsgrids::EY];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 2] =
+                             (*EGrid.get(x, y, z))[fsgrids::EZ];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"V/m","$\\mathrm{V}\\,\\mathrm{m}^{-1}$","$E$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -238,32 +245,32 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_rhom") { // Overall mass density (summed over all populations)
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rhom",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_rhom",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               // Iterate through fsgrid cells and extract rho valuesg
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = (*momentsGrid.get(x,y,z))[fsgrids::RHOM];
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract rho valuesg
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             (*momentsGrid.get(x, y, z))[fsgrids::RHOM];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"kg/m^3","$\\mathrm{kg}\\,\\mathrm{m}^{-3}$","$\\rho_\\mathrm{m}$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -277,32 +284,32 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_rhoq") { // Overall charge density (summed over all populations)
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rhoq",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_rhoq",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               // Iterate through fsgrid cells and extract charge density
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = (*momentsGrid.get(x,y,z))[fsgrids::RHOQ];
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract charge density
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             (*momentsGrid.get(x, y, z))[fsgrids::RHOQ];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"C/m^3","$\\mathrm{C}\\,\\mathrm{m}^{-3}$","$\\rho_\\mathrm{q}$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -328,34 +335,36 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_v") { // Overall effective bulk density defining the center-of-mass frame from all populations
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_v",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_v",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2] * 3);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
-
-               // Iterate through fsgrid cells and extract bulk Velocity
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*momentsGrid.get(x,y,z))[fsgrids::VX];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*momentsGrid.get(x,y,z))[fsgrids::VY];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*momentsGrid.get(x,y,z))[fsgrids::VZ];
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract bulk Velocity
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x)] =
+                             (*momentsGrid.get(x, y, z))[fsgrids::VX];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 1] =
+                             (*momentsGrid.get(x, y, z))[fsgrids::VY];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 2] =
+                             (*momentsGrid.get(x, y, z))[fsgrids::VZ];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"m/s","$\\mathrm{m}\\,\\mathrm{s}^{-1}$","$V$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -547,32 +556,32 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "maxfieldsdt" || lowercase == "fg_maxfieldsdt" || lowercase == "fg_maxdt_fieldsolver") {
          // Maximum timestep constraint as calculated by the fieldsolver
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_maxdt_fieldsolver",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_maxdt_fieldsolver",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               // Iterate through fsgrid cells and extract field solver timestep limit
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.get(x,y,z)->maxFsDt;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract field solver timestep limit
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             technicalGrid.get(x, y, z)->maxFsDt;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"s","$\\mathrm{s}$","$\\Delta t_\\mathrm{f,max}$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -588,23 +597,22 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "fsgridrank" || lowercase == "fg_rank") {
          // Map of spatial decomposition of the FsGrid into MPI ranks
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rank",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
-
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2],technicalGrid.getRank());
-               return retval;
-             }
-         ));
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_rank",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2], technicalGrid.getRank());
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"","","$\\mathrm{fGrid rank}$","");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -612,33 +620,32 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "fg_amr_level") {
          // Map of spatial decomposition of the FsGrid into MPI ranks
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_amr_level",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_amr_level",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               // Iterate through fsgrid cells and extract corresponding AMR level
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.get(x,y,z)->refLevel;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                // Iterate through fsgrid cells and extract corresponding AMR level
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             technicalGrid.get(x, y, z)->refLevel;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"","","$\\mathrm{fGrid rank}$","");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -654,32 +661,32 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "fsgridboundarytype" || lowercase == "fg_boundarytype") {
          // Type of boundarycells as stored in FSGrid
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_boundarytype",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_boundarytype",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               // Iterate through fsgrid cells and extract boundary flag
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.get(x,y,z)->sysBoundaryFlag;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract boundary flag
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             technicalGrid.get(x, y, z)->sysBoundaryFlag;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"","","$\\mathrm{fGrid Boundary type}$","");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -695,32 +702,32 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "fsgridboundarylayer" || lowercase == "fg_boundarylayer") {
          // Type of boundarycells as stored in FSGrid
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_boundarylayer",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_boundarylayer",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               // Iterate through fsgrid cells and extract boundary layer
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.get(x,y,z)->sysBoundaryLayer;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract boundary layer
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             technicalGrid.get(x, y, z)->sysBoundaryLayer;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"","","$\\mathrm{fGrid Boundary layer}$","");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -767,34 +774,36 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_vole" || lowercase == "fg_e_vol" || lowercase == "fg_evol") {
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_e_vol",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_e_vol",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2] * 3);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
-
-               // Iterate through fsgrid cells and extract EVOL
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =  (*volGrid.get(x,y,z))[fsgrids::volfields::EXVOL];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*volGrid.get(x,y,z))[fsgrids::volfields::EYVOL];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*volGrid.get(x,y,z))[fsgrids::volfields::EZVOL];
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract EVOL
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x)] =
+                             (*volGrid.get(x, y, z))[fsgrids::volfields::EXVOL];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 1] =
+                             (*volGrid.get(x, y, z))[fsgrids::volfields::EYVOL];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 2] =
+                             (*volGrid.get(x, y, z))[fsgrids::volfields::EZVOL];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"V/m","$\\mathrm{V}\\,\\mathrm{m}^{-1}$","$E_\\mathrm{vol,fg}$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -803,32 +812,32 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(P::systemWriteAllDROs || lowercase == "halle" || lowercase == "fg_halle" || lowercase == "fg_e_hall") {
          for(int index=0; index<fsgrids::N_EHALL; index++) {
             std::string reducer_name = "fg_e_hall_" + std::to_string(index);
-            outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(reducer_name,[index](
-                         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                         FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                         FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                         FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                         FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                         FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                         FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                         FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+            outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+                reducer_name,
+                [index](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                        FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                        FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                        FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                        FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                        FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                        FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                        FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                        FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                        FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                   const auto& gridSize = technicalGrid.getLocalSize();
+                   std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-                  std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-                  std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-                  // Iterate through fsgrid cells and extract EHall
-                  for(int z=0; z<gridSize[2]; z++) {
-                     for(int y=0; y<gridSize[1]; y++) {
-                        for(int x=0; x<gridSize[0]; x++) {
-                           retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = (*EHallGrid.get(x,y,z))[index];
-                        }
-                     }
-                  }
-                  return retval;
-            }
-            ));
+                   // Iterate through fsgrid cells and extract EHall
+                   for (int z = 0; z < gridSize[2]; z++) {
+                      for (int y = 0; y < gridSize[1]; y++) {
+                         for (int x = 0; x < gridSize[0]; x++) {
+                            retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                                (*EHallGrid.get(x, y, z))[index];
+                         }
+                      }
+                   }
+                   return retval;
+                }));
             outputReducer->addMetadata(outputReducer->size()-1,"V/m","$\\mathrm{V}\\,\\mathrm{m}^{-1}$","$E_\\mathrm{Hall,"+std::to_string(index)+"}$","1.0");
          }
          if(!P::systemWriteAllDROs) {
@@ -852,37 +861,36 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_volb" || lowercase == "fg_bvol" || lowercase == "fg_b_vol") { // Static (typically dipole) magnetic field part
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_vol",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_b_vol",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2] * 3);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
-
-               // Iterate through fsgrid cells and extract total BVOL
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*BgBGrid.get(x,y,z))[fsgrids::BGBXVOL]
-                           + (*volGrid.get(x,y,z))[fsgrids::PERBXVOL];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*BgBGrid.get(x,y,z))[fsgrids::BGBYVOL]
-                           + (*volGrid.get(x,y,z))[fsgrids::PERBYVOL];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*BgBGrid.get(x,y,z))[fsgrids::BGBZVOL]
-                           + (*volGrid.get(x,y,z))[fsgrids::PERBZVOL];
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract total BVOL
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x)] =
+                             (*BgBGrid.get(x, y, z))[fsgrids::BGBXVOL] + (*volGrid.get(x, y, z))[fsgrids::PERBXVOL];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 1] =
+                             (*BgBGrid.get(x, y, z))[fsgrids::BGBYVOL] + (*volGrid.get(x, y, z))[fsgrids::PERBYVOL];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 2] =
+                             (*BgBGrid.get(x, y, z))[fsgrids::BGBZVOL] + (*volGrid.get(x, y, z))[fsgrids::PERBZVOL];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T","$\\mathrm{T}$","$B_\\mathrm{vol,fg}$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -912,33 +920,33 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "fg_pressure") {
          // Overall scalar pressure from all populations
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_pressure",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_pressure",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               // Iterate through fsgrid cells and extract boundary flag
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        auto& moments=(*momentsGrid.get(x,y,z));
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = 1./3. * (moments[fsgrids::P_11] + moments[fsgrids::P_22] + moments[fsgrids::P_33]);
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract boundary flag
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         auto& moments = (*momentsGrid.get(x, y, z));
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             1. / 3. * (moments[fsgrids::P_11] + moments[fsgrids::P_22] + moments[fsgrids::P_33]);
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa","$\\mathrm{Pa}$","$P_\\mathrm{fg}$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -992,1335 +1000,1334 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       // As of summer 2023 they are proper derivatives in DROs, unlike in the code where they are differences.
       // Search for "fg_derivs" to find the end of this block.
       if(P::systemWriteAllDROs || lowercase == "fg_derivs") {
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbxdy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdy) / dPerBGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdy) / dPerBGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{per,fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbxdz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdz) / dPerBGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdz) / dPerBGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{per,fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbydx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydx) / dPerBGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydx) / dPerBGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{per,fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbydz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydz) / dPerBGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydz) / dPerBGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{per,fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbzdx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdx) / dPerBGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdx) / dPerBGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{per,fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbzdy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdy) / dPerBGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdy) / dPerBGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{per,fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdyy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbxdyy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdyy) / dPerBGrid.DY / dPerBGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdyy) / dPerBGrid.DY / dPerBGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{X,\\mathrm{per,fg}} (\\Delta Y)^{-2}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdzz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbxdzz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdzz) / dPerBGrid.DZ / dPerBGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdzz) / dPerBGrid.DZ / dPerBGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{X,\\mathrm{per,fg}} (\\Delta Z)^{-2}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdyz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbxdyz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdyz) / dPerBGrid.DY / dPerBGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBxdyz) / dPerBGrid.DY / dPerBGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{X,\\mathrm{per,fg}} (\\Delta Y \\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydxx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbydxx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydxx) / dPerBGrid.DX / dPerBGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydxx) / dPerBGrid.DX / dPerBGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{Y,\\mathrm{per,fg}} (\\Delta X)^{-2}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydzz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbydzz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydzz) / dPerBGrid.DZ / dPerBGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydzz) / dPerBGrid.DZ / dPerBGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{Y,\\mathrm{per,fg}} (\\Delta Z)^{-2}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydxz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbydxz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydxz) / dPerBGrid.DX / dPerBGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBydxz) / dPerBGrid.DX / dPerBGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{Y,\\mathrm{per,fg}} (\\Delta X \\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdxx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbzdxx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdxx) / dPerBGrid.DX / dPerBGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdxx) / dPerBGrid.DX / dPerBGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{Z,\\mathrm{per,fg}} (\\Delta Z)^{-2}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdyy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbzdyy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdyy) / dPerBGrid.DY / dPerBGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdyy) / dPerBGrid.DY / dPerBGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{Z,\\mathrm{per,fg}} (\\Delta Y)^{-2}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdxy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbzdxy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdxy) / dPerBGrid.DX / dPerBGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dPerBGrid.get(x, y, z)->at(fsgrids::dperb::dPERBzdxy) / dPerBGrid.DX / dPerBGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{Z,\\mathrm{per,fg}} (\\Delta X \\Delta Y)^{-1}$","1.0");
 
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_drhomdx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhomdx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
-
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhomdx) / dMomentsGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhomdx) / dMomentsGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"kg/m^4","$\\mathrm{kg}\\mathrm{m}^{-4}$","$\\Delta \\rho_{m,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhomdy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_drhomdy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhomdy) / dMomentsGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhomdy) / dMomentsGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"kg/m^4","$\\mathrm{kg}\\mathrm{m}^{-4}$","$\\Delta \\rho_{m,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhomdz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_drhomdz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhomdz) / dMomentsGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhomdz) / dMomentsGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"kg/m^4","$\\mathrm{kg}\\mathrm{m}^{-4}$","$\\Delta \\rho_{m,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhoqdx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_drhoqdx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhoqdx) / dMomentsGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhoqdx) / dMomentsGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"C/m^4","$\\mathrm{C}\\mathrm{m}^{-4}$","$\\Delta \\rho_{q,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhoqdy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_drhoqdy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhoqdy) / dMomentsGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhoqdy) / dMomentsGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"C/m^4","$\\mathrm{C}\\mathrm{m}^{-4}$","$\\Delta \\rho_{q,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhoqdz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_drhoqdz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhoqdz) / dMomentsGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::drhoqdz) / dMomentsGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"C/m^4","$\\mathrm{C}\\mathrm{m}^{-4}$","$\\Delta \\rho_{q,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp11dx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dp11dx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp11dx) / dMomentsGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp11dx) / dMomentsGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{11,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp11dy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dp11dy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp11dy) / dMomentsGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp11dy) / dMomentsGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{11,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp11dz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dp11dz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp11dz) / dMomentsGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp11dz) / dMomentsGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{11,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp22dx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dp22dx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp22dx) / dMomentsGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp22dx) / dMomentsGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{22,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp22dy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dp22dy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp22dy) / dMomentsGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp22dy) / dMomentsGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{22,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp22dz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dp22dz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp22dz) / dMomentsGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp22dz) / dMomentsGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{22,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp33dx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dp33dx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp33dx) / dMomentsGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp33dx) / dMomentsGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{33,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp33dy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dp33dy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp33dy) / dMomentsGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp33dy) / dMomentsGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{33,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp33dz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dp33dz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp33dz) / dMomentsGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dp33dz) / dMomentsGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{33,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvxdx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dvxdx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVxdx) / dMomentsGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVxdx) / dMomentsGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{X,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvxdy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dvxdy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVxdy) / dMomentsGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVxdy) / dMomentsGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{X,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvxdz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dvxdz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVxdz) / dMomentsGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVxdz) / dMomentsGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{X,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvydx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dvydx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVydx) / dMomentsGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVydx) / dMomentsGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{Y,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvydy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dvydy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVydy) / dMomentsGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVydy) / dMomentsGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{Y,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvydz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dvydz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVydz) / dMomentsGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVydz) / dMomentsGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{Y,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvzdx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dvzdx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVzdx) / dMomentsGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVzdx) / dMomentsGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{Z,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvzdy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dvzdy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVzdy) / dMomentsGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVzdy) / dMomentsGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{Z,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvzdz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dvzdz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVzdz) / dMomentsGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dVzdz) / dMomentsGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{Z,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dpedx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dpedx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dPedx) / dMomentsGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dPedx) / dMomentsGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_\\mathrm{e,fg} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dpedy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dpedy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dPedy) / dMomentsGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dPedy) / dMomentsGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_\\mathrm{e,fg} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dpedz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dpedz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dPedz) / dMomentsGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             dMomentsGrid.get(x, y, z)->at(fsgrids::dmoments::dPedz) / dMomentsGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_\\mathrm{e,fg} (\\Delta Z)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxvoldx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbxvoldx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBXVOLdx) / BgBGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBXVOLdx) / BgBGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{per,vol,fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxvoldy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbxvoldy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBXVOLdy) / BgBGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBXVOLdy) / BgBGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{per,vol,fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxvoldz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbxvoldz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBXVOLdz) / BgBGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBXVOLdz) / BgBGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{per,vol,fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbyvoldx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbyvoldx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBYVOLdx) / BgBGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBYVOLdx) / BgBGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{per,vol,fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbyvoldy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbyvoldy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBYVOLdy) / BgBGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBYVOLdy) / BgBGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{per,vol,fg}} (\\Delta Y)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbyvoldz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbyvoldz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBYVOLdz) / BgBGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBYVOLdz) / BgBGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{per,vol,fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzvoldx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbzvoldx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBZVOLdx) / BgBGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBZVOLdx) / BgBGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{per,vol,fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzvoldy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbzvoldy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBZVOLdy) / BgBGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBZVOLdy) / BgBGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{per,vol,fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzvoldz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dperbzvoldz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBZVOLdz) / BgBGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             volGrid.get(x, y, z)->at(fsgrids::volfields::dPERBZVOLdz) / BgBGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{per,vol,fg}} (\\Delta Z)^{-1}$","1.0");
 
          if(!P::systemWriteAllDROs) {
@@ -2335,409 +2342,409 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       // They are derivatives in these DROs, not differences as in the code.
       // Search for "fg_derivs_b_background" to find the end of the block.
       if(P::systemWriteAllDROs || lowercase == "fg_derivs_b_background") { // includes all face and volume-averaged derivatives of BGB on fg
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxdy",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbxdy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBxdy) / technicalGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBxdy) / technicalGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{bg,fg}} (\\Delta Y)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxdz",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbxdz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBxdz) / technicalGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBxdz) / technicalGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{bg,fg}} (\\Delta Z)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbydx",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbydx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBydx) / technicalGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBydx) / technicalGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{bg,fg}} (\\Delta X)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbydz",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbydz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBydz) / technicalGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBydz) / technicalGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{bg,fg}} (\\Delta Z)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzdx",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbzdx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBzdx) / technicalGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBzdx) / technicalGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{bg,fg}} (\\Delta X)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzdy",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbzdy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBzdy) / technicalGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBzdy) / technicalGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{bg,fg}} (\\Delta Y)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxvoldx",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbxvoldx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBXVOLdx) / technicalGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBXVOLdx) / technicalGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{bg,vol,fg}} (\\Delta X)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxvoldy",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbxvoldy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBXVOLdy) / technicalGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBXVOLdy) / technicalGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{bg,vol,fg}} (\\Delta Y)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxvoldz",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbxvoldz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBXVOLdz) / technicalGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBXVOLdz) / technicalGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{bg,vol,fg}} (\\Delta Z)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbyvoldx",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbyvoldx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBYVOLdx) / technicalGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBYVOLdx) / technicalGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{bg,vol,fg}} (\\Delta X)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbyvoldy",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbyvoldy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBYVOLdy) / technicalGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBYVOLdy) / technicalGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{bg,vol,fg}} (\\Delta Y)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbyvoldz",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbyvoldz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBYVOLdz) / technicalGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBYVOLdz) / technicalGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{bg,vol,fg}} (\\Delta Z)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzvoldx",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbzvoldx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBZVOLdx) / technicalGrid.DX;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBZVOLdx) / technicalGrid.DX;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{bg,vol,fg}} (\\Delta X)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzvoldy",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbzvoldy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBZVOLdy) / technicalGrid.DY;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBZVOLdy) / technicalGrid.DY;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{bg,vol,fg}} (\\Delta Y)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzvoldz",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_derivatives/fg_dbgbzvoldz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBZVOLdz) / technicalGrid.DZ;
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             BgBGrid.get(x, y, z)->at(fsgrids::bgbfield::dBGBZVOLdz) / technicalGrid.DZ;
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{bg,vol,fg}} (\\Delta Z)^{-1}$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -2765,140 +2772,137 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_gridcoordinates") {
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_x",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_x",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               // Iterate through fsgrid cells and extract X coordinate
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.getPhysicalCoords(x,y,z)[0];
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract X coordinate
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             technicalGrid.getPhysicalCoords(x, y, z)[0];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$X_\\mathrm{fg}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_y",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_y",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               // Iterate through fsgrid cells and extract Y coordinate
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.getPhysicalCoords(x,y,z)[1];
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract Y coordinate
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             technicalGrid.getPhysicalCoords(x, y, z)[1];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$Y_\\mathrm{fg}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_z",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_z",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2]);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-
-               // Iterate through fsgrid cells and extract Z coordinate
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.getPhysicalCoords(x,y,z)[2];
-                     }
-                  }
-               }
-               return retval;
-         }
-         ));
+                // Iterate through fsgrid cells and extract Z coordinate
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[gridSize[1] * gridSize[0] * z + gridSize[0] * y + x] =
+                             technicalGrid.getPhysicalCoords(x, y, z)[2];
+                      }
+                   }
+                }
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$Z_\\mathrm{fg}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_dx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
-
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2], technicalGrid.DX);
-               return retval;
-         }
-         ));
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_dx",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2], technicalGrid.DX);
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$\\delta X_\\mathrm{fg}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_dy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
-
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2], technicalGrid.DY);
-               return retval;
-         }
-         ));
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_dy",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2], technicalGrid.DY);
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$\\delta Y_\\mathrm{fg}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_dz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
-
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2], technicalGrid.DZ);
-               return retval;
-         }
-         ));
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_dz",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2], technicalGrid.DZ);
+                return retval;
+             }));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$\\delta Z_\\mathrm{fg}$","1.0");
          if(!P::systemWriteAllDROs) {
             continue;
@@ -3565,33 +3569,35 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "fg_curvature") {
          Parameters::computeCurvature = true;
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_curvature",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(
+             "fg_curvature",
+             [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+                FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+                FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+                FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+                FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+                FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<double> {
+                const auto& gridSize = technicalGrid.getLocalSize();
+                std::vector<double> retval(gridSize[0] * gridSize[1] * gridSize[2] * 3);
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
-
-               for(int z=0; z<gridSize[2]; z++) {
-                  for(int y=0; y<gridSize[1]; y++) {
-                     for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*volGrid.get(x,y,z))[fsgrids::volfields::CURVATUREX];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*volGrid.get(x,y,z))[fsgrids::volfields::CURVATUREY];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*volGrid.get(x,y,z))[fsgrids::volfields::CURVATUREZ];
-                     }
-                  }
-               }
-               return retval;
-            }
-         ));
+                for (int z = 0; z < gridSize[2]; z++) {
+                   for (int y = 0; y < gridSize[1]; y++) {
+                      for (int x = 0; x < gridSize[0]; x++) {
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x)] =
+                             (*volGrid.get(x, y, z))[fsgrids::volfields::CURVATUREX];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 1] =
+                             (*volGrid.get(x, y, z))[fsgrids::volfields::CURVATUREY];
+                         retval[3 * (gridSize[1] * gridSize[0] * z + gridSize[0] * y + x) + 2] =
+                             (*volGrid.get(x, y, z))[fsgrids::volfields::CURVATUREZ];
+                      }
+                   }
+                }
+                return retval;
+             }));
          if(!P::systemWriteAllDROs) {
             continue;
          }

--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -151,7 +151,7 @@ namespace DRO {
       std::vector<double> varBuffer =
          lambda(perBGrid,EGrid,EHallGrid,EGradPeGrid,momentsGrid,dPerBGrid,dMomentsGrid,BgBGrid,volGrid,technicalGrid);
 
-      std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+      const auto& gridSize = technicalGrid.getLocalSize();
       int vectorSize;
 
       // Check if there is anything to write (eg, we are a non-FS process)

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -640,9 +640,16 @@ void calculateCurvature(
       rght_z_by /= rght_z_bnorm;
       rght_z_bz /= rght_z_bnorm;
 
-      vol->at(fsgrids::volfields::CURVATUREX) = bx * 0.5*(rght_x_bx-left_x_bx) / technicalGrid.DX + by * 0.5*(rght_y_bx-left_y_bx) / technicalGrid.DY + bz * 0.5*(rght_z_bx-left_z_bx) / technicalGrid.DZ;
-      vol->at(fsgrids::volfields::CURVATUREY) = bx * 0.5*(rght_x_by-left_x_by) / technicalGrid.DX + by * 0.5*(rght_y_by-left_y_by) / technicalGrid.DY + bz * 0.5*(rght_z_by-left_z_by) / technicalGrid.DZ;
-      vol->at(fsgrids::volfields::CURVATUREZ) = bx * 0.5*(rght_x_bz-left_x_bz) / technicalGrid.DX + by * 0.5*(rght_y_bz-left_y_bz) / technicalGrid.DY + bz * 0.5*(rght_z_bz-left_z_bz) / technicalGrid.DZ;
+      const auto& gridSpacing = technicalGrid.getGridSpacing();
+      vol->at(fsgrids::volfields::CURVATUREX) = bx * 0.5 * (rght_x_bx - left_x_bx) / gridSpacing[0] +
+                                                by * 0.5 * (rght_y_bx - left_y_bx) / gridSpacing[1] +
+                                                bz * 0.5 * (rght_z_bx - left_z_bx) / gridSpacing[2];
+      vol->at(fsgrids::volfields::CURVATUREY) = bx * 0.5 * (rght_x_by - left_x_by) / gridSpacing[0] +
+                                                by * 0.5 * (rght_y_by - left_y_by) / gridSpacing[1] +
+                                                bz * 0.5 * (rght_z_by - left_z_by) / gridSpacing[2];
+      vol->at(fsgrids::volfields::CURVATUREZ) = bx * 0.5 * (rght_x_bz - left_x_bz) / gridSpacing[0] +
+                                                by * 0.5 * (rght_y_bz - left_y_bz) / gridSpacing[1] +
+                                                bz * 0.5 * (rght_z_bz - left_z_bz) / gridSpacing[2];
    }
 }
 

--- a/fieldsolver/fs_common.cpp
+++ b/fieldsolver/fs_common.cpp
@@ -428,9 +428,10 @@ std::array<Real, 3> interpolateCurlB(
    std::array<Real,3> cell;
    std::array<int,3> fsc,lfsc;
    // Convert physical coordinate to cell index
-   cell[0] =  (x[0] - P::xmin) / technicalGrid.DX;
-   cell[1] =  (x[1] - P::ymin) / technicalGrid.DY;
-   cell[2] =  (x[2] - P::zmin) / technicalGrid.DZ;
+   const auto& gridSpacing = technicalGrid.getGridSpacing();
+   cell[0] = (x[0] - P::xmin) / gridSpacing[0];
+   cell[1] = (x[1] - P::ymin) / gridSpacing[1];
+   cell[2] = (x[2] - P::zmin) / gridSpacing[2];
    for(int c=0; c<3; c++) {
       fsc[c] = floor(cell[c]);
    }
@@ -469,13 +470,19 @@ std::array<Real, 3> interpolateCurlB(
 
             // Calc rotB
             std::array<Real, 3> rotB;
-            rotB[0] += (volgrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::dPERBZVOLdy)
-                  - volgrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::dPERBYVOLdz)) / volgrid.DX;
-            rotB[1] += (volgrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::dPERBXVOLdz)
-                  - volgrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::dPERBZVOLdx)) / volgrid.DX;
-            rotB[2] += (volgrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::dPERBYVOLdx)
-                  - volgrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::dPERBXVOLdy)) / volgrid.DX;
-
+            const auto& gridSpacing = volgrid.getGridSpacing();
+            rotB[0] +=
+                (volgrid.get(lfsc[0] + xoffset, lfsc[1] + yoffset, lfsc[2] + zoffset)->at(fsgrids::dPERBZVOLdy) -
+                 volgrid.get(lfsc[0] + xoffset, lfsc[1] + yoffset, lfsc[2] + zoffset)->at(fsgrids::dPERBYVOLdz)) /
+                gridSpacing[0];
+            rotB[1] +=
+                (volgrid.get(lfsc[0] + xoffset, lfsc[1] + yoffset, lfsc[2] + zoffset)->at(fsgrids::dPERBXVOLdz) -
+                 volgrid.get(lfsc[0] + xoffset, lfsc[1] + yoffset, lfsc[2] + zoffset)->at(fsgrids::dPERBZVOLdx)) /
+                gridSpacing[0];
+            rotB[2] +=
+                (volgrid.get(lfsc[0] + xoffset, lfsc[1] + yoffset, lfsc[2] + zoffset)->at(fsgrids::dPERBYVOLdx) -
+                 volgrid.get(lfsc[0] + xoffset, lfsc[1] + yoffset, lfsc[2] + zoffset)->at(fsgrids::dPERBXVOLdy)) /
+                gridSpacing[0];
          }
       }
    }

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -35,55 +35,56 @@ int getNumberOfCellsOnMaxRefLvl(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geomet
 Filter moments after feeding them to FsGrid to alleviate the staircase effect caused in AMR runs.
 This is using a 3D, 5-point stencil triangle kernel.
 */
-void filterMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-                           FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                           FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid) 
-{
-
-
+void filterMoments(FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+                   FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) {
 
    // Kernel Characteristics
-   constexpr int kernelOffset = 2;   // offset of 5 pointstencil 3D kernel => (floor(stencilWidth/2);)
-   constexpr Real inverseKernelSum = 1.0 / 729.0;   // the inverse of the total kernel's sum 
-   constexpr static Real kernel[5][5][5] ={
-                                 {{ 1 * inverseKernelSum,  2 * inverseKernelSum,  3 * inverseKernelSum,  2 * inverseKernelSum,  1 * inverseKernelSum},
-                                 { 2 * inverseKernelSum,  4 * inverseKernelSum,  6 * inverseKernelSum,  4 * inverseKernelSum,  2 * inverseKernelSum},
-                                 { 3 * inverseKernelSum,  6 * inverseKernelSum,  9 * inverseKernelSum,  6 * inverseKernelSum,  3 * inverseKernelSum},
-                                 { 2 * inverseKernelSum,  4 * inverseKernelSum,  6 * inverseKernelSum,  4 * inverseKernelSum,  2 * inverseKernelSum},
-                                 { 1 * inverseKernelSum,  2 * inverseKernelSum,  3 * inverseKernelSum,  2 * inverseKernelSum,  1 * inverseKernelSum}},
+   constexpr int kernelOffset = 2;                // offset of 5 pointstencil 3D kernel => (floor(stencilWidth/2);)
+   constexpr Real inverseKernelSum = 1.0 / 729.0; // the inverse of the total kernel's sum
+   constexpr Real kernel[5][5][5] = {
+       {{1 * inverseKernelSum, 2 * inverseKernelSum, 3 * inverseKernelSum, 2 * inverseKernelSum, 1 * inverseKernelSum},
+        {2 * inverseKernelSum, 4 * inverseKernelSum, 6 * inverseKernelSum, 4 * inverseKernelSum, 2 * inverseKernelSum},
+        {3 * inverseKernelSum, 6 * inverseKernelSum, 9 * inverseKernelSum, 6 * inverseKernelSum, 3 * inverseKernelSum},
+        {2 * inverseKernelSum, 4 * inverseKernelSum, 6 * inverseKernelSum, 4 * inverseKernelSum, 2 * inverseKernelSum},
+        {1 * inverseKernelSum, 2 * inverseKernelSum, 3 * inverseKernelSum, 2 * inverseKernelSum, 1 * inverseKernelSum}},
 
-                                 {{ 2 * inverseKernelSum,  4 * inverseKernelSum,  6 * inverseKernelSum,  4 * inverseKernelSum,  2 * inverseKernelSum},
-                                 { 4 * inverseKernelSum,  8 * inverseKernelSum, 12 * inverseKernelSum,  8 * inverseKernelSum,  4 * inverseKernelSum},
-                                 { 6 * inverseKernelSum, 12 * inverseKernelSum, 18 * inverseKernelSum, 12 * inverseKernelSum,  6 * inverseKernelSum},
-                                 { 4 * inverseKernelSum,  8 * inverseKernelSum, 12 * inverseKernelSum,  8 * inverseKernelSum,  4 * inverseKernelSum},
-                                 { 2 * inverseKernelSum,  4 * inverseKernelSum,  6 * inverseKernelSum,  4 * inverseKernelSum,  2 * inverseKernelSum}},
+       {{2 * inverseKernelSum, 4 * inverseKernelSum, 6 * inverseKernelSum, 4 * inverseKernelSum, 2 * inverseKernelSum},
+        {4 * inverseKernelSum, 8 * inverseKernelSum, 12 * inverseKernelSum, 8 * inverseKernelSum, 4 * inverseKernelSum},
+        {6 * inverseKernelSum, 12 * inverseKernelSum, 18 * inverseKernelSum, 12 * inverseKernelSum,
+         6 * inverseKernelSum},
+        {4 * inverseKernelSum, 8 * inverseKernelSum, 12 * inverseKernelSum, 8 * inverseKernelSum, 4 * inverseKernelSum},
+        {2 * inverseKernelSum, 4 * inverseKernelSum, 6 * inverseKernelSum, 4 * inverseKernelSum, 2 * inverseKernelSum}},
 
-                                 {{ 3 * inverseKernelSum,  6 * inverseKernelSum,  9 * inverseKernelSum,  6 * inverseKernelSum,  3 * inverseKernelSum},
-                                 { 6 * inverseKernelSum, 12 * inverseKernelSum, 18 * inverseKernelSum, 12 * inverseKernelSum,  6 * inverseKernelSum},
-                                 { 9 * inverseKernelSum, 18 * inverseKernelSum, 27 * inverseKernelSum, 18 * inverseKernelSum,  9 * inverseKernelSum},
-                                 { 6 * inverseKernelSum, 12 * inverseKernelSum, 18 * inverseKernelSum, 12 * inverseKernelSum,  6 * inverseKernelSum},
-                                 { 3 * inverseKernelSum,  6 * inverseKernelSum,  9 * inverseKernelSum,  6 * inverseKernelSum,  3 * inverseKernelSum}},
+       {{3 * inverseKernelSum, 6 * inverseKernelSum, 9 * inverseKernelSum, 6 * inverseKernelSum, 3 * inverseKernelSum},
+        {6 * inverseKernelSum, 12 * inverseKernelSum, 18 * inverseKernelSum, 12 * inverseKernelSum,
+         6 * inverseKernelSum},
+        {9 * inverseKernelSum, 18 * inverseKernelSum, 27 * inverseKernelSum, 18 * inverseKernelSum,
+         9 * inverseKernelSum},
+        {6 * inverseKernelSum, 12 * inverseKernelSum, 18 * inverseKernelSum, 12 * inverseKernelSum,
+         6 * inverseKernelSum},
+        {3 * inverseKernelSum, 6 * inverseKernelSum, 9 * inverseKernelSum, 6 * inverseKernelSum, 3 * inverseKernelSum}},
 
-                                 {{ 2 * inverseKernelSum,  4 * inverseKernelSum,  6 * inverseKernelSum,  4 * inverseKernelSum,  2 * inverseKernelSum},
-                                 { 4 * inverseKernelSum,  8 * inverseKernelSum, 12 * inverseKernelSum,  8 * inverseKernelSum,  4 * inverseKernelSum},
-                                 { 6 * inverseKernelSum, 12 * inverseKernelSum, 18 * inverseKernelSum, 12 * inverseKernelSum,  6 * inverseKernelSum},
-                                 { 4 * inverseKernelSum,  8 * inverseKernelSum, 12 * inverseKernelSum,  8 * inverseKernelSum,  4 * inverseKernelSum},
-                                 { 2 * inverseKernelSum,  4 * inverseKernelSum,  6 * inverseKernelSum,  4 * inverseKernelSum,  2 * inverseKernelSum}},
+       {{2 * inverseKernelSum, 4 * inverseKernelSum, 6 * inverseKernelSum, 4 * inverseKernelSum, 2 * inverseKernelSum},
+        {4 * inverseKernelSum, 8 * inverseKernelSum, 12 * inverseKernelSum, 8 * inverseKernelSum, 4 * inverseKernelSum},
+        {6 * inverseKernelSum, 12 * inverseKernelSum, 18 * inverseKernelSum, 12 * inverseKernelSum,
+         6 * inverseKernelSum},
+        {4 * inverseKernelSum, 8 * inverseKernelSum, 12 * inverseKernelSum, 8 * inverseKernelSum, 4 * inverseKernelSum},
+        {2 * inverseKernelSum, 4 * inverseKernelSum, 6 * inverseKernelSum, 4 * inverseKernelSum, 2 * inverseKernelSum}},
 
-                                 {{ 1 * inverseKernelSum,  2 * inverseKernelSum,  3 * inverseKernelSum,  2 * inverseKernelSum,  1 * inverseKernelSum},
-                                 { 2 * inverseKernelSum,  4 * inverseKernelSum,  6 * inverseKernelSum,  4 * inverseKernelSum,  2 * inverseKernelSum},
-                                 { 3 * inverseKernelSum,  6 * inverseKernelSum,  9 * inverseKernelSum,  6 * inverseKernelSum,  3 * inverseKernelSum},
-                                 { 2 * inverseKernelSum,  4 * inverseKernelSum,  6 * inverseKernelSum,  4 * inverseKernelSum,  2 * inverseKernelSum},
-                                 { 1 * inverseKernelSum,  2 * inverseKernelSum,  3 * inverseKernelSum,  2 * inverseKernelSum,  1 * inverseKernelSum}}
-                                 };
+       {{1 * inverseKernelSum, 2 * inverseKernelSum, 3 * inverseKernelSum, 2 * inverseKernelSum, 1 * inverseKernelSum},
+        {2 * inverseKernelSum, 4 * inverseKernelSum, 6 * inverseKernelSum, 4 * inverseKernelSum, 2 * inverseKernelSum},
+        {3 * inverseKernelSum, 6 * inverseKernelSum, 9 * inverseKernelSum, 6 * inverseKernelSum, 3 * inverseKernelSum},
+        {2 * inverseKernelSum, 4 * inverseKernelSum, 6 * inverseKernelSum, 4 * inverseKernelSum, 2 * inverseKernelSum},
+        {1 * inverseKernelSum, 2 * inverseKernelSum, 3 * inverseKernelSum, 2 * inverseKernelSum,
+         1 * inverseKernelSum}}};
 
    // Update momentsGrid Ghost Cells
-   momentsGrid.updateGhostCells(); 
+   momentsGrid.updateGhostCells();
 
-
-   // Get size of local domain and create swapGrid for filtering
-   const FsGridTools::FsIndex_t* mntDims = &momentsGrid.getLocalSize()[0];  
-   FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> swapGrid = momentsGrid;  //swap array 
+   // Get size of local domain
+   const auto& mntDims = momentsGrid.getLocalSize();
+   // Create a copy of momentsGrid data for filtering
+   std::vector<std::array<Real, fsgrids::moments::N_MOMENTS>> swapData(momentsGrid.getData());
 
    // Filtering Loop
    for (int blurPass = 0; blurPass < Parameters::maxFilteringPasses; blurPass++){
@@ -94,27 +95,24 @@ void filterMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
          for (FsGridTools::FsIndex_t j = 0; j < mntDims[1]; j++){
             for (FsGridTools::FsIndex_t i = 0; i < mntDims[0]; i++){
 
-               int refLevel = technicalGrid.get(i, j, k)->refLevel;
-               auto* swap {swapGrid.get(i, j, k)};
-
-               // Skip pass and copy value
+               const int refLevel = technicalGrid.get(i, j, k)->refLevel;
+               // Skip pass
                if (blurPass >= P::numPasses.at(refLevel) || technicalGrid.get(i, j, k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY) {
-                  *swap = *momentsGrid.get(i, j, k);
                   continue;
                }
 
-               // Set moments to zero before passing filter
-               for (int e = 0; e < fsgrids::moments::N_MOMENTS; ++e) {
-                  swap->at(e) = 0.0;
-               }
+               // Set Cell to zero before passing filter
+               auto& swap = swapData[momentsGrid.localIDFromLocalCoordinates(i, j, k)];
+               swap.fill(0.0);
 
                // Perform the blur
                for (int c=-kernelOffset; c<=kernelOffset; c++){
                   for (int b=-kernelOffset; b<=kernelOffset; b++){
                      for (int a=-kernelOffset; a<=kernelOffset; a++){
-                        const auto* cell {momentsGrid.get(i+a,j+b,k+c)};
+                        const auto* cell = momentsGrid.get(i + a, j + b, k + c);
+#pragma omp simd
                         for (int e = 0; e < fsgrids::moments::N_MOMENTS; ++e) {
-                           swap->at(e) += cell->at(e) * kernel[kernelOffset+a][kernelOffset+b][kernelOffset+c];
+                           swap.at(e) += cell->at(e) * kernel[kernelOffset + a][kernelOffset + b][kernelOffset + c];
                         } 
                      }
                   }
@@ -123,10 +121,9 @@ void filterMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
          }
       } //spatial loops
 
-      // Allows argument dependent lookup (ADL)
-      // i.e. use specialized swap if it exists, fall back on std
-      using std::swap;
-      swap(momentsGrid, swapGrid);
+      // Swap filtered data with momentsGrid old data
+      std::swap(momentsGrid.getData(), swapData);
+      // Update Ghost Cells
       momentsGrid.updateGhostCells();
    }
 }
@@ -221,7 +218,7 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
    //Filter Moments if this is a 3D AMR run.
   if (P::amrMaxSpatialRefLevel>0) { 
       phiprof::Timer filteringTimer {"AMR Filtering-Triangle-3D"};
-      filterMoments(mpiGrid,momentsGrid,technicalGrid);
+      filterMoments(momentsGrid, technicalGrid);
    }   
 }
 

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -83,47 +83,50 @@ void filterMoments(FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STEN
 
    // Get size of local domain
    const auto& mntDims = momentsGrid.getLocalSize();
+   auto& moments = momentsGrid.getData();
+   const auto& technical = technicalGrid.getData();
    // Create a copy of momentsGrid data for filtering
-   std::vector<std::array<Real, fsgrids::moments::N_MOMENTS>> swapData(momentsGrid.getData());
+   std::vector<std::array<Real, fsgrids::moments::N_MOMENTS>> blurred(moments.size());
 
    // Filtering Loop
-   for (int blurPass = 0; blurPass < Parameters::maxFilteringPasses; blurPass++){
-
+   for (auto blurPass = 0; blurPass < Parameters::maxFilteringPasses; blurPass++) {
       // Blurring Pass
       #pragma omp parallel for collapse(2)
-      for (FsGridTools::FsIndex_t k = 0; k < mntDims[2]; k++){
-         for (FsGridTools::FsIndex_t j = 0; j < mntDims[1]; j++){
-            for (FsGridTools::FsIndex_t i = 0; i < mntDims[0]; i++){
+      for (auto k = 0; k < mntDims[2]; k++) {
+         for (auto j = 0; j < mntDims[1]; j++) {
+            for (auto i = 0; i < mntDims[0]; i++) {
+               const auto localId = technicalGrid.localIDFromLocalCoordinates(i, j, k);
+               const auto refLevel = technical[localId].refLevel;
+               const auto flag = technical[localId].sysBoundaryFlag;
+               auto& blurCell = blurred[localId];
 
-               const int refLevel = technicalGrid.get(i, j, k)->refLevel;
-               // Skip pass
-               if (blurPass >= P::numPasses.at(refLevel) || technicalGrid.get(i, j, k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY) {
+               // Skip pass, set blurCell value equal to original
+               if (blurPass >= P::numPasses.at(refLevel) || flag != sysboundarytype::NOT_SYSBOUNDARY) {
+                  blurCell = moments[localId];
                   continue;
+               } else {
+                  // Set Cell to zero before passing filter
+                  blurCell.fill(0.0);
                }
 
-               // Set Cell to zero before passing filter
-               auto& swap = swapData[momentsGrid.localIDFromLocalCoordinates(i, j, k)];
-               swap.fill(0.0);
-
                // Perform the blur
-               for (int c=-kernelOffset; c<=kernelOffset; c++){
-                  for (int b=-kernelOffset; b<=kernelOffset; b++){
-                     for (int a=-kernelOffset; a<=kernelOffset; a++){
-                        const auto* cell = momentsGrid.get(i + a, j + b, k + c);
-#pragma omp simd
+               for (int c = -kernelOffset; c <= kernelOffset; c++) {
+                  for (int b = -kernelOffset; b <= kernelOffset; b++) {
+                     for (int a = -kernelOffset; a <= kernelOffset; a++) {
+                        const auto localId = technicalGrid.localIDFromLocalCoordinates(i + a, j + b, k + c);
+                        const auto& cell = moments[localId];
+			#pragma omp simd
                         for (int e = 0; e < fsgrids::moments::N_MOMENTS; ++e) {
-                           swap.at(e) += cell->at(e) * kernel[kernelOffset + a][kernelOffset + b][kernelOffset + c];
-                        } 
+                           blurCell[e] += cell[e] * kernel[kernelOffset + a][kernelOffset + b][kernelOffset + c];
+                        }
                      }
                   }
-               }//inner filtering loop
+               } // inner filtering loop
             }
          }
-      } //spatial loops
+      } // spatial loops
 
-      // Swap filtered data with momentsGrid old data
-      std::swap(momentsGrid.getData(), swapData);
-      // Update Ghost Cells
+      std::swap(moments, blurred);
       momentsGrid.updateGhostCells();
    }
 }

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -309,30 +309,49 @@ void getFieldsFromFsGrid(
             std::array<Real, fsgrids::volfields::N_VOL> * volcell = volumeFieldsGrid.get(fsgridCell);
             std::array<Real, fsgrids::bgbfield::N_BGB> * bgcell = BgBGrid.get(fsgridCell);
             std::array<Real, fsgrids::egradpe::N_EGRADPE> * egradpecell = EGradPeGrid.get(fsgridCell);	
-            std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dMomentscell = dMomentsGrid.get(fsgridCell);	
-            
+            std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dMomentscell = dMomentsGrid.get(fsgridCell);
+            const auto& gridSpacing = technicalGrid.getGridSpacing();
+
             // TODO consider pruning these and communicating only when required
             sendBuffer[ii].sums[FieldsToCommunicate::PERBXVOL] += volcell->at(fsgrids::volfields::PERBXVOL);
             sendBuffer[ii].sums[FieldsToCommunicate::PERBYVOL] += volcell->at(fsgrids::volfields::PERBYVOL);
             sendBuffer[ii].sums[FieldsToCommunicate::PERBZVOL] += volcell->at(fsgrids::volfields::PERBZVOL);
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBXVOLdx] += volcell->at(fsgrids::volfields::dPERBXVOLdx) / technicalGrid.DX;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBXVOLdy] += volcell->at(fsgrids::volfields::dPERBXVOLdy) / technicalGrid.DY;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBXVOLdz] += volcell->at(fsgrids::volfields::dPERBXVOLdz) / technicalGrid.DZ;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBYVOLdx] += volcell->at(fsgrids::volfields::dPERBYVOLdx) / technicalGrid.DX;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBYVOLdy] += volcell->at(fsgrids::volfields::dPERBYVOLdy) / technicalGrid.DY;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBYVOLdz] += volcell->at(fsgrids::volfields::dPERBYVOLdz) / technicalGrid.DZ;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBZVOLdx] += volcell->at(fsgrids::volfields::dPERBZVOLdx) / technicalGrid.DX;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBZVOLdy] += volcell->at(fsgrids::volfields::dPERBZVOLdy) / technicalGrid.DY;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBZVOLdz] += volcell->at(fsgrids::volfields::dPERBZVOLdz) / technicalGrid.DZ;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVxdx] += dMomentscell->at(fsgrids::dmoments::dVxdx) / technicalGrid.DX;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVxdy] += dMomentscell->at(fsgrids::dmoments::dVxdy) / technicalGrid.DY;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVxdz] += dMomentscell->at(fsgrids::dmoments::dVxdz) / technicalGrid.DZ;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVydx] += dMomentscell->at(fsgrids::dmoments::dVydx) / technicalGrid.DX;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVydy] += dMomentscell->at(fsgrids::dmoments::dVydy) / technicalGrid.DY;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVydz] += dMomentscell->at(fsgrids::dmoments::dVydz) / technicalGrid.DZ;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVzdx] += dMomentscell->at(fsgrids::dmoments::dVzdx) / technicalGrid.DX;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVzdy] += dMomentscell->at(fsgrids::dmoments::dVzdy) / technicalGrid.DY;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVzdz] += dMomentscell->at(fsgrids::dmoments::dVzdz) / technicalGrid.DZ;
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBXVOLdx] +=
+                volcell->at(fsgrids::volfields::dPERBXVOLdx) / gridSpacing[0];
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBXVOLdy] +=
+                volcell->at(fsgrids::volfields::dPERBXVOLdy) / gridSpacing[1];
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBXVOLdz] +=
+                volcell->at(fsgrids::volfields::dPERBXVOLdz) / gridSpacing[2];
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBYVOLdx] +=
+                volcell->at(fsgrids::volfields::dPERBYVOLdx) / gridSpacing[0];
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBYVOLdy] +=
+                volcell->at(fsgrids::volfields::dPERBYVOLdy) / gridSpacing[1];
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBYVOLdz] +=
+                volcell->at(fsgrids::volfields::dPERBYVOLdz) / gridSpacing[2];
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBZVOLdx] +=
+                volcell->at(fsgrids::volfields::dPERBZVOLdx) / gridSpacing[0];
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBZVOLdy] +=
+                volcell->at(fsgrids::volfields::dPERBZVOLdy) / gridSpacing[1];
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBZVOLdz] +=
+                volcell->at(fsgrids::volfields::dPERBZVOLdz) / gridSpacing[2];
+            sendBuffer[ii].sums[FieldsToCommunicate::dVxdx] +=
+                dMomentscell->at(fsgrids::dmoments::dVxdx) / gridSpacing[0];
+            sendBuffer[ii].sums[FieldsToCommunicate::dVxdy] +=
+                dMomentscell->at(fsgrids::dmoments::dVxdy) / gridSpacing[1];
+            sendBuffer[ii].sums[FieldsToCommunicate::dVxdz] +=
+                dMomentscell->at(fsgrids::dmoments::dVxdz) / gridSpacing[2];
+            sendBuffer[ii].sums[FieldsToCommunicate::dVydx] +=
+                dMomentscell->at(fsgrids::dmoments::dVydx) / gridSpacing[0];
+            sendBuffer[ii].sums[FieldsToCommunicate::dVydy] +=
+                dMomentscell->at(fsgrids::dmoments::dVydy) / gridSpacing[1];
+            sendBuffer[ii].sums[FieldsToCommunicate::dVydz] +=
+                dMomentscell->at(fsgrids::dmoments::dVydz) / gridSpacing[2];
+            sendBuffer[ii].sums[FieldsToCommunicate::dVzdx] +=
+                dMomentscell->at(fsgrids::dmoments::dVzdx) / gridSpacing[0];
+            sendBuffer[ii].sums[FieldsToCommunicate::dVzdy] +=
+                dMomentscell->at(fsgrids::dmoments::dVzdy) / gridSpacing[1];
+            sendBuffer[ii].sums[FieldsToCommunicate::dVzdz] +=
+                dMomentscell->at(fsgrids::dmoments::dVzdz) / gridSpacing[2];
             sendBuffer[ii].sums[FieldsToCommunicate::BGBXVOL] += bgcell->at(fsgrids::bgbfield::BGBXVOL);
             sendBuffer[ii].sums[FieldsToCommunicate::BGBYVOL] += bgcell->at(fsgrids::bgbfield::BGBYVOL);
             sendBuffer[ii].sums[FieldsToCommunicate::BGBZVOL] += bgcell->at(fsgrids::bgbfield::BGBZVOL);

--- a/fieldsolver/gridGlue.hpp
+++ b/fieldsolver/gridGlue.hpp
@@ -151,17 +151,17 @@ template <typename T, int stencil> void computeCoupling(dccrg::Dccrg<SpatialCell
       for (FsGridTools::FsIndex_t k=0; k<gridDims[2]; k++) {
          for (FsGridTools::FsIndex_t j=0; j<gridDims[1]; j++) {
             for (FsGridTools::FsIndex_t i=0; i<gridDims[0]; i++) {
-               const std::array<FsGridTools::FsIndex_t, 3> globalIndices = momentsGrid.getGlobalIndices(i,j,k);
+               const std::array<FsGridTools::FsSize_t, 3> globalIndices = momentsGrid.localToGlobal(i, j, k);
                const dccrg::Types<3>::indices_t  indices = {{(uint64_t)globalIndices[0],
                         (uint64_t)globalIndices[1],
                         (uint64_t)globalIndices[2]}}; //cast to avoid warnings
-         CellID dccrgCell = mpiGrid.get_existing_cell(indices, 0, mpiGrid.mapping.get_maximum_refinement_level());
-        
-         int process = mpiGrid.get_process(dccrgCell);
-         FsGridTools::LocalID fsgridLid = momentsGrid.LocalIDForCoords(i,j,k);
-         //int64_t  fsgridGid = momentsGrid.GlobalIDForCoords(i,j,k);
-         onFsgridMapRemoteProcessGlobal[process].insert(dccrgCell); //cells are ordered (sorted) in set
-         onFsgridMapCellsGlobal[dccrgCell].push_back(fsgridLid);
+               const CellID dccrgCell =
+                   mpiGrid.get_existing_cell(indices, 0, mpiGrid.mapping.get_maximum_refinement_level());
+
+               const int process = mpiGrid.get_process(dccrgCell);
+               const FsGridTools::LocalID fsgridLid = momentsGrid.localIDFromLocalCoordinates(i, j, k);
+               onFsgridMapRemoteProcessGlobal[process].insert(dccrgCell); // cells are ordered (sorted) in set
+               onFsgridMapCellsGlobal[dccrgCell].push_back(fsgridLid);
          }
       }
    }
@@ -169,11 +169,11 @@ template <typename T, int stencil> void computeCoupling(dccrg::Dccrg<SpatialCell
    // Compute where to send data and what to send
    for(uint64_t i=0; i< dccrgCells.size(); i++) {
       //compute to which processes this cell maps
-      std::vector<CellID> fsCells = mapDccrgIdToFsGridGlobalID(mpiGrid, dccrgCells[i]);
+      const std::vector<CellID> fsCells = mapDccrgIdToFsGridGlobalID(mpiGrid, dccrgCells[i]);
 
       //loop over fsgrid cells which this dccrg cell maps to
       for (auto const &fsCellID : fsCells) {
-         int process = momentsGrid.getTaskForGlobalID(fsCellID).first; //process on fsgrid
+         const int process = momentsGrid.getTaskForGlobalID(fsCellID); // process on fsgrid
          onDccrgMapRemoteProcessGlobal[process].insert(dccrgCells[i]); //add to map
       }    
    }

--- a/fieldsolver/ldz_electric_field.cpp
+++ b/fieldsolver/ldz_electric_field.cpp
@@ -174,12 +174,18 @@ void calculateWaveSpeedYZ(
    // for details.
    const Real vA2 = divideIfNonZero(Bmag2, pc::MU_0*rhom); // Alfven speed
    const Real vS2 = divideIfNonZero(p11+p22+p33, 2.0*rhom); // sound speed, adiabatic coefficient 3/2, P=1/3*trace in sound speed
-//   const Real vW = Parameters::ohmHallTerm > 0 ? divideIfNonZero(2.0*M_PI*vA2*pc::MASS_PROTON, perBGrid.DX*pc::CHARGE*sqrt(Bmag2)) : 0.0; // whistler speed
-   const Real vW = Parameters::ohmHallTerm > 0 ?
-      sqrt(vA2) * (1 + divideIfNonZero(2*M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, perBGrid.DX*perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)
-            / sqrt(1 + divideIfNonZero(  M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, perBGrid.DX*perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)))
-      : 0.0; // whistler speed
-   
+   //   const Real vW = Parameters::ohmHallTerm > 0 ? divideIfNonZero(2.0*M_PI*vA2*pc::MASS_PROTON,
+   //   perBGrid.getGridSpacing()[0]*pc::CHARGE*sqrt(Bmag2)) : 0.0; // whistler speed
+   const Real vW =
+       Parameters::ohmHallTerm > 0
+           ? sqrt(vA2) * (1 + divideIfNonZero(2 * M_PI * M_PI * pc::MASS_PROTON * pc::MASS_PROTON,
+                                              perBGrid.getGridSpacing()[0] * perBGrid.getGridSpacing()[0] * rhom *
+                                                  pc::CHARGE * pc::CHARGE * pc::MU_0) /
+                                  sqrt(1 + divideIfNonZero(M_PI * M_PI * pc::MASS_PROTON * pc::MASS_PROTON,
+                                                           perBGrid.getGridSpacing()[0] * perBGrid.getGridSpacing()[0] *
+                                                               rhom * pc::CHARGE * pc::CHARGE * pc::MU_0)))
+           : 0.0; // whistler speed
+
    ret_vA = sqrt(vA2);
    ret_vS = sqrt(vS2);
    ret_vW = vW;
@@ -297,12 +303,18 @@ void calculateWaveSpeedXZ(
    // for details.
    const Real vA2 = divideIfNonZero(Bmag2, pc::MU_0*rhom); // Alfven speed
    const Real vS2 = divideIfNonZero(p11+p22+p33, 2.0*rhom); // sound speed, adiabatic coefficient 3/2, P=1/3*trace in sound speed
-//   const Real vW = Parameters::ohmHallTerm > 0 ? divideIfNonZero(2.0*M_PI*vA2*pc::MASS_PROTON, perBGrid.DX*pc::CHARGE*sqrt(Bmag2)) : 0.0; // whistler speed
-   const Real vW = Parameters::ohmHallTerm > 0 ?
-      sqrt(vA2) * (1 + divideIfNonZero(2*M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, perBGrid.DX*perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)
-            / sqrt(1 + divideIfNonZero(  M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, perBGrid.DX*perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)))
-      : 0.0; // whistler speed
-   
+   //   const Real vW = Parameters::ohmHallTerm > 0 ? divideIfNonZero(2.0*M_PI*vA2*pc::MASS_PROTON,
+   //   perBGrid.getGridSpacing()[0]*pc::CHARGE*sqrt(Bmag2)) : 0.0; // whistler speed
+   const Real vW =
+       Parameters::ohmHallTerm > 0
+           ? sqrt(vA2) * (1 + divideIfNonZero(2 * M_PI * M_PI * pc::MASS_PROTON * pc::MASS_PROTON,
+                                              perBGrid.getGridSpacing()[0] * perBGrid.getGridSpacing()[0] * rhom *
+                                                  pc::CHARGE * pc::CHARGE * pc::MU_0) /
+                                  sqrt(1 + divideIfNonZero(M_PI * M_PI * pc::MASS_PROTON * pc::MASS_PROTON,
+                                                           perBGrid.getGridSpacing()[0] * perBGrid.getGridSpacing()[0] *
+                                                               rhom * pc::CHARGE * pc::CHARGE * pc::MU_0)))
+           : 0.0; // whistler speed
+
    ret_vA = sqrt(vA2);
    ret_vS = sqrt(vS2);
    ret_vW = vW;
@@ -420,12 +432,18 @@ void calculateWaveSpeedXY(
    // for details.
    const Real vA2 = divideIfNonZero(Bmag2, pc::MU_0*rhom); // Alfven speed
    const Real vS2 = divideIfNonZero(p11+p22+p33, 2.0*rhom); // sound speed, adiabatic coefficient 3/2, P=1/3*trace in sound speed
-//   const Real vW = Parameters::ohmHallTerm > 0 ? divideIfNonZero(2.0*M_PI*vA2*pc::MASS_PROTON, perBGrid.DX*pc::CHARGE*sqrt(Bmag2)) : 0.0; // whistler speed
-   const Real vW = Parameters::ohmHallTerm > 0 ?
-      sqrt(vA2) * (1 + divideIfNonZero(2*M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, perBGrid.DX*perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)
-            / sqrt(1 + divideIfNonZero(  M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, perBGrid.DX*perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)))
-      : 0.0; // whistler speed
-   
+   //   const Real vW = Parameters::ohmHallTerm > 0 ? divideIfNonZero(2.0*M_PI*vA2*pc::MASS_PROTON,
+   //   perBGrid.getGridSpacing()[0]*pc::CHARGE*sqrt(Bmag2)) : 0.0; // whistler speed
+   const Real vW =
+       Parameters::ohmHallTerm > 0
+           ? sqrt(vA2) * (1 + divideIfNonZero(2 * M_PI * M_PI * pc::MASS_PROTON * pc::MASS_PROTON,
+                                              perBGrid.getGridSpacing()[0] * perBGrid.getGridSpacing()[0] * rhom *
+                                                  pc::CHARGE * pc::CHARGE * pc::MU_0) /
+                                  sqrt(1 + divideIfNonZero(M_PI * M_PI * pc::MASS_PROTON * pc::MASS_PROTON,
+                                                           perBGrid.getGridSpacing()[0] * perBGrid.getGridSpacing()[0] *
+                                                               rhom * pc::CHARGE * pc::CHARGE * pc::MU_0)))
+           : 0.0; // whistler speed
+
    ret_vA = sqrt(vA2);
    ret_vS = sqrt(vS2);
    ret_vW = vW;
@@ -561,17 +579,16 @@ void calculateEdgeElectricFieldX(
 
    // Resistive term
    if (Parameters::resistivity > 0) {
-     Ex_SW += Parameters::resistivity *
-       sqrt((bgb_SW->at(fsgrids::bgbfield::BGBX)+perb_SW->at(fsgrids::bfield::PERBX))*
-            (bgb_SW->at(fsgrids::bgbfield::BGBX)+perb_SW->at(fsgrids::bfield::PERBX)) +
-            (bgb_SW->at(fsgrids::bgbfield::BGBY)+perb_SW->at(fsgrids::bfield::PERBY))*
-            (bgb_SW->at(fsgrids::bgbfield::BGBY)+perb_SW->at(fsgrids::bfield::PERBY)) +
-            (bgb_SW->at(fsgrids::bgbfield::BGBZ)+perb_SW->at(fsgrids::bfield::PERBZ))*
-            (bgb_SW->at(fsgrids::bgbfield::BGBZ)+perb_SW->at(fsgrids::bfield::PERBZ))
-           ) /
-       moments_SW->at(fsgrids::moments::RHOQ) /
-       physicalconstants::MU_0 *
-       (dperb_SW->at(fsgrids::dperb::dPERBzdy)/technicalGrid.DY - dperb_SW->at(fsgrids::dperb::dPERBydz)/technicalGrid.DZ);
+      Ex_SW += Parameters::resistivity *
+               sqrt((bgb_SW->at(fsgrids::bgbfield::BGBX) + perb_SW->at(fsgrids::bfield::PERBX)) *
+                        (bgb_SW->at(fsgrids::bgbfield::BGBX) + perb_SW->at(fsgrids::bfield::PERBX)) +
+                    (bgb_SW->at(fsgrids::bgbfield::BGBY) + perb_SW->at(fsgrids::bfield::PERBY)) *
+                        (bgb_SW->at(fsgrids::bgbfield::BGBY) + perb_SW->at(fsgrids::bfield::PERBY)) +
+                    (bgb_SW->at(fsgrids::bgbfield::BGBZ) + perb_SW->at(fsgrids::bfield::PERBZ)) *
+                        (bgb_SW->at(fsgrids::bgbfield::BGBZ) + perb_SW->at(fsgrids::bfield::PERBZ))) /
+               moments_SW->at(fsgrids::moments::RHOQ) / physicalconstants::MU_0 *
+               (dperb_SW->at(fsgrids::dperb::dPERBzdy) / technicalGrid.getGridSpacing()[1] -
+                dperb_SW->at(fsgrids::dperb::dPERBydz) / technicalGrid.getGridSpacing()[2]);
    }
    
    // Hall term
@@ -616,17 +633,16 @@ void calculateEdgeElectricFieldX(
    
    // Resistive term
    if (Parameters::resistivity > 0) {
-     Ex_SE += Parameters::resistivity *
-       sqrt((bgb_SE->at(fsgrids::bgbfield::BGBX)+perb_SE->at(fsgrids::bfield::PERBX))*
-            (bgb_SE->at(fsgrids::bgbfield::BGBX)+perb_SE->at(fsgrids::bfield::PERBX)) +
-            (bgb_SE->at(fsgrids::bgbfield::BGBY)+perb_SE->at(fsgrids::bfield::PERBY))*
-            (bgb_SE->at(fsgrids::bgbfield::BGBY)+perb_SE->at(fsgrids::bfield::PERBY)) +
-            (bgb_SE->at(fsgrids::bgbfield::BGBZ)+perb_SE->at(fsgrids::bfield::PERBZ))*
-            (bgb_SE->at(fsgrids::bgbfield::BGBZ)+perb_SE->at(fsgrids::bfield::PERBZ))
-           ) /
-       moments_SE->at(fsgrids::moments::RHOQ) /
-       physicalconstants::MU_0 *
-       (dperb_SE->at(fsgrids::dperb::dPERBzdy)/technicalGrid.DY - dperb_SE->at(fsgrids::dperb::dPERBydz)/technicalGrid.DZ);
+      Ex_SE += Parameters::resistivity *
+               sqrt((bgb_SE->at(fsgrids::bgbfield::BGBX) + perb_SE->at(fsgrids::bfield::PERBX)) *
+                        (bgb_SE->at(fsgrids::bgbfield::BGBX) + perb_SE->at(fsgrids::bfield::PERBX)) +
+                    (bgb_SE->at(fsgrids::bgbfield::BGBY) + perb_SE->at(fsgrids::bfield::PERBY)) *
+                        (bgb_SE->at(fsgrids::bgbfield::BGBY) + perb_SE->at(fsgrids::bfield::PERBY)) +
+                    (bgb_SE->at(fsgrids::bgbfield::BGBZ) + perb_SE->at(fsgrids::bfield::PERBZ)) *
+                        (bgb_SE->at(fsgrids::bgbfield::BGBZ) + perb_SE->at(fsgrids::bfield::PERBZ))) /
+               moments_SE->at(fsgrids::moments::RHOQ) / physicalconstants::MU_0 *
+               (dperb_SE->at(fsgrids::dperb::dPERBzdy) / technicalGrid.getGridSpacing()[1] -
+                dperb_SE->at(fsgrids::dperb::dPERBydz) / technicalGrid.getGridSpacing()[2]);
    }
 
    // Hall term
@@ -672,17 +688,16 @@ void calculateEdgeElectricFieldX(
    
    // Resistive term
    if (Parameters::resistivity > 0) {
-     Ex_NW += Parameters::resistivity *
-       sqrt((bgb_NW->at(fsgrids::bgbfield::BGBX)+perb_NW->at(fsgrids::bfield::PERBX))*
-            (bgb_NW->at(fsgrids::bgbfield::BGBX)+perb_NW->at(fsgrids::bfield::PERBX)) +
-            (bgb_NW->at(fsgrids::bgbfield::BGBY)+perb_NW->at(fsgrids::bfield::PERBY))*
-            (bgb_NW->at(fsgrids::bgbfield::BGBY)+perb_NW->at(fsgrids::bfield::PERBY)) +
-            (bgb_NW->at(fsgrids::bgbfield::BGBZ)+perb_NW->at(fsgrids::bfield::PERBZ))*
-            (bgb_NW->at(fsgrids::bgbfield::BGBZ)+perb_NW->at(fsgrids::bfield::PERBZ))
-           ) /
-       moments_NW->at(fsgrids::moments::RHOQ) /
-       physicalconstants::MU_0 *
-       (dperb_NW->at(fsgrids::dperb::dPERBzdy)/technicalGrid.DY - dperb_NW->at(fsgrids::dperb::dPERBydz)/technicalGrid.DZ);
+      Ex_NW += Parameters::resistivity *
+               sqrt((bgb_NW->at(fsgrids::bgbfield::BGBX) + perb_NW->at(fsgrids::bfield::PERBX)) *
+                        (bgb_NW->at(fsgrids::bgbfield::BGBX) + perb_NW->at(fsgrids::bfield::PERBX)) +
+                    (bgb_NW->at(fsgrids::bgbfield::BGBY) + perb_NW->at(fsgrids::bfield::PERBY)) *
+                        (bgb_NW->at(fsgrids::bgbfield::BGBY) + perb_NW->at(fsgrids::bfield::PERBY)) +
+                    (bgb_NW->at(fsgrids::bgbfield::BGBZ) + perb_NW->at(fsgrids::bfield::PERBZ)) *
+                        (bgb_NW->at(fsgrids::bgbfield::BGBZ) + perb_NW->at(fsgrids::bfield::PERBZ))) /
+               moments_NW->at(fsgrids::moments::RHOQ) / physicalconstants::MU_0 *
+               (dperb_NW->at(fsgrids::dperb::dPERBzdy) / technicalGrid.getGridSpacing()[1] -
+                dperb_NW->at(fsgrids::dperb::dPERBydz) / technicalGrid.getGridSpacing()[2]);
    }
    
    // Hall term
@@ -729,16 +744,15 @@ void calculateEdgeElectricFieldX(
    // Resistive term
    if (Parameters::resistivity > 0) {
       Ex_NE += Parameters::resistivity *
-               sqrt((bgb_NE->at(fsgrids::bgbfield::BGBX)+perb_NE->at(fsgrids::bfield::PERBX))*
-                    (bgb_NE->at(fsgrids::bgbfield::BGBX)+perb_NE->at(fsgrids::bfield::PERBX)) +
-                    (bgb_NE->at(fsgrids::bgbfield::BGBY)+perb_NE->at(fsgrids::bfield::PERBY))*
-                    (bgb_NE->at(fsgrids::bgbfield::BGBY)+perb_NE->at(fsgrids::bfield::PERBY)) +
-                    (bgb_NE->at(fsgrids::bgbfield::BGBZ)+perb_NE->at(fsgrids::bfield::PERBZ))*
-                    (bgb_NE->at(fsgrids::bgbfield::BGBZ)+perb_NE->at(fsgrids::bfield::PERBZ))
-                   ) /
-               moments_NE->at(fsgrids::moments::RHOQ) /
-               physicalconstants::MU_0 *
-               (dperb_NE->at(fsgrids::dperb::dPERBzdy)/technicalGrid.DY - dperb_NE->at(fsgrids::dperb::dPERBydz)/technicalGrid.DZ);
+               sqrt((bgb_NE->at(fsgrids::bgbfield::BGBX) + perb_NE->at(fsgrids::bfield::PERBX)) *
+                        (bgb_NE->at(fsgrids::bgbfield::BGBX) + perb_NE->at(fsgrids::bfield::PERBX)) +
+                    (bgb_NE->at(fsgrids::bgbfield::BGBY) + perb_NE->at(fsgrids::bfield::PERBY)) *
+                        (bgb_NE->at(fsgrids::bgbfield::BGBY) + perb_NE->at(fsgrids::bfield::PERBY)) +
+                    (bgb_NE->at(fsgrids::bgbfield::BGBZ) + perb_NE->at(fsgrids::bfield::PERBZ)) *
+                        (bgb_NE->at(fsgrids::bgbfield::BGBZ) + perb_NE->at(fsgrids::bfield::PERBZ))) /
+               moments_NE->at(fsgrids::moments::RHOQ) / physicalconstants::MU_0 *
+               (dperb_NE->at(fsgrids::dperb::dPERBzdy) / technicalGrid.getGridSpacing()[1] -
+                dperb_NE->at(fsgrids::dperb::dPERBydz) / technicalGrid.getGridSpacing()[2]);
    }
 
    // Hall term
@@ -792,8 +806,8 @@ void calculateEdgeElectricFieldX(
    if ((RKCase == RK_ORDER1) || (RKCase == RK_ORDER2_STEP2)) {
       //compute maximum timestep for fieldsolver in this cell (CFL=1)
       Real min_dx=std::numeric_limits<Real>::max();
-      min_dx=min(min_dx,technicalGrid.DY);
-      min_dx=min(min_dx,technicalGrid.DZ);
+      min_dx = min(min_dx, technicalGrid.getGridSpacing()[1]);
+      min_dx = min(min_dx, technicalGrid.getGridSpacing()[2]);
       //update max allowed timestep for field propagation in this cell, which is the minimum of CFL=1 timesteps
       if (maxV != ZERO) technicalGrid.get(i,j,k)->maxFsDt = min(technicalGrid.get(i,j,k)->maxFsDt,min_dx/maxV);
    }
@@ -919,16 +933,15 @@ void calculateEdgeElectricFieldY(
    // Resistive term
    if (Parameters::resistivity > 0) {
       Ey_SW += Parameters::resistivity *
-        sqrt((bgb_SW->at(fsgrids::bgbfield::BGBX)+perb_SW->at(fsgrids::bfield::PERBX))*
-             (bgb_SW->at(fsgrids::bgbfield::BGBX)+perb_SW->at(fsgrids::bfield::PERBX)) +
-             (bgb_SW->at(fsgrids::bgbfield::BGBY)+perb_SW->at(fsgrids::bfield::PERBY))*
-             (bgb_SW->at(fsgrids::bgbfield::BGBY)+perb_SW->at(fsgrids::bfield::PERBY)) +
-             (bgb_SW->at(fsgrids::bgbfield::BGBZ)+perb_SW->at(fsgrids::bfield::PERBZ))*
-             (bgb_SW->at(fsgrids::bgbfield::BGBZ)+perb_SW->at(fsgrids::bfield::PERBZ))
-            ) /
-        moments_SW->at(fsgrids::moments::RHOQ) /
-        physicalconstants::MU_0 *
-        (dperb_SW->at(fsgrids::dperb::dPERBxdz)/technicalGrid.DZ - dperb_SW->at(fsgrids::dperb::dPERBzdx)/technicalGrid.DX);
+               sqrt((bgb_SW->at(fsgrids::bgbfield::BGBX) + perb_SW->at(fsgrids::bfield::PERBX)) *
+                        (bgb_SW->at(fsgrids::bgbfield::BGBX) + perb_SW->at(fsgrids::bfield::PERBX)) +
+                    (bgb_SW->at(fsgrids::bgbfield::BGBY) + perb_SW->at(fsgrids::bfield::PERBY)) *
+                        (bgb_SW->at(fsgrids::bgbfield::BGBY) + perb_SW->at(fsgrids::bfield::PERBY)) +
+                    (bgb_SW->at(fsgrids::bgbfield::BGBZ) + perb_SW->at(fsgrids::bfield::PERBZ)) *
+                        (bgb_SW->at(fsgrids::bgbfield::BGBZ) + perb_SW->at(fsgrids::bfield::PERBZ))) /
+               moments_SW->at(fsgrids::moments::RHOQ) / physicalconstants::MU_0 *
+               (dperb_SW->at(fsgrids::dperb::dPERBxdz) / technicalGrid.getGridSpacing()[2] -
+                dperb_SW->at(fsgrids::dperb::dPERBzdx) / technicalGrid.getGridSpacing()[0]);
    }
 
    // Hall term
@@ -975,16 +988,15 @@ void calculateEdgeElectricFieldY(
    // Resistive term
    if (Parameters::resistivity > 0) {
       Ey_SE += Parameters::resistivity *
-        sqrt((bgb_SE->at(fsgrids::bgbfield::BGBX)+perb_SE->at(fsgrids::bfield::PERBX))*
-             (bgb_SE->at(fsgrids::bgbfield::BGBX)+perb_SE->at(fsgrids::bfield::PERBX)) +
-             (bgb_SE->at(fsgrids::bgbfield::BGBY)+perb_SE->at(fsgrids::bfield::PERBY))*
-             (bgb_SE->at(fsgrids::bgbfield::BGBY)+perb_SE->at(fsgrids::bfield::PERBY)) +
-             (bgb_SE->at(fsgrids::bgbfield::BGBZ)+perb_SE->at(fsgrids::bfield::PERBZ))*
-             (bgb_SE->at(fsgrids::bgbfield::BGBZ)+perb_SE->at(fsgrids::bfield::PERBZ))
-            ) /
-        moments_SE->at(fsgrids::moments::RHOQ) /
-        physicalconstants::MU_0 *
-        (dperb_SE->at(fsgrids::dperb::dPERBxdz)/technicalGrid.DZ - dperb_SE->at(fsgrids::dperb::dPERBzdx)/technicalGrid.DX);
+               sqrt((bgb_SE->at(fsgrids::bgbfield::BGBX) + perb_SE->at(fsgrids::bfield::PERBX)) *
+                        (bgb_SE->at(fsgrids::bgbfield::BGBX) + perb_SE->at(fsgrids::bfield::PERBX)) +
+                    (bgb_SE->at(fsgrids::bgbfield::BGBY) + perb_SE->at(fsgrids::bfield::PERBY)) *
+                        (bgb_SE->at(fsgrids::bgbfield::BGBY) + perb_SE->at(fsgrids::bfield::PERBY)) +
+                    (bgb_SE->at(fsgrids::bgbfield::BGBZ) + perb_SE->at(fsgrids::bfield::PERBZ)) *
+                        (bgb_SE->at(fsgrids::bgbfield::BGBZ) + perb_SE->at(fsgrids::bfield::PERBZ))) /
+               moments_SE->at(fsgrids::moments::RHOQ) / physicalconstants::MU_0 *
+               (dperb_SE->at(fsgrids::dperb::dPERBxdz) / technicalGrid.getGridSpacing()[2] -
+                dperb_SE->at(fsgrids::dperb::dPERBzdx) / technicalGrid.getGridSpacing()[0]);
    }
 
    // Hall term
@@ -1031,16 +1043,15 @@ void calculateEdgeElectricFieldY(
    // Resistive term
    if (Parameters::resistivity > 0) {
       Ey_NW += Parameters::resistivity *
-        sqrt((bgb_NW->at(fsgrids::bgbfield::BGBX)+perb_NW->at(fsgrids::bfield::PERBX))*
-             (bgb_NW->at(fsgrids::bgbfield::BGBX)+perb_NW->at(fsgrids::bfield::PERBX)) +
-             (bgb_NW->at(fsgrids::bgbfield::BGBY)+perb_NW->at(fsgrids::bfield::PERBY))*
-             (bgb_NW->at(fsgrids::bgbfield::BGBY)+perb_NW->at(fsgrids::bfield::PERBY)) +
-             (bgb_NW->at(fsgrids::bgbfield::BGBZ)+perb_NW->at(fsgrids::bfield::PERBZ))*
-             (bgb_NW->at(fsgrids::bgbfield::BGBZ)+perb_NW->at(fsgrids::bfield::PERBZ))
-            ) /
-        moments_NW->at(fsgrids::moments::RHOQ) /
-        physicalconstants::MU_0 *
-        (dperb_NW->at(fsgrids::dperb::dPERBxdz)/technicalGrid.DZ - dperb_NW->at(fsgrids::dperb::dPERBzdx)/technicalGrid.DX);
+               sqrt((bgb_NW->at(fsgrids::bgbfield::BGBX) + perb_NW->at(fsgrids::bfield::PERBX)) *
+                        (bgb_NW->at(fsgrids::bgbfield::BGBX) + perb_NW->at(fsgrids::bfield::PERBX)) +
+                    (bgb_NW->at(fsgrids::bgbfield::BGBY) + perb_NW->at(fsgrids::bfield::PERBY)) *
+                        (bgb_NW->at(fsgrids::bgbfield::BGBY) + perb_NW->at(fsgrids::bfield::PERBY)) +
+                    (bgb_NW->at(fsgrids::bgbfield::BGBZ) + perb_NW->at(fsgrids::bfield::PERBZ)) *
+                        (bgb_NW->at(fsgrids::bgbfield::BGBZ) + perb_NW->at(fsgrids::bfield::PERBZ))) /
+               moments_NW->at(fsgrids::moments::RHOQ) / physicalconstants::MU_0 *
+               (dperb_NW->at(fsgrids::dperb::dPERBxdz) / technicalGrid.getGridSpacing()[2] -
+                dperb_NW->at(fsgrids::dperb::dPERBzdx) / technicalGrid.getGridSpacing()[0]);
    }
 
    // Hall term
@@ -1087,16 +1098,15 @@ void calculateEdgeElectricFieldY(
    // Resistive term
    if (Parameters::resistivity > 0) {
       Ey_NE += Parameters::resistivity *
-        sqrt((bgb_NE->at(fsgrids::bgbfield::BGBX)+perb_NE->at(fsgrids::bfield::PERBX))*
-             (bgb_NE->at(fsgrids::bgbfield::BGBX)+perb_NE->at(fsgrids::bfield::PERBX)) +
-             (bgb_NE->at(fsgrids::bgbfield::BGBY)+perb_NE->at(fsgrids::bfield::PERBY))*
-             (bgb_NE->at(fsgrids::bgbfield::BGBY)+perb_NE->at(fsgrids::bfield::PERBY)) +
-             (bgb_NE->at(fsgrids::bgbfield::BGBZ)+perb_NE->at(fsgrids::bfield::PERBZ))*
-             (bgb_NE->at(fsgrids::bgbfield::BGBZ)+perb_NE->at(fsgrids::bfield::PERBZ))
-            ) /
-        moments_NE->at(fsgrids::moments::RHOQ) /
-        physicalconstants::MU_0 *
-        (dperb_NE->at(fsgrids::dperb::dPERBxdz)/technicalGrid.DZ - dperb_NE->at(fsgrids::dperb::dPERBzdx)/technicalGrid.DX);
+               sqrt((bgb_NE->at(fsgrids::bgbfield::BGBX) + perb_NE->at(fsgrids::bfield::PERBX)) *
+                        (bgb_NE->at(fsgrids::bgbfield::BGBX) + perb_NE->at(fsgrids::bfield::PERBX)) +
+                    (bgb_NE->at(fsgrids::bgbfield::BGBY) + perb_NE->at(fsgrids::bfield::PERBY)) *
+                        (bgb_NE->at(fsgrids::bgbfield::BGBY) + perb_NE->at(fsgrids::bfield::PERBY)) +
+                    (bgb_NE->at(fsgrids::bgbfield::BGBZ) + perb_NE->at(fsgrids::bfield::PERBZ)) *
+                        (bgb_NE->at(fsgrids::bgbfield::BGBZ) + perb_NE->at(fsgrids::bfield::PERBZ))) /
+               moments_NE->at(fsgrids::moments::RHOQ) / physicalconstants::MU_0 *
+               (dperb_NE->at(fsgrids::dperb::dPERBxdz) / technicalGrid.getGridSpacing()[2] -
+                dperb_NE->at(fsgrids::dperb::dPERBzdx) / technicalGrid.getGridSpacing()[0]);
    }
 
    // Hall term
@@ -1149,8 +1159,8 @@ void calculateEdgeElectricFieldY(
    if ((RKCase == RK_ORDER1) || (RKCase == RK_ORDER2_STEP2)) {
       //compute maximum timestep for fieldsolver in this cell (CFL=1)      
       Real min_dx=std::numeric_limits<Real>::max();;
-      min_dx=min(min_dx,technicalGrid.DX);
-      min_dx=min(min_dx,technicalGrid.DZ);
+      min_dx = min(min_dx, technicalGrid.getGridSpacing()[0]);
+      min_dx = min(min_dx, technicalGrid.getGridSpacing()[2]);
       //update max allowed timestep for field propagation in this cell, which is the minimum of CFL=1 timesteps
       if (maxV!=ZERO) technicalGrid.get(i,j,k)->maxFsDt=min(technicalGrid.get(i,j,k)->maxFsDt,min_dx/maxV);
    }
@@ -1277,17 +1287,16 @@ void calculateEdgeElectricFieldZ(
    
    // Resistive term
    if (Parameters::resistivity > 0) {
-     Ez_SW += Parameters::resistivity *
-       sqrt((bgb_SW->at(fsgrids::bgbfield::BGBX)+perb_SW->at(fsgrids::bfield::PERBX))*
-            (bgb_SW->at(fsgrids::bgbfield::BGBX)+perb_SW->at(fsgrids::bfield::PERBX)) +
-            (bgb_SW->at(fsgrids::bgbfield::BGBY)+perb_SW->at(fsgrids::bfield::PERBY))*
-            (bgb_SW->at(fsgrids::bgbfield::BGBY)+perb_SW->at(fsgrids::bfield::PERBY)) +
-            (bgb_SW->at(fsgrids::bgbfield::BGBZ)+perb_SW->at(fsgrids::bfield::PERBZ))*
-            (bgb_SW->at(fsgrids::bgbfield::BGBZ)+perb_SW->at(fsgrids::bfield::PERBZ))
-           ) /
-       moments_SW->at(fsgrids::moments::RHOQ) /
-       physicalconstants::MU_0 *
-       (dperb_SW->at(fsgrids::dperb::dPERBydx)/technicalGrid.DX - dperb_SW->at(fsgrids::dperb::dPERBxdy)/technicalGrid.DY);
+      Ez_SW += Parameters::resistivity *
+               sqrt((bgb_SW->at(fsgrids::bgbfield::BGBX) + perb_SW->at(fsgrids::bfield::PERBX)) *
+                        (bgb_SW->at(fsgrids::bgbfield::BGBX) + perb_SW->at(fsgrids::bfield::PERBX)) +
+                    (bgb_SW->at(fsgrids::bgbfield::BGBY) + perb_SW->at(fsgrids::bfield::PERBY)) *
+                        (bgb_SW->at(fsgrids::bgbfield::BGBY) + perb_SW->at(fsgrids::bfield::PERBY)) +
+                    (bgb_SW->at(fsgrids::bgbfield::BGBZ) + perb_SW->at(fsgrids::bfield::PERBZ)) *
+                        (bgb_SW->at(fsgrids::bgbfield::BGBZ) + perb_SW->at(fsgrids::bfield::PERBZ))) /
+               moments_SW->at(fsgrids::moments::RHOQ) / physicalconstants::MU_0 *
+               (dperb_SW->at(fsgrids::dperb::dPERBydx) / technicalGrid.getGridSpacing()[0] -
+                dperb_SW->at(fsgrids::dperb::dPERBxdy) / technicalGrid.getGridSpacing()[1]);
    }
    
    // Hall term
@@ -1336,16 +1345,15 @@ void calculateEdgeElectricFieldZ(
    // Resistive term
    if (Parameters::resistivity > 0) {
       Ez_SE += Parameters::resistivity *
-        sqrt((bgb_SE->at(fsgrids::bgbfield::BGBX)+perb_SE->at(fsgrids::bfield::PERBX))*
-             (bgb_SE->at(fsgrids::bgbfield::BGBX)+perb_SE->at(fsgrids::bfield::PERBX)) +
-             (bgb_SE->at(fsgrids::bgbfield::BGBY)+perb_SE->at(fsgrids::bfield::PERBY))*
-             (bgb_SE->at(fsgrids::bgbfield::BGBY)+perb_SE->at(fsgrids::bfield::PERBY)) +
-             (bgb_SE->at(fsgrids::bgbfield::BGBZ)+perb_SE->at(fsgrids::bfield::PERBZ))*
-             (bgb_SE->at(fsgrids::bgbfield::BGBZ)+perb_SE->at(fsgrids::bfield::PERBZ))
-            ) /
-        moments_SE->at(fsgrids::moments::RHOQ) /
-        physicalconstants::MU_0 *
-        (dperb_SE->at(fsgrids::dperb::dPERBydx)/technicalGrid.DX - dperb_SE->at(fsgrids::dperb::dPERBxdy)/technicalGrid.DY);
+               sqrt((bgb_SE->at(fsgrids::bgbfield::BGBX) + perb_SE->at(fsgrids::bfield::PERBX)) *
+                        (bgb_SE->at(fsgrids::bgbfield::BGBX) + perb_SE->at(fsgrids::bfield::PERBX)) +
+                    (bgb_SE->at(fsgrids::bgbfield::BGBY) + perb_SE->at(fsgrids::bfield::PERBY)) *
+                        (bgb_SE->at(fsgrids::bgbfield::BGBY) + perb_SE->at(fsgrids::bfield::PERBY)) +
+                    (bgb_SE->at(fsgrids::bgbfield::BGBZ) + perb_SE->at(fsgrids::bfield::PERBZ)) *
+                        (bgb_SE->at(fsgrids::bgbfield::BGBZ) + perb_SE->at(fsgrids::bfield::PERBZ))) /
+               moments_SE->at(fsgrids::moments::RHOQ) / physicalconstants::MU_0 *
+               (dperb_SE->at(fsgrids::dperb::dPERBydx) / technicalGrid.getGridSpacing()[0] -
+                dperb_SE->at(fsgrids::dperb::dPERBxdy) / technicalGrid.getGridSpacing()[1]);
    }
    
    // Hall term
@@ -1392,16 +1400,15 @@ void calculateEdgeElectricFieldZ(
    // Resistive term
    if (Parameters::resistivity > 0) {
       Ez_NW += Parameters::resistivity *
-        sqrt((bgb_NW->at(fsgrids::bgbfield::BGBX)+perb_NW->at(fsgrids::bfield::PERBX))*
-             (bgb_NW->at(fsgrids::bgbfield::BGBX)+perb_NW->at(fsgrids::bfield::PERBX)) +
-             (bgb_NW->at(fsgrids::bgbfield::BGBY)+perb_NW->at(fsgrids::bfield::PERBY))*
-             (bgb_NW->at(fsgrids::bgbfield::BGBY)+perb_NW->at(fsgrids::bfield::PERBY)) +
-             (bgb_NW->at(fsgrids::bgbfield::BGBZ)+perb_NW->at(fsgrids::bfield::PERBZ))*
-             (bgb_NW->at(fsgrids::bgbfield::BGBZ)+perb_NW->at(fsgrids::bfield::PERBZ))
-            ) /
-        moments_NW->at(fsgrids::moments::RHOQ) /
-        physicalconstants::MU_0 *
-        (dperb_NW->at(fsgrids::dperb::dPERBydx)/technicalGrid.DX - dperb_NW->at(fsgrids::dperb::dPERBxdy)/technicalGrid.DY);
+               sqrt((bgb_NW->at(fsgrids::bgbfield::BGBX) + perb_NW->at(fsgrids::bfield::PERBX)) *
+                        (bgb_NW->at(fsgrids::bgbfield::BGBX) + perb_NW->at(fsgrids::bfield::PERBX)) +
+                    (bgb_NW->at(fsgrids::bgbfield::BGBY) + perb_NW->at(fsgrids::bfield::PERBY)) *
+                        (bgb_NW->at(fsgrids::bgbfield::BGBY) + perb_NW->at(fsgrids::bfield::PERBY)) +
+                    (bgb_NW->at(fsgrids::bgbfield::BGBZ) + perb_NW->at(fsgrids::bfield::PERBZ)) *
+                        (bgb_NW->at(fsgrids::bgbfield::BGBZ) + perb_NW->at(fsgrids::bfield::PERBZ))) /
+               moments_NW->at(fsgrids::moments::RHOQ) / physicalconstants::MU_0 *
+               (dperb_NW->at(fsgrids::dperb::dPERBydx) / technicalGrid.getGridSpacing()[0] -
+                dperb_NW->at(fsgrids::dperb::dPERBxdy) / technicalGrid.getGridSpacing()[1]);
    }
    
    // Hall term
@@ -1448,16 +1455,15 @@ void calculateEdgeElectricFieldZ(
    // Resistive term
    if (Parameters::resistivity > 0) {
       Ez_NE += Parameters::resistivity *
-        sqrt((bgb_NE->at(fsgrids::bgbfield::BGBX)+perb_NE->at(fsgrids::bfield::PERBX))*
-             (bgb_NE->at(fsgrids::bgbfield::BGBX)+perb_NE->at(fsgrids::bfield::PERBX)) +
-             (bgb_NE->at(fsgrids::bgbfield::BGBY)+perb_NE->at(fsgrids::bfield::PERBY))*
-             (bgb_NE->at(fsgrids::bgbfield::BGBY)+perb_NE->at(fsgrids::bfield::PERBY)) +
-             (bgb_NE->at(fsgrids::bgbfield::BGBZ)+perb_NE->at(fsgrids::bfield::PERBZ))*
-             (bgb_NE->at(fsgrids::bgbfield::BGBZ)+perb_NE->at(fsgrids::bfield::PERBZ))
-            ) /
-        moments_NE->at(fsgrids::moments::RHOQ) /
-        physicalconstants::MU_0 *
-        (dperb_NE->at(fsgrids::dperb::dPERBydx)/technicalGrid.DX - dperb_NE->at(fsgrids::dperb::dPERBxdy)/technicalGrid.DY);
+               sqrt((bgb_NE->at(fsgrids::bgbfield::BGBX) + perb_NE->at(fsgrids::bfield::PERBX)) *
+                        (bgb_NE->at(fsgrids::bgbfield::BGBX) + perb_NE->at(fsgrids::bfield::PERBX)) +
+                    (bgb_NE->at(fsgrids::bgbfield::BGBY) + perb_NE->at(fsgrids::bfield::PERBY)) *
+                        (bgb_NE->at(fsgrids::bgbfield::BGBY) + perb_NE->at(fsgrids::bfield::PERBY)) +
+                    (bgb_NE->at(fsgrids::bgbfield::BGBZ) + perb_NE->at(fsgrids::bfield::PERBZ)) *
+                        (bgb_NE->at(fsgrids::bgbfield::BGBZ) + perb_NE->at(fsgrids::bfield::PERBZ))) /
+               moments_NE->at(fsgrids::moments::RHOQ) / physicalconstants::MU_0 *
+               (dperb_NE->at(fsgrids::dperb::dPERBydx) / technicalGrid.getGridSpacing()[0] -
+                dperb_NE->at(fsgrids::dperb::dPERBxdy) / technicalGrid.getGridSpacing()[1]);
    }
    
    // Hall term
@@ -1511,8 +1517,8 @@ void calculateEdgeElectricFieldZ(
    if ((RKCase == RK_ORDER1) || (RKCase == RK_ORDER2_STEP2)) {
       //compute maximum timestep for fieldsolver in this cell (CFL=1)
       Real min_dx=std::numeric_limits<Real>::max();;
-      min_dx=min(min_dx,technicalGrid.DX);
-      min_dx=min(min_dx,technicalGrid.DY);
+      min_dx = min(min_dx, technicalGrid.getGridSpacing()[0]);
+      min_dx = min(min_dx, technicalGrid.getGridSpacing()[1]);
       //update max allowed timestep for field propagation in this cell, which is the minimum of CFL=1 timesteps
       if(maxV!=ZERO) technicalGrid.get(i,j,k)->maxFsDt=min(technicalGrid.get(i,j,k)->maxFsDt,min_dx/maxV);
    }

--- a/fieldsolver/ldz_gradpe.cpp
+++ b/fieldsolver/ldz_gradpe.cpp
@@ -47,9 +47,12 @@ void calculateEdgeGradPeTermXComponents(
       case 1:
          rhoq = momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ);
          hallRhoq = (rhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : rhoq ;
-         //EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EXGRADPE) = -physicalconstants::K_B*Parameters::electronTemperature*dMomentsGrid.get(i,j,k)->at(fsgrids::dmoments::drhoqdx) / (hallRhoq*EGradPeGrid.DX);
-         EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EXGRADPE) = - dMomentsGrid.get(i,j,k)->at(fsgrids::dmoments::dPedx) / (hallRhoq*EGradPeGrid.DX);
-	 break;
+         // EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EXGRADPE) =
+         // -physicalconstants::K_B*Parameters::electronTemperature*dMomentsGrid.get(i,j,k)->at(fsgrids::dmoments::drhoqdx)
+         // / (hallRhoq*EGradPeGrid.getGridSpacing()[0]);
+         EGradPeGrid.get(i, j, k)->at(fsgrids::egradpe::EXGRADPE) =
+             -dMomentsGrid.get(i, j, k)->at(fsgrids::dmoments::dPedx) / (hallRhoq * EGradPeGrid.getGridSpacing()[0]);
+         break;
 
       default:
          cerr << __FILE__ << ":" << __LINE__ << "You are welcome to code higher-order Hall term correction terms." << endl;
@@ -75,8 +78,11 @@ void calculateEdgeGradPeTermYComponents(
       case 1:
          rhoq = momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ);
          hallRhoq = (rhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : rhoq ;
-         //EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EYGRADPE) = -physicalconstants::K_B*Parameters::electronTemperature*dMomentsGrid.get(i,j,k)->at(fsgrids::dmoments::drhoqdy) / (hallRhoq*EGradPeGrid.DY);
-         EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EYGRADPE) = - dMomentsGrid.get(i,j,k)->at(fsgrids::dmoments::dPedy) / (hallRhoq*EGradPeGrid.DY);
+         // EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EYGRADPE) =
+         // -physicalconstants::K_B*Parameters::electronTemperature*dMomentsGrid.get(i,j,k)->at(fsgrids::dmoments::drhoqdy)
+         // / (hallRhoq*EGradPeGrid.getGridSpacing()[1]);
+         EGradPeGrid.get(i, j, k)->at(fsgrids::egradpe::EYGRADPE) =
+             -dMomentsGrid.get(i, j, k)->at(fsgrids::dmoments::dPedy) / (hallRhoq * EGradPeGrid.getGridSpacing()[1]);
          break;
 
       default:
@@ -103,8 +109,11 @@ void calculateEdgeGradPeTermZComponents(
       case 1:
          rhoq = momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ);
          hallRhoq = (rhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : rhoq ;
-         //EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EZGRADPE) = -physicalconstants::K_B*Parameters::electronTemperature*dMomentsGrid.get(i,j,k)->at(fsgrids::dmoments::drhoqdz) / (hallRhoq*EGradPeGrid.DZ);
-         EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EZGRADPE) = - dMomentsGrid.get(i,j,k)->at(fsgrids::dmoments::dPedz) / (hallRhoq*EGradPeGrid.DZ);
+         // EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EZGRADPE) =
+         // -physicalconstants::K_B*Parameters::electronTemperature*dMomentsGrid.get(i,j,k)->at(fsgrids::dmoments::drhoqdz)
+         // / (hallRhoq*EGradPeGrid.getGridSpacing()[2]);
+         EGradPeGrid.get(i, j, k)->at(fsgrids::egradpe::EZGRADPE) =
+             -dMomentsGrid.get(i, j, k)->at(fsgrids::dmoments::dPedz) / (hallRhoq * EGradPeGrid.getGridSpacing()[2]);
          break;
 
       default:

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -460,10 +460,18 @@ void calculateEdgeHallTermXComponents(
       Bz = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBZ)+BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ);
 
       hallRhoq =  (momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ) <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ) ;
-      EXHall = Bz*((BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBxdz)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBxdz)) / technicalGrid.DZ -
-                  (BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBzdx)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBzdx)) / technicalGrid.DX) -
-               By*((BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBydx)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBydx)) / technicalGrid.DX -
-                  (BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBxdy)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBxdy)) / technicalGrid.DY);
+      EXHall = Bz * ((BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::dBGBxdz) +
+                      dPerBGrid.get(i, j, k)->at(fsgrids::dperb::dPERBxdz)) /
+                         technicalGrid.getGridSpacing()[2] -
+                     (BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::dBGBzdx) +
+                      dPerBGrid.get(i, j, k)->at(fsgrids::dperb::dPERBzdx)) /
+                         technicalGrid.getGridSpacing()[0]) -
+               By * ((BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::dBGBydx) +
+                      dPerBGrid.get(i, j, k)->at(fsgrids::dperb::dPERBydx)) /
+                         technicalGrid.getGridSpacing()[0] -
+                     (BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::dBGBxdy) +
+                      dPerBGrid.get(i, j, k)->at(fsgrids::dperb::dPERBxdy)) /
+                         technicalGrid.getGridSpacing()[1]);
       EXHall /= physicalconstants::MU_0 * hallRhoq;
 
       EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_000_100) =
@@ -480,7 +488,11 @@ void calculateEdgeHallTermXComponents(
          momentsGrid.get(i  ,j-1,k-1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_000_100) = JXBX_000_100(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      EHallGrid.get(i, j, k)->at(fsgrids::ehall::EXHALL_000_100) =
+          JXBX_000_100(perturbedCoefficients, BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBY),
+                       BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.getGridSpacing()[0],
+                       technicalGrid.getGridSpacing()[1], technicalGrid.getGridSpacing()[2]) /
+          (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
          momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
          momentsGrid.get(i  ,j+1,k  )->at(fsgrids::moments::RHOQ) +
@@ -488,7 +500,11 @@ void calculateEdgeHallTermXComponents(
          momentsGrid.get(i  ,j+1,k-1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_010_110) = JXBX_010_110(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      EHallGrid.get(i, j, k)->at(fsgrids::ehall::EXHALL_010_110) =
+          JXBX_010_110(perturbedCoefficients, BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBY),
+                       BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.getGridSpacing()[0],
+                       technicalGrid.getGridSpacing()[1], technicalGrid.getGridSpacing()[2]) /
+          (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
          momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
          momentsGrid.get(i  ,j-1,k  )->at(fsgrids::moments::RHOQ) +
@@ -496,7 +512,11 @@ void calculateEdgeHallTermXComponents(
          momentsGrid.get(i  ,j-1,k+1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_001_101) = JXBX_001_101(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      EHallGrid.get(i, j, k)->at(fsgrids::ehall::EXHALL_001_101) =
+          JXBX_001_101(perturbedCoefficients, BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBY),
+                       BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.getGridSpacing()[0],
+                       technicalGrid.getGridSpacing()[1], technicalGrid.getGridSpacing()[2]) /
+          (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
          momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
          momentsGrid.get(i  ,j+1,k  )->at(fsgrids::moments::RHOQ) +
@@ -504,7 +524,11 @@ void calculateEdgeHallTermXComponents(
          momentsGrid.get(i  ,j+1,k+1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_011_111) = JXBX_011_111(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      EHallGrid.get(i, j, k)->at(fsgrids::ehall::EXHALL_011_111) =
+          JXBX_011_111(perturbedCoefficients, BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBY),
+                       BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.getGridSpacing()[0],
+                       technicalGrid.getGridSpacing()[1], technicalGrid.getGridSpacing()[2]) /
+          (physicalconstants::MU_0 * hallRhoq);
       break;
 
     default:
@@ -558,10 +582,18 @@ void calculateEdgeHallTermYComponents(
       Bz = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBZ)+BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ);
 
       hallRhoq =  (momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ) <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ) ;
-      EYHall = Bx*((BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBydx)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBydx)) / technicalGrid.DX -
-                  (BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBxdy)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBxdy)) / technicalGrid.DY) -
-               Bz*((BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBzdy)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBzdy)) / technicalGrid.DY -
-                  (BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBydz)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBydz)) / technicalGrid.DZ);
+      EYHall = Bx * ((BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::dBGBydx) +
+                      dPerBGrid.get(i, j, k)->at(fsgrids::dperb::dPERBydx)) /
+                         technicalGrid.getGridSpacing()[0] -
+                     (BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::dBGBxdy) +
+                      dPerBGrid.get(i, j, k)->at(fsgrids::dperb::dPERBxdy)) /
+                         technicalGrid.getGridSpacing()[1]) -
+               Bz * ((BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::dBGBzdy) +
+                      dPerBGrid.get(i, j, k)->at(fsgrids::dperb::dPERBzdy)) /
+                         technicalGrid.getGridSpacing()[1] -
+                     (BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::dBGBydz) +
+                      dPerBGrid.get(i, j, k)->at(fsgrids::dperb::dPERBydz)) /
+                         technicalGrid.getGridSpacing()[2]);
       EYHall /= physicalconstants::MU_0 * hallRhoq;
 
       EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_000_010) =
@@ -578,7 +610,11 @@ void calculateEdgeHallTermYComponents(
          momentsGrid.get(i-1,j  ,k-1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_000_010) = JXBY_000_010(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      EHallGrid.get(i, j, k)->at(fsgrids::ehall::EYHALL_000_010) =
+          JXBY_000_010(perturbedCoefficients, BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBX),
+                       BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.getGridSpacing()[0],
+                       technicalGrid.getGridSpacing()[1], technicalGrid.getGridSpacing()[2]) /
+          (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
          momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
          momentsGrid.get(i+1,j  ,k  )->at(fsgrids::moments::RHOQ) +
@@ -586,7 +622,11 @@ void calculateEdgeHallTermYComponents(
          momentsGrid.get(i+1,j  ,k-1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_100_110) = JXBY_100_110(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      EHallGrid.get(i, j, k)->at(fsgrids::ehall::EYHALL_100_110) =
+          JXBY_100_110(perturbedCoefficients, BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBX),
+                       BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.getGridSpacing()[0],
+                       technicalGrid.getGridSpacing()[1], technicalGrid.getGridSpacing()[2]) /
+          (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
          momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
          momentsGrid.get(i-1,j  ,k  )->at(fsgrids::moments::RHOQ) +
@@ -594,7 +634,11 @@ void calculateEdgeHallTermYComponents(
          momentsGrid.get(i-1,j  ,k+1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_001_011) = JXBY_001_011(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      EHallGrid.get(i, j, k)->at(fsgrids::ehall::EYHALL_001_011) =
+          JXBY_001_011(perturbedCoefficients, BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBX),
+                       BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.getGridSpacing()[0],
+                       technicalGrid.getGridSpacing()[1], technicalGrid.getGridSpacing()[2]) /
+          (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
          momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
          momentsGrid.get(i+1,j  ,k  )->at(fsgrids::moments::RHOQ) +
@@ -602,7 +646,11 @@ void calculateEdgeHallTermYComponents(
          momentsGrid.get(i+1,j  ,k+1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_101_111) = JXBY_101_111(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      EHallGrid.get(i, j, k)->at(fsgrids::ehall::EYHALL_101_111) =
+          JXBY_101_111(perturbedCoefficients, BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBX),
+                       BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.getGridSpacing()[0],
+                       technicalGrid.getGridSpacing()[1], technicalGrid.getGridSpacing()[2]) /
+          (physicalconstants::MU_0 * hallRhoq);
       break;
 
     default:
@@ -656,10 +704,18 @@ void calculateEdgeHallTermZComponents(
      By = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBY)+BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY);
 
      hallRhoq =  (momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ) <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ) ;
-     EZHall = By*((BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBzdy)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBzdy)) / technicalGrid.DY -
-                 (BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBydz)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBydz)) / technicalGrid.DZ) -
-              Bx*((BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBxdz)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBxdz)) / technicalGrid.DZ -
-                 (BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBzdx)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBzdx)) / technicalGrid.DX);
+     EZHall = By * ((BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::dBGBzdy) +
+                     dPerBGrid.get(i, j, k)->at(fsgrids::dperb::dPERBzdy)) /
+                        technicalGrid.getGridSpacing()[1] -
+                    (BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::dBGBydz) +
+                     dPerBGrid.get(i, j, k)->at(fsgrids::dperb::dPERBydz)) /
+                        technicalGrid.getGridSpacing()[2]) -
+              Bx * ((BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::dBGBxdz) +
+                     dPerBGrid.get(i, j, k)->at(fsgrids::dperb::dPERBxdz)) /
+                        technicalGrid.getGridSpacing()[2] -
+                    (BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::dBGBzdx) +
+                     dPerBGrid.get(i, j, k)->at(fsgrids::dperb::dPERBzdx)) /
+                        technicalGrid.getGridSpacing()[0]);
      EZHall /= physicalconstants::MU_0 * hallRhoq;
 
      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_000_001) =
@@ -676,7 +732,11 @@ void calculateEdgeHallTermZComponents(
          momentsGrid.get(i-1,j-1,k  )->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_000_001) = JXBZ_000_001(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      EHallGrid.get(i, j, k)->at(fsgrids::ehall::EZHALL_000_001) =
+          JXBZ_000_001(perturbedCoefficients, BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBX),
+                       BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBY), technicalGrid.getGridSpacing()[0],
+                       technicalGrid.getGridSpacing()[1], technicalGrid.getGridSpacing()[2]) /
+          (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
          momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
          momentsGrid.get(i+1,j  ,k  )->at(fsgrids::moments::RHOQ) +
@@ -684,7 +744,11 @@ void calculateEdgeHallTermZComponents(
          momentsGrid.get(i+1,j-1,k  )->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_100_101) = JXBZ_100_101(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      EHallGrid.get(i, j, k)->at(fsgrids::ehall::EZHALL_100_101) =
+          JXBZ_100_101(perturbedCoefficients, BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBX),
+                       BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBY), technicalGrid.getGridSpacing()[0],
+                       technicalGrid.getGridSpacing()[1], technicalGrid.getGridSpacing()[2]) /
+          (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
          momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
          momentsGrid.get(i-1,j  ,k  )->at(fsgrids::moments::RHOQ) +
@@ -692,7 +756,11 @@ void calculateEdgeHallTermZComponents(
          momentsGrid.get(i-1,j+1,k  )->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_010_011) = JXBZ_010_011(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      EHallGrid.get(i, j, k)->at(fsgrids::ehall::EZHALL_010_011) =
+          JXBZ_010_011(perturbedCoefficients, BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBX),
+                       BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBY), technicalGrid.getGridSpacing()[0],
+                       technicalGrid.getGridSpacing()[1], technicalGrid.getGridSpacing()[2]) /
+          (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
          momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
          momentsGrid.get(i+1,j  ,k  )->at(fsgrids::moments::RHOQ) +
@@ -700,7 +768,11 @@ void calculateEdgeHallTermZComponents(
          momentsGrid.get(i+1,j+1,k  )->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_110_111) = JXBZ_110_111(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      EHallGrid.get(i, j, k)->at(fsgrids::ehall::EZHALL_110_111) =
+          JXBZ_110_111(perturbedCoefficients, BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBX),
+                       BgBGrid.get(i, j, k)->at(fsgrids::bgbfield::BGBY), technicalGrid.getGridSpacing()[0],
+                       technicalGrid.getGridSpacing()[1], technicalGrid.getGridSpacing()[2]) /
+          (physicalconstants::MU_0 * hallRhoq);
       break;
 
     default:

--- a/fieldsolver/ldz_magnetic_field.cpp
+++ b/fieldsolver/ldz_magnetic_field.cpp
@@ -60,9 +60,10 @@ void propagateMagneticField(
    const bool doY, //=true (default)
    const bool doZ  //=true (default)
 ) {
-   creal dx = perBGrid.DX;
-   creal dy = perBGrid.DY;
-   creal dz = perBGrid.DZ;
+   const auto& gridSpacing = perBGrid.getGridSpacing();
+   creal dx = gridSpacing[0];
+   creal dy = gridSpacing[1];
+   creal dz = gridSpacing[2];
 
    std::array<Real, fsgrids::bfield::N_BFIELD> * perBGrid0 = perBGrid.get(i,j,k);
    std::array<Real, fsgrids::efield::N_EFIELD> * EGrid0;

--- a/fieldsolver/ldz_main.cpp
+++ b/fieldsolver/ldz_main.cpp
@@ -355,7 +355,7 @@ bool propagateFields(
          Real dtMaxGlobal;
          dtMaxLocal=std::numeric_limits<Real>::max();
 
-         std::array<FsGridTools::FsIndex_t, 3>& localSize = technicalGrid.getLocalSize();
+         const auto& localSize = technicalGrid.getLocalSize();
          for(FsGridTools::FsIndex_t z=0; z<localSize[2]; z++) {
             for(FsGridTools::FsIndex_t y=0; y<localSize[1]; y++) {
                for(FsGridTools::FsIndex_t x=0; x<localSize[0]; x++) {

--- a/fieldtracing/fieldtracing.cpp
+++ b/fieldtracing/fieldtracing.cpp
@@ -489,7 +489,7 @@ namespace FieldTracing {
       const TReal stepSize = min(1000e3, technicalGrid.DX / 2.);
       std::vector<TReal> nodeTracingStepSize(nodes.size(), stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
       std::vector<TReal> reducedNodeTracingStepSize(nodes.size());
-      const std::array<FsGridTools::FsSize_t, 3> gridSize = technicalGrid.getGlobalSize();
+      std::array<FsGridTools::FsSize_t, 3> gridSize = technicalGrid.getGlobalSize();
       uint64_t maxTracingSteps = 8 * (gridSize[0] * technicalGrid.DX + gridSize[1] * technicalGrid.DY + gridSize[2] * technicalGrid.DZ) / stepSize;
       
       std::vector<int> nodeMapping(nodes.size(), TracingLineEndType::UNPROCESSED);                                 /*!< For reduction of node coupling */
@@ -857,8 +857,8 @@ namespace FieldTracing {
       const TReal stepSize = min(1000e3, technicalGrid.DX / 2.);
       std::vector<TReal> cellFWTracingStepSize(globalDccrgSize, stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
       std::vector<TReal> cellBWTracingStepSize(globalDccrgSize, stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
-
-      const std::array<FsGridTools::FsSize_t, 3> gridSize = technicalGrid.getGlobalSize();
+      
+      std::array<FsGridTools::FsSize_t, 3> gridSize = technicalGrid.getGlobalSize();
       // If fullbox_and_fluxrope_max_distance is unset, use this heuristic considering how far an IMF+dipole combo can sensibly stretch in the box before we're safe to assume it's rolled up more or less pathologically.
       const TReal maxTracingDistance = fieldTracingParameters.fullbox_and_fluxrope_max_distance > 0 ? fieldTracingParameters.fullbox_and_fluxrope_max_distance : gridSize[0] * technicalGrid.DX + gridSize[1] * technicalGrid.DY + gridSize[2] * technicalGrid.DZ;
       

--- a/fieldtracing/fieldtracing.cpp
+++ b/fieldtracing/fieldtracing.cpp
@@ -489,7 +489,7 @@ namespace FieldTracing {
       const TReal stepSize = min(1000e3, technicalGrid.DX / 2.);
       std::vector<TReal> nodeTracingStepSize(nodes.size(), stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
       std::vector<TReal> reducedNodeTracingStepSize(nodes.size());
-      std::array<FsGridTools::FsSize_t, 3> gridSize = technicalGrid.getGlobalSize();
+      const std::array<FsGridTools::FsSize_t, 3> gridSize = technicalGrid.getGlobalSize();
       uint64_t maxTracingSteps = 8 * (gridSize[0] * technicalGrid.DX + gridSize[1] * technicalGrid.DY + gridSize[2] * technicalGrid.DZ) / stepSize;
       
       std::vector<int> nodeMapping(nodes.size(), TracingLineEndType::UNPROCESSED);                                 /*!< For reduction of node coupling */
@@ -857,8 +857,8 @@ namespace FieldTracing {
       const TReal stepSize = min(1000e3, technicalGrid.DX / 2.);
       std::vector<TReal> cellFWTracingStepSize(globalDccrgSize, stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
       std::vector<TReal> cellBWTracingStepSize(globalDccrgSize, stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
-      
-      std::array<FsGridTools::FsSize_t, 3> gridSize = technicalGrid.getGlobalSize();
+
+      const std::array<FsGridTools::FsSize_t, 3> gridSize = technicalGrid.getGlobalSize();
       // If fullbox_and_fluxrope_max_distance is unset, use this heuristic considering how far an IMF+dipole combo can sensibly stretch in the box before we're safe to assume it's rolled up more or less pathologically.
       const TReal maxTracingDistance = fieldTracingParameters.fullbox_and_fluxrope_max_distance > 0 ? fieldTracingParameters.fullbox_and_fluxrope_max_distance : gridSize[0] * technicalGrid.DX + gridSize[1] * technicalGrid.DY + gridSize[2] * technicalGrid.DZ;
       

--- a/fieldtracing/fieldtracing.h
+++ b/fieldtracing/fieldtracing.h
@@ -37,11 +37,7 @@ typedef float TReal;
 // Get the (integer valued) global fsgrid cell index (i,j,k) for the magnetic-field traced mapping point that node n is
 // associated with
 template<class T> std::array<FsGridTools::FsSize_t, 3> getGlobalFsGridCellIndexForCoord(T& grid,const std::array<Real, 3>& x) {
-   std::array<FsGridTools::FsSize_t, 3> retval;
-   retval[0] = floor((x[0] - grid.physicalGlobalStart[0]) / grid.DX);
-   retval[1] = floor((x[1] - grid.physicalGlobalStart[1]) / grid.DY);
-   retval[2] = floor((x[2] - grid.physicalGlobalStart[2]) / grid.DZ);
-   return retval;
+   return grid.physicalToGlobal(x[0], x[1], x[2]);
 }
 // Get the (integer valued) local fsgrid cell index (i,j,k) for the magnetic-field traced mapping point that node n is
 // associated with If the cell is not in our local domain, will return {-1,-1,-1}
@@ -61,12 +57,7 @@ template<class T> std::array<FsGridTools::FsIndex_t, 3> getLocalFsGridCellIndexW
 // Get the fraction fsgrid cell index for the magnetic-field traced mapping point that node n is associated with.
 // Note that these are floating point values between 0 and 1
 template<class T> std::array<Real, 3> getFractionalFsGridCellForCoord(T& grid, const std::array<Real, 3>& x) {
-   std::array<Real, 3> retval;
-   std::array<FsGridTools::FsSize_t, 3> fsgridCell = getGlobalFsGridCellIndexForCoord(grid,x);
-   retval[0] = (x[0] - grid.physicalGlobalStart[0]) / grid.DX - fsgridCell[0];
-   retval[1] = (x[1] - grid.physicalGlobalStart[1]) / grid.DY - fsgridCell[1];
-   retval[2] = (x[2] - grid.physicalGlobalStart[2]) / grid.DZ - fsgridCell[2];
-   return retval;
+   return grid.physicalToFractionalGlobal(x[0], x[1], x[2]);
 }
 
 namespace FieldTracing {

--- a/grid.cpp
+++ b/grid.cpp
@@ -1511,7 +1511,7 @@ void mapRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
       for (FsGridTools::FsIndex_t j=0; j<localDims[1]; j++) {
          for (FsGridTools::FsIndex_t i=0; i<localDims[0]; i++) {
 
-            const std::array<FsGridTools::FsIndex_t, 3> mapIndices = technicalGrid.localToGlobal(i, j, k);
+            const std::array<FsGridTools::FsSize_t, 3> mapIndices = technicalGrid.localToGlobal(i, j, k);
             const dccrg::Types<3>::indices_t  indices = {{(uint64_t)mapIndices[0],(uint64_t)mapIndices[1],(uint64_t)mapIndices[2]}}; //cast to avoid warnings
             CellID dccrgCellID2 = mpiGrid.get_existing_cell(indices, 0, mpiGrid.mapping.get_maximum_refinement_level());
             int amrLevel= mpiGrid.get_refinement_level(dccrgCellID2);

--- a/grid.cpp
+++ b/grid.cpp
@@ -1511,7 +1511,7 @@ void mapRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
       for (FsGridTools::FsIndex_t j=0; j<localDims[1]; j++) {
          for (FsGridTools::FsIndex_t i=0; i<localDims[0]; i++) {
 
-            const std::array<FsGridTools::FsIndex_t, 3> mapIndices = technicalGrid.getGlobalIndices(i,j,k);
+            const std::array<FsGridTools::FsIndex_t, 3> mapIndices = technicalGrid.localToGlobal(i, j, k);
             const dccrg::Types<3>::indices_t  indices = {{(uint64_t)mapIndices[0],(uint64_t)mapIndices[1],(uint64_t)mapIndices[2]}}; //cast to avoid warnings
             CellID dccrgCellID2 = mpiGrid.get_existing_cell(indices, 0, mpiGrid.mapping.get_maximum_refinement_level());
             int amrLevel= mpiGrid.get_refinement_level(dccrgCellID2);

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -858,9 +858,9 @@ template<unsigned long int N> bool readFsGridVariable(
    MPI_Comm_size(MPI_COMM_WORLD, &size);
    MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
 
-   std::array<FsGridTools::FsIndex_t,3>& localSize = targetGrid.getLocalSize();
-   std::array<FsGridTools::FsIndex_t,3>& localStart = targetGrid.getLocalStart();
-   std::array<FsGridTools::FsSize_t,3>& globalSize = targetGrid.getGlobalSize();
+   const auto& localSize = targetGrid.getLocalSize();
+   const auto& localStart = targetGrid.getLocalStart();
+   const auto& globalSize = targetGrid.getGlobalSize();
 
    // Determine our tasks storage size
    size_t storageSize = localSize[0]*localSize[1]*localSize[2];
@@ -888,7 +888,7 @@ template<unsigned long int N> bool readFsGridVariable(
       }
    }
 
-   std::array<FsGridTools::Task_t,3> decomposition = targetGrid.getDecomposition();
+   const auto& decomposition = targetGrid.getDecomposition();
    // targetGrid.computeDomainDecomposition(globalSize, size, decomposition);
 
    if(decomposition == fileDecomposition) {

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -860,7 +860,7 @@ template<unsigned long int N> bool readFsGridVariable(
 
    std::array<FsGridTools::FsIndex_t,3>& localSize = targetGrid.getLocalSize();
    std::array<FsGridTools::FsIndex_t,3>& localStart = targetGrid.getLocalStart();
-   const std::array<FsGridTools::FsSize_t, 3>& globalSize = targetGrid.getGlobalSize();
+   std::array<FsGridTools::FsSize_t,3>& globalSize = targetGrid.getGlobalSize();
 
    // Determine our tasks storage size
    size_t storageSize = localSize[0]*localSize[1]*localSize[2];

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -899,9 +899,9 @@ template<unsigned long int N> bool readFsGridVariable(
       size_t localStartOffset = 0;
       for(FsGridTools::Task_t task = 0; task < myRank; task++) {
          std::array<FsGridTools::FsIndex_t, 3> thatTasksSize;
-         thatTasksSize[0] = targetGrid.calcLocalSize(globalSize[0], decomposition[0], task/decomposition[2]/decomposition[1]);
-         thatTasksSize[1] = targetGrid.calcLocalSize(globalSize[1], decomposition[1], (task/decomposition[2])%decomposition[1]);
-         thatTasksSize[2] = targetGrid.calcLocalSize(globalSize[2], decomposition[2], task%decomposition[2]);
+         thatTasksSize[0] = FsGridTools::calcLocalSize(globalSize[0], decomposition[0], task/decomposition[2]/decomposition[1]);
+         thatTasksSize[1] = FsGridTools::calcLocalSize(globalSize[1], decomposition[1], (task/decomposition[2])%decomposition[1]);
+         thatTasksSize[2] = FsGridTools::calcLocalSize(globalSize[2], decomposition[2], task%decomposition[2]);
          localStartOffset += thatTasksSize[0] * thatTasksSize[1] * thatTasksSize[2];
       }
       
@@ -953,13 +953,13 @@ template<unsigned long int N> bool readFsGridVariable(
 
          std::array<FsGridTools::FsIndex_t,3> thatTasksSize;
          std::array<FsGridTools::FsIndex_t,3> thatTasksStart;
-         thatTasksSize[0] = targetGrid.calcLocalSize(globalSize[0], fileDecomposition[0], task/fileDecomposition[2]/fileDecomposition[1]);
-         thatTasksSize[1] = targetGrid.calcLocalSize(globalSize[1], fileDecomposition[1], (task/fileDecomposition[2])%fileDecomposition[1]);
-         thatTasksSize[2] = targetGrid.calcLocalSize(globalSize[2], fileDecomposition[2], task%fileDecomposition[2]);
+         thatTasksSize[0] = FsGridTools::calcLocalSize(globalSize[0], fileDecomposition[0], task/fileDecomposition[2]/fileDecomposition[1]);
+         thatTasksSize[1] = FsGridTools::calcLocalSize(globalSize[1], fileDecomposition[1], (task/fileDecomposition[2])%fileDecomposition[1]);
+         thatTasksSize[2] = FsGridTools::calcLocalSize(globalSize[2], fileDecomposition[2], task%fileDecomposition[2]);
 
-         thatTasksStart[0] = targetGrid.calcLocalStart(globalSize[0], fileDecomposition[0], task/fileDecomposition[2]/fileDecomposition[1]);
-         thatTasksStart[1] = targetGrid.calcLocalStart(globalSize[1], fileDecomposition[1], (task/fileDecomposition[2])%fileDecomposition[1]);
-         thatTasksStart[2] = targetGrid.calcLocalStart(globalSize[2], fileDecomposition[2], task%fileDecomposition[2]);
+         thatTasksStart[0] = FsGridTools::calcLocalStart(globalSize[0], fileDecomposition[0], task/fileDecomposition[2]/fileDecomposition[1]);
+         thatTasksStart[1] = FsGridTools::calcLocalStart(globalSize[1], fileDecomposition[1], (task/fileDecomposition[2])%fileDecomposition[1]);
+         thatTasksStart[2] = FsGridTools::calcLocalStart(globalSize[2], fileDecomposition[2], task%fileDecomposition[2]);
 
          // Iterate through overlap area
          std::array<FsGridTools::FsIndex_t,3> overlapStart,overlapEnd,overlapSize;

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -860,7 +860,7 @@ template<unsigned long int N> bool readFsGridVariable(
 
    std::array<FsGridTools::FsIndex_t,3>& localSize = targetGrid.getLocalSize();
    std::array<FsGridTools::FsIndex_t,3>& localStart = targetGrid.getLocalStart();
-   std::array<FsGridTools::FsSize_t,3>& globalSize = targetGrid.getGlobalSize();
+   const std::array<FsGridTools::FsSize_t, 3>& globalSize = targetGrid.getGlobalSize();
 
    // Determine our tasks storage size
    size_t storageSize = localSize[0]*localSize[1]*localSize[2];

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -886,7 +886,7 @@ bool writeFsGridMetadata(FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technic
 
   //The visit plugin expects MESH_BBOX as a keyword. We only write one
   //from the first rank.
-  const std::array<FsGridTools::FsSize_t, 3>& globalSize = technicalGrid.getGlobalSize();
+  std::array<FsGridTools::FsSize_t, 3>& globalSize = technicalGrid.getGlobalSize();
   std::array<FsGridTools::FsSize_t, 6> boundaryBox({globalSize[0], globalSize[1], globalSize[2],
       1,1,1});
 

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -939,7 +939,7 @@ bool writeFsGridMetadata(FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technic
   vlsvWriter.writeArray("MESH_DOMAIN_SIZES", xmlAttributes, 1, 2, &meshDomainSize[0]);
 
   // how many MPI ranks we wrote from
-  int size = technicalGrid.getSize();
+  int size = technicalGrid.getNumFsRanks();
   vlsvWriter.writeParameter("numWritingRanks", &size);
 
   // Save the FSgrid decomposition

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -886,7 +886,7 @@ bool writeFsGridMetadata(FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technic
 
   //The visit plugin expects MESH_BBOX as a keyword. We only write one
   //from the first rank.
-  std::array<FsGridTools::FsSize_t, 3>& globalSize = technicalGrid.getGlobalSize();
+  const std::array<FsGridTools::FsSize_t, 3>& globalSize = technicalGrid.getGlobalSize();
   std::array<FsGridTools::FsSize_t, 6> boundaryBox({globalSize[0], globalSize[1], globalSize[2],
       1,1,1});
 

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -966,7 +966,7 @@ bool writeFsGridMetadata(FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technic
      for(int z=0; z<localSize[2]; z++) {
         for(int y=0; y<localSize[1]; y++) {
            for(int x=0; x<localSize[0]; x++) {
-              std::array<FsGridTools::FsIndex_t,3> globalIndex = technicalGrid.getGlobalIndices(x,y,z);
+              std::array<FsGridTools::FsIndex_t, 3> globalIndex = technicalGrid.localToGlobal(x, y, z);
               globalIds[i++] = globalIndex[2]*globalSize[0]*globalSize[1]+
                  globalIndex[1]*globalSize[0] +
                  globalIndex[0];

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -961,12 +961,13 @@ bool writeFsGridMetadata(FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technic
 
   if (writeIDs) {
      // Write cell "globalID" numbers, which are just the global array indices.
-     std::vector<FsGridTools::FsIndex_t> globalIds(localSize[0]*localSize[1]*localSize[2]);
+     std::vector<FsGridTools::FsSize_t> globalIds(
+         static_cast<FsGridTools::FsSize_t>(localSize[0] * localSize[1] * localSize[2]));
      int i=0;
      for(int z=0; z<localSize[2]; z++) {
         for(int y=0; y<localSize[1]; y++) {
            for(int x=0; x<localSize[0]; x++) {
-              std::array<FsGridTools::FsIndex_t, 3> globalIndex = technicalGrid.localToGlobal(x, y, z);
+              const std::array<FsGridTools::FsSize_t, 3> globalIndex = technicalGrid.localToGlobal(x, y, z);
               globalIds[i++] = globalIndex[2]*globalSize[0]*globalSize[1]+
                  globalIndex[1]*globalSize[0] +
                  globalIndex[0];

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -886,7 +886,7 @@ bool writeFsGridMetadata(FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technic
 
   //The visit plugin expects MESH_BBOX as a keyword. We only write one
   //from the first rank.
-  std::array<FsGridTools::FsSize_t, 3>& globalSize = technicalGrid.getGlobalSize();
+  const std::array<FsGridTools::FsSize_t, 3>& globalSize = technicalGrid.getGlobalSize();
   std::array<FsGridTools::FsSize_t, 6> boundaryBox({globalSize[0], globalSize[1], globalSize[2],
       1,1,1});
 
@@ -934,7 +934,7 @@ bool writeFsGridMetadata(FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technic
   vlsvWriter.writeArray("MESH_GHOST_LOCALIDS", xmlAttributes, 0, 1, &dummyghost);
 
   // writeDomainSizes
-  std::array<FsGridTools::FsIndex_t,3>& localSize = technicalGrid.getLocalSize();
+  const std::array<FsGridTools::FsIndex_t, 3>& localSize = technicalGrid.getLocalSize();
   std::array<uint64_t,2> meshDomainSize({(uint64_t)localSize[0]*(uint64_t)localSize[1]*(uint64_t)localSize[2], 0});
   vlsvWriter.writeArray("MESH_DOMAIN_SIZES", xmlAttributes, 1, 2, &meshDomainSize[0]);
 
@@ -1671,57 +1671,57 @@ bool writeRestart(
    restartReducer.addOperator(new DRO::BoundaryLayer);
 
    // Fsgrid Reducers
-   restartReducer.addOperator(new DRO::DataReductionOperatorFsGrid("fg_E",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<Real> {
-            std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-            std::vector<Real> retval(gridSize[0]*gridSize[1]*gridSize[2]*fsgrids::efield::N_EFIELD);
-            int index=0;
-            for(FsGridTools::FsIndex_t z=0; z<gridSize[2]; z++) {
-               for(FsGridTools::FsIndex_t y=0; y<gridSize[1]; y++) {
-                  for(FsGridTools::FsIndex_t x=0; x<gridSize[0]; x++) {
-                     std::memcpy(&retval[index], EGrid.get(x,y,z), sizeof(Real)*fsgrids::efield::N_EFIELD);
-                     index += fsgrids::efield::N_EFIELD;
-                  }
-               }
-            }
-            return retval;
-         }
-   ));
-   
-   restartReducer.addOperator(new DRO::DataReductionOperatorFsGrid("fg_PERB",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<Real> {
-            std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-            std::vector<Real> retval(gridSize[0]*gridSize[1]*gridSize[2]*fsgrids::bfield::N_BFIELD);
-            int index=0;
-            for(FsGridTools::FsIndex_t z=0; z<gridSize[2]; z++) {
-               for(FsGridTools::FsIndex_t y=0; y<gridSize[1]; y++) {
-                  for(FsGridTools::FsIndex_t x=0; x<gridSize[0]; x++) {
-                     std::memcpy(&retval[index], perBGrid.get(x,y,z), sizeof(Real)*fsgrids::bfield::N_BFIELD);
-                     index += fsgrids::bfield::N_BFIELD;
-                  }
-               }
-            }
-            return retval;
-         }
-   ));
+   restartReducer.addOperator(new DRO::DataReductionOperatorFsGrid(
+       "fg_E",
+       [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+          FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+          FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+          FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+          FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+          FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+          FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+          FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+          FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+          FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<Real> {
+          const std::array<FsGridTools::FsIndex_t, 3>& gridSize = technicalGrid.getLocalSize();
+          std::vector<Real> retval(gridSize[0] * gridSize[1] * gridSize[2] * fsgrids::efield::N_EFIELD);
+          int index = 0;
+          for (FsGridTools::FsIndex_t z = 0; z < gridSize[2]; z++) {
+             for (FsGridTools::FsIndex_t y = 0; y < gridSize[1]; y++) {
+                for (FsGridTools::FsIndex_t x = 0; x < gridSize[0]; x++) {
+                   std::memcpy(&retval[index], EGrid.get(x, y, z), sizeof(Real) * fsgrids::efield::N_EFIELD);
+                   index += fsgrids::efield::N_EFIELD;
+                }
+             }
+          }
+          return retval;
+       }));
+
+   restartReducer.addOperator(new DRO::DataReductionOperatorFsGrid(
+       "fg_PERB",
+       [](FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
+          FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
+          FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
+          FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
+          FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
+          FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
+          FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
+          FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+          FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
+          FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid) -> std::vector<Real> {
+          const auto& gridSize = technicalGrid.getLocalSize();
+          std::vector<Real> retval(gridSize[0] * gridSize[1] * gridSize[2] * fsgrids::bfield::N_BFIELD);
+          int index = 0;
+          for (FsGridTools::FsIndex_t z = 0; z < gridSize[2]; z++) {
+             for (FsGridTools::FsIndex_t y = 0; y < gridSize[1]; y++) {
+                for (FsGridTools::FsIndex_t x = 0; x < gridSize[0]; x++) {
+                   std::memcpy(&retval[index], perBGrid.get(x, y, z), sizeof(Real) * fsgrids::bfield::N_BFIELD);
+                   index += fsgrids::bfield::N_BFIELD;
+                }
+             }
+          }
+          return retval;
+       }));
 
    // Add ionosphere restart variables
    // (To reconstruct state, we need the time-smoothed downmapped quantities: FACs, rhon and pressure.

--- a/mini-apps/balsaraFsgrid/main.cpp
+++ b/mini-apps/balsaraFsgrid/main.cpp
@@ -141,13 +141,12 @@ int main(int argc, char** argv) {
    // Set up fsgrids
    const std::array<int,3> fsGridDimensions = {5,5,5};
    std::array<bool,3> periodicity{true,true,true};
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> technicalGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity);
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> perBGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity);
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> dPerBGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity);
-   perBGrid.DX = dPerBGrid.DX = technicalGrid.DX = 1.;
-   perBGrid.DY = dPerBGrid.DY = technicalGrid.DY = 1.;
-   perBGrid.DZ = dPerBGrid.DZ = technicalGrid.DZ = 1.;
-   perBGrid.physicalGlobalStart = dPerBGrid.physicalGlobalStart = technicalGrid.physicalGlobalStart = {0,0,0};
+   FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> technicalGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,
+                                                              {1.0, 1.0, 1.0}, {0, 0, 0});
+   FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> perBGrid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, {1.0, 1.0, 1.0}, {0, 0, 0});
+   FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> dPerBGrid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, {1.0, 1.0, 1.0}, {0, 0, 0});
 
    // Fill in values
    for(int i=0; i< 5; i++) {

--- a/particles/readfields.h
+++ b/particles/readfields.h
@@ -219,8 +219,7 @@ std::vector<double> readFsGridData(Reader& r, std::string& name, unsigned int nu
    // |            |                |
    // +------------+----------------+
 
-   std::array<int,3> fileDecomposition;
-   FsGridTools::computeDomainDecomposition(size, numWritingRanks, fileDecomposition);
+   std::array<int, 3> fileDecomposition = FsGridTools::computeDomainDecomposition(size, numWritingRanks, 0);
    //computeFsGridDecomposition(size, numWritingRanks, fileDecomposition);
 
 

--- a/particles/readfields.h
+++ b/particles/readfields.h
@@ -219,9 +219,7 @@ std::vector<double> readFsGridData(Reader& r, std::string& name, unsigned int nu
    // |            |                |
    // +------------+----------------+
 
-   std::array<int, 3> fileDecomposition = FsGridTools::computeDomainDecomposition(size, numWritingRanks, 0);
-   //computeFsGridDecomposition(size, numWritingRanks, fileDecomposition);
-
+   const std::array<int, 3> fileDecomposition = FsGridTools::computeDomainDecomposition(size, numWritingRanks);
 
    // Iterate through tasks and find their overlap with our domain.
    size_t fileOffset = 0;

--- a/projects/Alfven/Alfven.cpp
+++ b/projects/Alfven/Alfven.cpp
@@ -146,9 +146,9 @@ namespace projects {
                for (FsGridTools::FsIndex_t z = 0; z < localSize[2]; ++z) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  
-                  Real dx = perBGrid.DX;
-                  Real dy = perBGrid.DY;
+
+                  Real dx = perBGrid.getGridSpacing()[0];
+                  Real dy = perBGrid.getGridSpacing()[1];
                   Real ksi = ((xyz[0] + 0.5 * dx)  * cos(this->ALPHA) + (xyz[1] + 0.5 * dy) * sin(this->ALPHA)) / this->WAVELENGTH;
                   Real dBxavg = sin(2.0 * M_PI * ksi);
                   Real dByavg = sin(2.0 * M_PI * ksi);

--- a/projects/Dispersion/Dispersion.cpp
+++ b/projects/Dispersion/Dispersion.cpp
@@ -231,8 +231,8 @@ namespace projects {
             for (FsGridTools::FsIndex_t y = 0; y < localSize[1]; ++y) {
                for (FsGridTools::FsIndex_t z = 0; z < localSize[2]; ++z) {
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  const int64_t cellid = perBGrid.GlobalIDForCoords(x, y, z);
-                  
+                  const int64_t cellid = perBGrid.globalIDFromLocalCoordinates(x, y, z);
+
                   std::default_random_engine rndState;
                   setRandomSeed(cellid,rndState);
                   

--- a/projects/Distributions/Distributions.cpp
+++ b/projects/Distributions/Distributions.cpp
@@ -177,7 +177,7 @@ namespace projects {
             for (FsGridTools::FsIndex_t y = 0; y < localSize[1]; ++y) {
                for (FsGridTools::FsIndex_t z = 0; z < localSize[2]; ++z) {
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  const int64_t cellid = perBGrid.GlobalIDForCoords(x, y, z);
+                  const int64_t cellid = perBGrid.globalIDFromLocalCoordinates(x, y, z);
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
                   
                   std::default_random_engine rndState;

--- a/projects/Fluctuations/Fluctuations.cpp
+++ b/projects/Fluctuations/Fluctuations.cpp
@@ -165,8 +165,8 @@ namespace projects {
             for (FsGridTools::FsIndex_t y = 0; y < localSize[1]; ++y) {
                for (FsGridTools::FsIndex_t z = 0; z < localSize[2]; ++z) {
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  const int64_t cellid = perBGrid.GlobalIDForCoords(x, y, z);
-                  
+                  const int64_t cellid = perBGrid.globalIDFromLocalCoordinates(x, y, z);
+
                   std::default_random_engine rndState;
                   setRandomSeed(cellid,rndState);
                   

--- a/projects/Harris/Harris.cpp
+++ b/projects/Harris/Harris.cpp
@@ -125,17 +125,21 @@ namespace projects {
       
       if(!P::isRestart) {
          auto localSize = perBGrid.getLocalSize().data();
-         
-         #pragma omp parallel for collapse(3)
+         const auto& gridSpacing = perBGrid.getGridSpacing();
+
+#pragma omp parallel for collapse(3)
          for (FsGridTools::FsIndex_t x = 0; x < localSize[0]; ++x) {
             for (FsGridTools::FsIndex_t y = 0; y < localSize[1]; ++y) {
                for (FsGridTools::FsIndex_t z = 0; z < localSize[2]; ++z) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  
-                  cell->at(fsgrids::bfield::PERBX) = this->BX0 * tanh((xyz[1] + 0.5 * perBGrid.DY) / this->SCA_LAMBDA);
-                  cell->at(fsgrids::bfield::PERBY) = this->BY0 * tanh((xyz[2] + 0.5 * perBGrid.DZ) / this->SCA_LAMBDA);
-                  cell->at(fsgrids::bfield::PERBZ) = this->BZ0 * tanh((xyz[0] + 0.5 * perBGrid.DX) / this->SCA_LAMBDA);
+
+                  cell->at(fsgrids::bfield::PERBX) =
+                      this->BX0 * tanh((xyz[1] + 0.5 * gridSpacing[1]) / this->SCA_LAMBDA);
+                  cell->at(fsgrids::bfield::PERBY) =
+                      this->BY0 * tanh((xyz[2] + 0.5 * gridSpacing[2]) / this->SCA_LAMBDA);
+                  cell->at(fsgrids::bfield::PERBZ) =
+                      this->BZ0 * tanh((xyz[0] + 0.5 * gridSpacing[0]) / this->SCA_LAMBDA);
                }
             }
          }

--- a/projects/KHB/KHB.cpp
+++ b/projects/KHB/KHB.cpp
@@ -178,17 +178,21 @@ namespace projects {
       
       if(!P::isRestart) {
          auto localSize = perBGrid.getLocalSize().data();
-         
-         #pragma omp parallel for collapse(3)
+         const auto& gridSpacing = perBGrid.getGridSpacing();
+
+#pragma omp parallel for collapse(3)
          for (FsGridTools::FsIndex_t x = 0; x < localSize[0]; ++x) {
             for (FsGridTools::FsIndex_t y = 0; y < localSize[1]; ++y) {
                for (FsGridTools::FsIndex_t z = 0; z < localSize[2]; ++z) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  
-                  cell->at(fsgrids::bfield::PERBX) = profile(this->Bx[this->BOTTOM], this->Bx[this->TOP], xyz[0]+0.5*perBGrid.DX);
-                  cell->at(fsgrids::bfield::PERBY) = profile(this->By[this->BOTTOM], this->By[this->TOP], xyz[0]+0.5*perBGrid.DX);
-                  cell->at(fsgrids::bfield::PERBZ) = profile(this->Bz[this->BOTTOM], this->Bz[this->TOP], xyz[0]+0.5*perBGrid.DX);
+
+                  cell->at(fsgrids::bfield::PERBX) =
+                      profile(this->Bx[this->BOTTOM], this->Bx[this->TOP], xyz[0] + 0.5 * gridSpacing[0]);
+                  cell->at(fsgrids::bfield::PERBY) =
+                      profile(this->By[this->BOTTOM], this->By[this->TOP], xyz[0] + 0.5 * gridSpacing[0]);
+                  cell->at(fsgrids::bfield::PERBZ) =
+                      profile(this->Bz[this->BOTTOM], this->Bz[this->TOP], xyz[0] + 0.5 * gridSpacing[0]);
                }
             }
          }

--- a/projects/MultiPeak/MultiPeak.cpp
+++ b/projects/MultiPeak/MultiPeak.cpp
@@ -192,7 +192,7 @@ namespace projects {
                for (FsGridTools::FsIndex_t z = 0; z < localSize[2]; ++z) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(x, y, z);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(x, y, z);
-                  const int64_t cellid = perBGrid.GlobalIDForCoords(x, y, z);
+                  const int64_t cellid = perBGrid.globalIDFromLocalCoordinates(x, y, z);
                   std::default_random_engine rndState;
                   setRandomSeed(cellid,rndState);
 

--- a/projects/test_fp/test_fp.cpp
+++ b/projects/test_fp/test_fp.cpp
@@ -114,11 +114,12 @@ namespace projects {
       
       if(!P::isRestart) {
          auto localSize = perBGrid.getLocalSize().data();
-         
-         creal dx = perBGrid.DX * 3.5;
-         creal dy = perBGrid.DY * 3.5;
-         creal dz = perBGrid.DZ * 3.5;
-         
+         const auto& gridSpacing = perBGrid.getGridSpacing();
+
+         creal dx = gridSpacing[0] * 3.5;
+         creal dy = gridSpacing[1] * 3.5;
+         creal dz = gridSpacing[2] * 3.5;
+
          Real areaFactor = 1.0;
          
          #pragma omp parallel for collapse(3)
@@ -127,11 +128,12 @@ namespace projects {
                for (FsGridTools::FsIndex_t k = 0; k < localSize[2]; ++k) {
                   const std::array<Real, 3> xyz = perBGrid.getPhysicalCoords(i, j, k);
                   std::array<Real, fsgrids::bfield::N_BFIELD>* cell = perBGrid.get(i, j, k);
-                  
-                  creal x = xyz[0] + 0.5 * perBGrid.DX;
-                  creal y = xyz[1] + 0.5 * perBGrid.DY;
-                  creal z = xyz[2] + 0.5 * perBGrid.DZ;
-                  
+                  const auto& gridSpacing = perBGrid.getGridSpacing();
+
+                  creal x = xyz[0] + 0.5 * gridSpacing[0];
+                  creal y = xyz[1] + 0.5 * gridSpacing[1];
+                  creal z = xyz[2] + 0.5 * gridSpacing[2];
+
                   switch (this->CASE) {
                      case BXCASE:         
                         cell->at(fsgrids::bfield::PERBX) = 0.1 * this->B0 * areaFactor;

--- a/sysboundary/copysphere.cpp
+++ b/sysboundary/copysphere.cpp
@@ -216,7 +216,7 @@ namespace SBC {
       creal dx = technicalGrid.DX;
       creal dy = technicalGrid.DY;
       creal dz = technicalGrid.DZ;
-      const std::array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.getGlobalIndices(i,j,k);
+      const std::array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.localToGlobal(i, j, k);
       creal x = P::xmin + (convert<Real>(globalIndices[0])+0.5)*dx;
       creal y = P::ymin + (convert<Real>(globalIndices[1])+0.5)*dy;
       creal z = P::zmin + (convert<Real>(globalIndices[2])+0.5)*dz;

--- a/sysboundary/copysphere.cpp
+++ b/sysboundary/copysphere.cpp
@@ -216,7 +216,7 @@ namespace SBC {
       creal dx = technicalGrid.DX;
       creal dy = technicalGrid.DY;
       creal dz = technicalGrid.DZ;
-      const std::array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.localToGlobal(i, j, k);
+      const std::array<FsGridTools::FsSize_t, 3> globalIndices = technicalGrid.localToGlobal(i, j, k);
       creal x = P::xmin + (convert<Real>(globalIndices[0])+0.5)*dx;
       creal y = P::ymin + (convert<Real>(globalIndices[1])+0.5)*dy;
       creal z = P::zmin + (convert<Real>(globalIndices[2])+0.5)*dz;

--- a/sysboundary/copysphere.cpp
+++ b/sysboundary/copysphere.cpp
@@ -212,10 +212,12 @@ namespace SBC {
       
       static creal DIAG2 = 1.0 / sqrt(2.0);
       static creal DIAG3 = 1.0 / sqrt(3.0);
-      
-      creal dx = technicalGrid.DX;
-      creal dy = technicalGrid.DY;
-      creal dz = technicalGrid.DZ;
+
+      const auto& gridSpacing = technicalGrid.getGridSpacing();
+
+      creal dx = gridSpacing[0];
+      creal dy = gridSpacing[1];
+      creal dz = gridSpacing[2];
       const std::array<FsGridTools::FsSize_t, 3> globalIndices = technicalGrid.localToGlobal(i, j, k);
       creal x = P::xmin + (convert<Real>(globalIndices[0])+0.5)*dx;
       creal y = P::ymin + (convert<Real>(globalIndices[1])+0.5)*dy;

--- a/sysboundary/inflow.cpp
+++ b/sysboundary/inflow.cpp
@@ -194,7 +194,7 @@ Real Inflow::fieldSolverBoundaryCondMagneticField(
    creal dx = Parameters::dx_ini;
    creal dy = Parameters::dy_ini;
    creal dz = Parameters::dz_ini;
-   const array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.localToGlobal(i, j, k);
+   const array<FsGridTools::FsSize_t, 3> globalIndices = technicalGrid.localToGlobal(i, j, k);
    creal x = (convert<Real>(globalIndices[0]) + 0.5) * technicalGrid.DX + Parameters::xmin;
    creal y = (convert<Real>(globalIndices[1]) + 0.5) * technicalGrid.DY + Parameters::ymin;
    creal z = (convert<Real>(globalIndices[2]) + 0.5) * technicalGrid.DZ + Parameters::zmin;

--- a/sysboundary/inflow.cpp
+++ b/sysboundary/inflow.cpp
@@ -194,7 +194,7 @@ Real Inflow::fieldSolverBoundaryCondMagneticField(
    creal dx = Parameters::dx_ini;
    creal dy = Parameters::dy_ini;
    creal dz = Parameters::dz_ini;
-   const array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.getGlobalIndices(i, j, k);
+   const array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.localToGlobal(i, j, k);
    creal x = (convert<Real>(globalIndices[0]) + 0.5) * technicalGrid.DX + Parameters::xmin;
    creal y = (convert<Real>(globalIndices[1]) + 0.5) * technicalGrid.DY + Parameters::ymin;
    creal z = (convert<Real>(globalIndices[2]) + 0.5) * technicalGrid.DZ + Parameters::zmin;

--- a/sysboundary/inflow.cpp
+++ b/sysboundary/inflow.cpp
@@ -115,12 +115,13 @@ void Inflow::assignSysBoundary(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geomet
       for (FsGridTools::FsIndex_t j = 0; j < gridDims[1]; j++) {
          for (FsGridTools::FsIndex_t i = 0; i < gridDims[0]; i++) {
             const auto coords = technicalGrid.getPhysicalCoords(i, j, k);
+            const auto& gridSpacing = technicalGrid.getGridSpacing();
 
             // Shift to the center of the fsgrid cell
             auto cellCenterCoords = coords;
-            cellCenterCoords[0] += 0.5 * technicalGrid.DX;
-            cellCenterCoords[1] += 0.5 * technicalGrid.DY;
-            cellCenterCoords[2] += 0.5 * technicalGrid.DZ;
+            cellCenterCoords[0] += 0.5 * gridSpacing[0];
+            cellCenterCoords[1] += 0.5 * gridSpacing[1];
+            cellCenterCoords[2] += 0.5 * gridSpacing[2];
             const auto refLvl = mpiGrid.get_refinement_level(mpiGrid.get_existing_cell(cellCenterCoords));
 
             if (refLvl == -1) {
@@ -195,9 +196,10 @@ Real Inflow::fieldSolverBoundaryCondMagneticField(
    creal dy = Parameters::dy_ini;
    creal dz = Parameters::dz_ini;
    const array<FsGridTools::FsSize_t, 3> globalIndices = technicalGrid.localToGlobal(i, j, k);
-   creal x = (convert<Real>(globalIndices[0]) + 0.5) * technicalGrid.DX + Parameters::xmin;
-   creal y = (convert<Real>(globalIndices[1]) + 0.5) * technicalGrid.DY + Parameters::ymin;
-   creal z = (convert<Real>(globalIndices[2]) + 0.5) * technicalGrid.DZ + Parameters::zmin;
+   const auto& gridSpacing = technicalGrid.getGridSpacing();
+   creal x = (convert<Real>(globalIndices[0]) + 0.5) * gridSpacing[0] + Parameters::xmin;
+   creal y = (convert<Real>(globalIndices[1]) + 0.5) * gridSpacing[1] + Parameters::ymin;
+   creal z = (convert<Real>(globalIndices[2]) + 0.5) * gridSpacing[2] + Parameters::zmin;
 
    bool isThisCellOnAFace[6];
    determineFace(&isThisCellOnAFace[0], x, y, z, dx, dy, dz, true);
@@ -289,9 +291,10 @@ void Inflow::setBFromTemplate(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometr
             // function, it gets called in a lot of places.
             // Shift to the center of the fsgrid cell
             auto cellCenterCoords = coords;
-            cellCenterCoords[0] += 0.5 * perBGrid.DX;
-            cellCenterCoords[1] += 0.5 * perBGrid.DY;
-            cellCenterCoords[2] += 0.5 * perBGrid.DZ;
+            const auto& gridSpacing = perBGrid.getGridSpacing();
+            cellCenterCoords[0] += 0.5 * gridSpacing[0];
+            cellCenterCoords[1] += 0.5 * gridSpacing[1];
+            cellCenterCoords[2] += 0.5 * gridSpacing[2];
 
             const auto refLvl = mpiGrid.get_refinement_level(mpiGrid.get_existing_cell(cellCenterCoords));
 

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -2528,7 +2528,7 @@ namespace SBC {
       creal dx = technicalGrid.DX;
       creal dy = technicalGrid.DY;
       creal dz = technicalGrid.DZ;
-      const std::array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.getGlobalIndices(i,j,k);
+      const std::array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.localToGlobal(i, j, k);
       creal x = P::xmin + (convert<Real>(globalIndices[0])+0.5)*dx;
       creal y = P::ymin + (convert<Real>(globalIndices[1])+0.5)*dy;
       creal z = P::zmin + (convert<Real>(globalIndices[2])+0.5)*dz;

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -1176,16 +1176,23 @@ namespace SBC {
             );
 
             // Dot curl(B) with normalized B, scale by ratio of B(ionosphere)/B(upmapped), multiply by geometric area around ionosphere node to obtain current from density
-            FACinput[n] = nodeAreaGeometric * (nodes[n].parameters[ionosphereParameters::UPMAPPED_BX]*curlB[0] + nodes[n].parameters[ionosphereParameters::UPMAPPED_BY]*curlB[1] + nodes[n].parameters[ionosphereParameters::UPMAPPED_BZ]*curlB[2])
-               * sqrt((nodes[n].parameters[ionosphereParameters::NODE_BX]*nodes[n].parameters[ionosphereParameters::NODE_BX]
-                  + nodes[n].parameters[ionosphereParameters::NODE_BY]*nodes[n].parameters[ionosphereParameters::NODE_BY]
-                  + nodes[n].parameters[ionosphereParameters::NODE_BZ]*nodes[n].parameters[ionosphereParameters::NODE_BZ])
-               )
-               / ((nodes[n].parameters[ionosphereParameters::UPMAPPED_BX]*nodes[n].parameters[ionosphereParameters::UPMAPPED_BX]
-                  + nodes[n].parameters[ionosphereParameters::UPMAPPED_BY]*nodes[n].parameters[ionosphereParameters::UPMAPPED_BY]
-                  + nodes[n].parameters[ionosphereParameters::UPMAPPED_BZ]*nodes[n].parameters[ionosphereParameters::UPMAPPED_BZ])
-               * physicalconstants::MU_0 * technicalGrid.DX
-            );
+            FACinput[n] = nodeAreaGeometric *
+                          (nodes[n].parameters[ionosphereParameters::UPMAPPED_BX] * curlB[0] +
+                           nodes[n].parameters[ionosphereParameters::UPMAPPED_BY] * curlB[1] +
+                           nodes[n].parameters[ionosphereParameters::UPMAPPED_BZ] * curlB[2]) *
+                          sqrt((nodes[n].parameters[ionosphereParameters::NODE_BX] *
+                                    nodes[n].parameters[ionosphereParameters::NODE_BX] +
+                                nodes[n].parameters[ionosphereParameters::NODE_BY] *
+                                    nodes[n].parameters[ionosphereParameters::NODE_BY] +
+                                nodes[n].parameters[ionosphereParameters::NODE_BZ] *
+                                    nodes[n].parameters[ionosphereParameters::NODE_BZ])) /
+                          ((nodes[n].parameters[ionosphereParameters::UPMAPPED_BX] *
+                                nodes[n].parameters[ionosphereParameters::UPMAPPED_BX] +
+                            nodes[n].parameters[ionosphereParameters::UPMAPPED_BY] *
+                                nodes[n].parameters[ionosphereParameters::UPMAPPED_BY] +
+                            nodes[n].parameters[ionosphereParameters::UPMAPPED_BZ] *
+                                nodes[n].parameters[ionosphereParameters::UPMAPPED_BZ]) *
+                           physicalconstants::MU_0 * technicalGrid.getGridSpacing()[0]);
 
             // By definition, a downwards current into the ionosphere has a positive FAC value,
             // as it corresponds to positive divergence of horizontal current in the ionospheric plane.
@@ -2524,10 +2531,11 @@ namespace SBC {
 
       static creal DIAG2 = 1.0 / sqrt(2.0);
       static creal DIAG3 = 1.0 / sqrt(3.0);
+      const auto& gridSpacing = technicalGrid.getGridSpacing();
 
-      creal dx = technicalGrid.DX;
-      creal dy = technicalGrid.DY;
-      creal dz = technicalGrid.DZ;
+      creal dx = gridSpacing[0];
+      creal dy = gridSpacing[1];
+      creal dz = gridSpacing[2];
       const std::array<FsGridTools::FsSize_t, 3> globalIndices = technicalGrid.localToGlobal(i, j, k);
       creal x = P::xmin + (convert<Real>(globalIndices[0])+0.5)*dx;
       creal y = P::ymin + (convert<Real>(globalIndices[1])+0.5)*dy;

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -2528,7 +2528,7 @@ namespace SBC {
       creal dx = technicalGrid.DX;
       creal dy = technicalGrid.DY;
       creal dz = technicalGrid.DZ;
-      const std::array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.localToGlobal(i, j, k);
+      const std::array<FsGridTools::FsSize_t, 3> globalIndices = technicalGrid.localToGlobal(i, j, k);
       creal x = P::xmin + (convert<Real>(globalIndices[0])+0.5)*dx;
       creal y = P::ymin + (convert<Real>(globalIndices[1])+0.5)*dy;
       creal z = P::zmin + (convert<Real>(globalIndices[2])+0.5)*dz;

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -212,12 +212,13 @@ namespace SBC {
          for (FsGridTools::FsIndex_t j=0; j<gridDims[1]; j++) {
             for (FsGridTools::FsIndex_t i=0; i<gridDims[0]; i++) {
                const auto& coords = technicalGrid.getPhysicalCoords(i,j,k);
+               const auto& gridSpacing = technicalGrid.getGridSpacing();
 
                // Shift to the center of the fsgrid cell
                auto cellCenterCoords = coords;
-               cellCenterCoords[0] += 0.5 * technicalGrid.DX;
-               cellCenterCoords[1] += 0.5 * technicalGrid.DY;
-               cellCenterCoords[2] += 0.5 * technicalGrid.DZ;
+               cellCenterCoords[0] += 0.5 * gridSpacing[0];
+               cellCenterCoords[1] += 0.5 * gridSpacing[1];
+               cellCenterCoords[2] += 0.5 * gridSpacing[2];
                const auto refLvl = mpiGrid.get_refinement_level(mpiGrid.get_existing_cell(cellCenterCoords));
 
                if (refLvl == -1) {

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -552,7 +552,7 @@ void SysBoundary::classifyCells(dccrg::Dccrg<spatial_cell::SpatialCell, dccrg::C
          for (FsGridTools::FsIndex_t x = 0; x < localSize[0]; ++x) {
             technicalGrid.get(x, y, z)->SOLVE = 0;
 
-            array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.getGlobalIndices(x, y, z);
+            array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.localToGlobal(x, y, z);
 
             if (((globalIndices[0] == 0 || globalIndices[0] == (FsGridTools::FsIndex_t)fsGridDimensions[0] - 1) &&
                  !this->isPeriodic(0)) ||

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -552,14 +552,11 @@ void SysBoundary::classifyCells(dccrg::Dccrg<spatial_cell::SpatialCell, dccrg::C
          for (FsGridTools::FsIndex_t x = 0; x < localSize[0]; ++x) {
             technicalGrid.get(x, y, z)->SOLVE = 0;
 
-            array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.localToGlobal(x, y, z);
+            const array<FsGridTools::FsSize_t, 3> globalIndices = technicalGrid.localToGlobal(x, y, z);
 
-            if (((globalIndices[0] == 0 || globalIndices[0] == (FsGridTools::FsIndex_t)fsGridDimensions[0] - 1) &&
-                 !this->isPeriodic(0)) ||
-                ((globalIndices[1] == 0 || globalIndices[1] == (FsGridTools::FsIndex_t)fsGridDimensions[1] - 1) &&
-                 !this->isPeriodic(1)) ||
-                ((globalIndices[2] == 0 || globalIndices[2] == (FsGridTools::FsIndex_t)fsGridDimensions[2] - 1) &&
-                 !this->isPeriodic(2))) {
+            if (((globalIndices[0] == 0 || globalIndices[0] == fsGridDimensions[0] - 1) && !this->isPeriodic(0)) ||
+                ((globalIndices[1] == 0 || globalIndices[1] == fsGridDimensions[1] - 1) && !this->isPeriodic(1)) ||
+                ((globalIndices[2] == 0 || globalIndices[2] == fsGridDimensions[2] - 1) && !this->isPeriodic(2))) {
                continue;
             }
             if (technicalGrid.get(x, y, z)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) {

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -410,48 +410,50 @@ int simulate(int argn,char* args[]) {
    // Needs to be done here already ad the background field will be set right away, before going to initializeGrid even
    phiprof::Timer initFsTimer {"Init fieldsolver grids"};
 
-   std::array<FsGridTools::FsSize_t, 3> fsGridDimensions = {convert<FsGridTools::FsSize_t>(P::xcells_ini * pow(2,P::amrMaxSpatialRefLevel)),
-							    convert<FsGridTools::FsSize_t>(P::ycells_ini * pow(2,P::amrMaxSpatialRefLevel)),
-							    convert<FsGridTools::FsSize_t>(P::zcells_ini * pow(2,P::amrMaxSpatialRefLevel))};
+   const std::array<FsGridTools::FsSize_t, 3> fsGridDimensions = {
+       convert<FsGridTools::FsSize_t>(P::xcells_ini * pow(2, P::amrMaxSpatialRefLevel)),
+       convert<FsGridTools::FsSize_t>(P::ycells_ini * pow(2, P::amrMaxSpatialRefLevel)),
+       convert<FsGridTools::FsSize_t>(P::zcells_ini * pow(2, P::amrMaxSpatialRefLevel))};
 
-   std::array<bool,3> periodicity{sysBoundaryContainer.isPeriodic(0),
-                                  sysBoundaryContainer.isPeriodic(1),
-                                  sysBoundaryContainer.isPeriodic(2)};
+   const std::array<bool, 3> periodicity{sysBoundaryContainer.isPeriodic(0), sysBoundaryContainer.isPeriodic(1),
+                                         sysBoundaryContainer.isPeriodic(2)};
 
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> perBGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> perBDt2Grid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> EGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> EDt2Grid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> EHallGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> EGradPeGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> EGradPeDt2Grid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> momentsGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> momentsDt2Grid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> dPerBGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> dMomentsGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> dMomentsDt2Grid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> BgBGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> volGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> technicalGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
+   const std::array gridSpacing{P::dx_ini / pow(2, P::amrMaxSpatialRefLevel),
+                                P::dy_ini / pow(2, P::amrMaxSpatialRefLevel),
+                                P::dz_ini / pow(2, P::amrMaxSpatialRefLevel)};
+   const std::array physicalGlobalStart{P::xmin, P::ymin, P::zmin};
+   const auto decomposition = P::manualFsGridDecomposition;
 
-   // Set DX, DY and DZ
-   // TODO: This is currently just taking the values from cell 1, and assuming them to be
-   // constant throughout the simulation.
-   perBGrid.DX = perBDt2Grid.DX = EGrid.DX = EDt2Grid.DX = EHallGrid.DX = EGradPeGrid.DX = EGradPeDt2Grid.DX = momentsGrid.DX
-      = momentsDt2Grid.DX = dPerBGrid.DX = dMomentsGrid.DX = dMomentsDt2Grid.DX = BgBGrid.DX = volGrid.DX = technicalGrid.DX
-      = P::dx_ini / pow(2, P::amrMaxSpatialRefLevel);
-   perBGrid.DY = perBDt2Grid.DY = EGrid.DY = EDt2Grid.DY = EHallGrid.DY = EGradPeGrid.DY = EGradPeDt2Grid.DY = momentsGrid.DY
-      = momentsDt2Grid.DY = dPerBGrid.DY = dMomentsGrid.DY = dMomentsDt2Grid.DY = BgBGrid.DY = volGrid.DY = technicalGrid.DY
-      = P::dy_ini / pow(2, P::amrMaxSpatialRefLevel);
-   perBGrid.DZ = perBDt2Grid.DZ = EGrid.DZ = EDt2Grid.DZ = EHallGrid.DZ = EGradPeGrid.DZ = EGradPeDt2Grid.DZ = momentsGrid.DZ
-      = momentsDt2Grid.DZ = dPerBGrid.DZ = dMomentsGrid.DZ = dMomentsDt2Grid.DZ = BgBGrid.DZ = volGrid.DZ = technicalGrid.DZ
-      = P::dz_ini / pow(2, P::amrMaxSpatialRefLevel);
-   // Set the physical start (lower left corner) X, Y, Z
-   perBGrid.physicalGlobalStart = perBDt2Grid.physicalGlobalStart = EGrid.physicalGlobalStart = EDt2Grid.physicalGlobalStart
-      = EHallGrid.physicalGlobalStart = EGradPeGrid.physicalGlobalStart = EGradPeDt2Grid.physicalGlobalStart = momentsGrid.physicalGlobalStart
-      = momentsDt2Grid.physicalGlobalStart = dPerBGrid.physicalGlobalStart = dMomentsGrid.physicalGlobalStart = dMomentsDt2Grid.physicalGlobalStart
-      = BgBGrid.physicalGlobalStart = volGrid.physicalGlobalStart = technicalGrid.physicalGlobalStart
-      = {P::xmin, P::ymin, P::zmin};
+   FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> perBGrid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> perBDt2Grid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> EGrid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> EDt2Grid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> EHallGrid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> EGradPeGrid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> EGradPeDt2Grid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> momentsGrid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> momentsDt2Grid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> dPerBGrid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> dMomentsGrid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> dMomentsDt2Grid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> BgBGrid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> volGrid(
+       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> technicalGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,
+                                                              gridSpacing, physicalGlobalStart, decomposition);
 
    // Checking that spatial cells are cubic, otherwise field solver is incorrect (cf. derivatives in E, Hall term)
    constexpr Real uniformTolerance=1e-3;

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -457,9 +457,9 @@ int simulate(int argn,char* args[]) {
 
    // Checking that spatial cells are cubic, otherwise field solver is incorrect (cf. derivatives in E, Hall term)
    constexpr Real uniformTolerance=1e-3;
-   if ((abs((technicalGrid.DX - technicalGrid.DY) / technicalGrid.DX) >uniformTolerance) ||
-       (abs((technicalGrid.DX - technicalGrid.DZ) / technicalGrid.DX) >uniformTolerance) ||
-       (abs((technicalGrid.DY - technicalGrid.DZ) / technicalGrid.DY) >uniformTolerance)) {
+   if ((abs((gridSpacing[0] - gridSpacing[1]) / gridSpacing[0]) > uniformTolerance) ||
+       (abs((gridSpacing[0] - gridSpacing[2]) / gridSpacing[0]) > uniformTolerance) ||
+       (abs((gridSpacing[1] - gridSpacing[2]) / gridSpacing[1]) > uniformTolerance)) {
       if (myRank == MASTER_RANK) {
          std::cerr << "WARNING: Your spatial cells seem not to be cubic. The simulation will now abort!" << std::endl;
       }

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -424,35 +424,44 @@ int simulate(int argn,char* args[]) {
    const std::array physicalGlobalStart{P::xmin, P::ymin, P::zmin};
    const auto decomposition = P::manualFsGridDecomposition;
 
+   MPI_Comm parentComm = MPI_COMM_WORLD;
+   const auto numFsProcs = [&]() {
+      auto parentCommSize = 0;
+      MPI_Comm_size(parentComm, &parentCommSize);
+      const auto envVar = getenv("FSGRID_PROCS");
+      const auto fsgridProcs = envVar != NULL ? atoi(envVar) : 0;
+      return parentCommSize > fsgridProcs && fsgridProcs > 0 ? fsgridProcs : parentCommSize;
+   }();
+
    FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> perBGrid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> perBDt2Grid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> EGrid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> EDt2Grid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> EHallGrid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> EGradPeGrid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> EGradPeDt2Grid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> momentsGrid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> momentsDt2Grid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> dPerBGrid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> dMomentsGrid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> dMomentsDt2Grid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> BgBGrid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
    FsGrid<std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> volGrid(
-       fsGridDimensions, MPI_COMM_WORLD, periodicity, gridSpacing, physicalGlobalStart, decomposition);
-   FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> technicalGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,
+       fsGridDimensions, parentComm, numFsProcs, periodicity, gridSpacing, physicalGlobalStart, decomposition);
+   FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> technicalGrid(fsGridDimensions, parentComm, numFsProcs, periodicity,
                                                               gridSpacing, physicalGlobalStart, decomposition);
 
    // Checking that spatial cells are cubic, otherwise field solver is incorrect (cf. derivatives in E, Hall term)
@@ -497,7 +506,7 @@ int simulate(int argn,char* args[]) {
    // because we need a copy of the value from initialization in both perBGrid and perBDt2Grid and it isn't
    // touched as we are in boundary cells for components that aren't solved. We do a straight full copy instead
    // of looping and detecting boundary types here.
-   perBDt2Grid.copyData(perBGrid);
+   perBDt2Grid.getData() = perBGrid.getData();
 
    const std::vector<CellID>& cells = getLocalCells();
    


### PR DESCRIPTION
This updates vlasiator to use the updated [FsGrid](https://github.com/fmihpc/fsgrid/pull/32). Most changes are due to:
- automatic code formatting by clang-format
- FsGrid member variables becoming private: accessing them through a function (mostly DX, DY, DZ)
- FsGrid member variables becoming const: returned variables must be const ref instead of ref
- FsGrid construction happens in one go, not in three steps: added some input parameters
- FsGrid is not copyable anymore: `filterMoments` copies and updates the data of a grid object instead of the object itself