### PR TITLE
Slope limiter pass by reference

### DIFF
--- a/vlasovsolver/cpu_1d_ppm.hpp
+++ b/vlasovsolver/cpu_1d_ppm.hpp
@@ -36,13 +36,11 @@ using namespace std;
   Compute parabolic reconstruction with an explicit scheme
 */
 inline void compute_ppm_coeff(const Vec * const values, face_estimate_order order, uint k, Vec a[3], const Realv threshold){
-   Vec fv_l; /*left face value*/
-   Vec fv_r; /*right face value*/
-   compute_filtered_face_values(values, k, order, fv_l, fv_r, threshold); 
+   Vec m_face; /*left face value*/
+   Vec p_face; /*right face value*/
+   compute_filtered_face_values(values, k, order, m_face, p_face, threshold); 
    
    //Coella et al, check for monotonicity   
-   Vec m_face = fv_l;
-   Vec p_face = fv_r;
    m_face = select((p_face - m_face) * (values[k] - 0.5 * (m_face + p_face)) >
                    (p_face - m_face)*(p_face - m_face) * one_sixth,
                    3 * values[k] - 2 * p_face,

--- a/vlasovsolver/cpu_1d_ppm_nonuniform.hpp
+++ b/vlasovsolver/cpu_1d_ppm_nonuniform.hpp
@@ -37,17 +37,11 @@ using namespace std;
   Compute parabolic reconstruction with an explicit scheme
 */
 inline void compute_ppm_coeff_nonuniform(const Realf * const dv, const Vec * const values, face_estimate_order order, uint k, Vec a[3], const Realv threshold){
-   Vec fv_l; /*left face value*/
-   Vec fv_r; /*right face value*/
-   compute_filtered_face_values_nonuniform(dv, values, k, order, fv_l, fv_r, threshold); 
+   Vec m_face; /*left face value*/
+   Vec p_face; /*right face value*/
+   compute_filtered_face_values_nonuniform(dv, values, k, order, m_face, p_face, threshold); 
    
    //Coella et al, check for monotonicity   
-   Vec m_face = fv_l;
-   Vec p_face = fv_r;
-
-   //std::cout << "value = " << values[k][0] << ", m_face = " << m_face[0] << ", p_face = " << p_face[0] << "\n";
-   //std::cout << values[k][0] - m_face[0] << ", " << values[k][0] - p_face[0] << "\n";
-   
    m_face = select((p_face - m_face) * (values[k] - 0.5 * (m_face + p_face)) >
                    (p_face - m_face)*(p_face - m_face) * one_sixth,
                    3 * values[k] - 2 * p_face,

--- a/vlasovsolver/cpu_1d_ppm_nonuniform_conserving.hpp
+++ b/vlasovsolver/cpu_1d_ppm_nonuniform_conserving.hpp
@@ -36,17 +36,11 @@ using namespace std;
   Compute parabolic reconstruction with an explicit scheme
 */
 inline void compute_ppm_coeff_nonuniform(const Vec * const dv, const Vec * const values, face_estimate_order order, uint k, Vec a[3], const Realv threshold){
-   Vec fv_l; /*left face value*/
-   Vec fv_r; /*right face value*/
-   compute_filtered_face_values_nonuniform_conserving(dv, values, k, order, fv_l, fv_r, threshold); 
+   Vec m_face; /*left face value*/
+   Vec p_face; /*right face value*/
+   compute_filtered_face_values_nonuniform_conserving(dv, values, k, order, m_face, p_face, threshold); 
    
    //Coella et al, check for monotonicity   
-   Vec m_face = fv_l;
-   Vec p_face = fv_r;
-
-   //std::cout << "value = " << values[k][0] << ", m_face = " << m_face[0] << ", p_face = " << p_face[0] << "\n";
-   //std::cout << values[k][0] - m_face[0] << ", " << values[k][0] - p_face[0] << "\n";
-   
   //  m_face = select((p_face - m_face) * (values[k] - 0.5 * (m_face + p_face)) >
   //                  (p_face - m_face)*(p_face - m_face) * one_sixth,
   //                  3 * values[k] - 2 * p_face,

--- a/vlasovsolver/cpu_1d_pqm.hpp
+++ b/vlasovsolver/cpu_1d_pqm.hpp
@@ -37,9 +37,9 @@ using namespace std;
 /*make sure quartic polynomial is monotonic*/
 inline void filter_pqm_monotonicity(Vec *values, uint k, Vec &fv_l, Vec &fv_r, Vec &fd_l, Vec &fd_r){   
    /*second derivative coefficients, eq 23 in white et al.*/
-   Vec b0 =   60.0 * values[k] - 24.0 * fv_r - 36.0 * fv_l + 3.0 * (fd_r - 3.0 * fd_l);
-   Vec b1 = -360.0 * values[k] + 36.0 * fd_l - 24.0 * fd_r + 168.0 * fv_r + 192.0 * fv_l;
-   Vec b2 =  360.0 * values[k] + 30.0 * (fd_r - fd_l) - 180.0 * (fv_l + fv_r);
+   const Vec b0 =   60.0 * values[k] - 24.0 * fv_r - 36.0 * fv_l + 3.0 * (fd_r - 3.0 * fd_l);
+   const Vec b1 = -360.0 * values[k] + 36.0 * fd_l - 24.0 * fd_r + 168.0 * fv_r + 192.0 * fv_l;
+   const Vec b2 =  360.0 * values[k] + 30.0 * (fd_r - fd_l) - 180.0 * (fv_l + fv_r);
    /*let's compute sqrt value to be used for computing roots. If we
     take sqrt of negaitve numbers, then we instead set a value that
     will make the root to be +-100 which is well outside range
@@ -62,9 +62,9 @@ inline void filter_pqm_monotonicity(Vec *values, uint k, Vec &fv_l, Vec &fv_r, V
    const Vec root2 = (-b1 - sqrt_val) / (2 * b2);
 
    /*PLM slope, MC limiter*/
-   Vec plm_slope_l = 2.0 * (values[k] - values[k - 1]);
-   Vec plm_slope_r = 2.0 * (values[k + 1] - values[k]);
-   Vec slope_sign = plm_slope_l + plm_slope_r; //it also has some magnitude, but we will only use its sign.
+   const Vec plm_slope_l = 2.0 * (values[k] - values[k - 1]);
+   const Vec plm_slope_r = 2.0 * (values[k + 1] - values[k]);
+   const Vec slope_sign = plm_slope_l + plm_slope_r; //it also has some magnitude, but we will only use its sign.
    /*first derivative coefficients*/
    const Vec c0 = fd_l;
    const Vec c1 = b0;
@@ -74,13 +74,13 @@ inline void filter_pqm_monotonicity(Vec *values, uint k, Vec &fv_l, Vec &fv_r, V
    //is with [0..1]. If the root is not in this range, we
    //simplify later if statements by setting it to the plm slope
    //sign
-   Vec root1_slope = select(root1 >= 0.0 && root1 <= 1.0,
+   const Vec root1_slope = select(root1 >= 0.0 && root1 <= 1.0,
                              c0  + root1 * ( c1 + root1 * (c2 + root1 * c3 ) ),
                              slope_sign);
-   Vec root2_slope = select(root2 >= 0.0 && root2 <= 1.0,
+   const Vec root2_slope = select(root2 >= 0.0 && root2 <= 1.0,
                             c0  + root2 * ( c1 + root2 * (c2 + root2 * c3 ) ),
                             slope_sign);
-   Vecb fixInflexion = root1_slope * slope_sign < 0.0 || root2_slope * slope_sign < 0.0;
+   const Vecb fixInflexion = root1_slope * slope_sign < 0.0 || root2_slope * slope_sign < 0.0;
    if (horizontal_or (fixInflexion) ){ 
       Realv valuesa[VECL];
       Realv fva_l[VECL];

--- a/vlasovsolver/cpu_slope_limiters.hpp
+++ b/vlasovsolver/cpu_slope_limiters.hpp
@@ -27,16 +27,16 @@
 
 using namespace std;
 
-inline Vec minmod(const Vec slope1, const Vec slope2){
+inline Vec minmod(const Vec& slope1, const Vec& slope2){
    const Vec zero(0.0);
-   Vec slope=select(abs(slope1) < abs(slope2), slope1, slope2);
+   const Vec slope = select(abs(slope1) < abs(slope2), slope1, slope2);
    //check for extrema          
    return select(slope1 * slope2 <= 0, zero, slope);
 }
 
-inline Vec maxmod(const Vec slope1, const Vec slope2){
+inline Vec maxmod(const Vec& slope1, const Vec& slope2){
    const Vec zero(0.0);
-   Vec slope=select(abs(slope1) > abs(slope2), slope1, slope2);
+   const Vec slope = select(abs(slope1) > abs(slope2), slope1, slope2);
    //check for extrema          
    return select(slope1 * slope2 <= 0, zero, slope);
 }
@@ -46,8 +46,8 @@ inline Vec maxmod(const Vec slope1, const Vec slope2){
 */
 
 inline Vec slope_limiter_sb(const Vec& l,const Vec& m, const Vec& r) {
-  Vec a=r-m;
-  Vec b=m-l;
+  const Vec a=r-m;
+  const Vec b=m-l;
   const Vec slope1=minmod(a, 2*b);
   const Vec slope2=minmod(2*a, b);
   return maxmod(slope1, slope2);
@@ -59,8 +59,8 @@ inline Vec slope_limiter_sb(const Vec& l,const Vec& m, const Vec& r) {
 
 inline Vec slope_limiter_minmod(const Vec& l,const Vec& m, const Vec& r) {
    //Vec sign;
-   Vec a=r-m;
-   Vec b=m-l; 
+   const Vec a=r-m;
+   const Vec b=m-l; 
    return minmod(a,b);
 }
 
@@ -70,19 +70,19 @@ inline Vec slope_limiter_minmod(const Vec& l,const Vec& m, const Vec& r) {
 
 inline Vec slope_limiter_mc(const Vec& l,const Vec& m, const Vec& r) {
   //Vec sign;
-  Vec a=r-m;
-  Vec b=m-l; 
+  const Vec a=r-m;
+  const Vec b=m-l; 
   Vec minval=min(two*abs(a),two*abs(b));
   minval=min(minval,half*abs(a+b));
   
   //check for extrema
-  Vec output = select(a*b < 0,zero,minval);
+  const Vec output = select(a*b < 0,zero,minval);
   //set sign
   return select(a + b < 0,-output,output);
 }
 
 inline Vec slope_limiter_minmod_amr(const Vec& l,const Vec& m, const Vec& r,const Vec& a,const Vec& b) {
-   Vec J = r-l;
+   const Vec J = r-l;
    Vec f = (m-l)/J;
    f = min(Vec(1.0),f);
    return min(f/(1+a),(Vec(1.)-f)/(1+b))*2*J;


### PR DESCRIPTION
A few vectors were mistakenly passed by copy instead of reference, this fixes it. Found by Gerard Oliva at BSC as part of Plasma-PEPSC work, reported in D2.4.

Also changes many intermediate `Vec`s to const to aid with possible compiler optimization. 