### PR TITLE
Inspection script mechanism to use srun overlap. Works on LUMI at least.

### DIFF
--- a/tools/slurm/inspector.sh
+++ b/tools/slurm/inspector.sh
@@ -1,0 +1,10 @@
+# script run by srun overlap when overlap_inspection.sh is run.
+# As it can be slow at scale, all are run concurrently and we wait at the end.
+
+for proc in $( ps x | grep vlasiator | grep -v srun | grep -v grep | cut --delimiter=" " -f 1 )
+do
+  # add more -ex commands, or pass all commands in myfile as -x myfile
+  gdb -p $proc --batch -ex bt -ex q &> ${JOBID}_${NODE}_${proc} &
+done
+
+wait

--- a/tools/slurm/overlap_inspection.sh
+++ b/tools/slurm/overlap_inspection.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Modify target JOBID below, then execute to run the inspector.sh on every node for every srun vlasiator instance.
+
+export JOBID=8513363
+
+squeue --job $JOBID -o "%N" | grep nid | cut -b 5- | cut --delimiter "]" -f 1 > .nodelist
+
+python3 - $( cat .nodelist ) > .fullnodelist << EOS
+import sys
+
+nodes_str_list = sys.argv[1].split(",")
+outnodes = []
+
+for n in nodes_str_list:
+    if "-" in n:
+        n_range = n.split("-")
+        for i in range(int(n_range[0]),int(n_range[1])+1):
+            outnodes.append("nid"+str(i).zfill(6))
+    else:
+        outnodes.append("nid"+n)
+
+for t in outnodes:
+    print(str(t))
+
+EOS
+
+
+for node in $( cat .fullnodelist )
+do
+  export NODE=$node
+  srun --jobid $JOBID --overlap -w $node bash ./inspector.sh &
+done
+
+wait

--- a/tools/slurm/overlap_inspection.sh
+++ b/tools/slurm/overlap_inspection.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 # Modify target JOBID below, then execute to run the inspector.sh on every node for every srun vlasiator instance.
 
-export JOBID=8513363
+if [ ! $# -eq 1 ]
+then
+    cat <<EOF
+overlap_inspection.sh jobid
+    Script for running inspector.sh on every node of a running job usign srun --overlap..
+    
+    jobid    SLURM job ID.
+EOF
+    exit
+fi
+
+export JOBID=$1
 
 squeue --job $JOBID -o "%N" | grep nid | cut -b 5- | cut --delimiter "]" -f 1 > .nodelist
 


### PR DESCRIPTION
Runs once for every node as running on >1 node srun overlap fails on LUMI at the moment.