### PR TITLE
Wrap all fsgrids in a FsGridWrapper struct, pass that around.

### DIFF
--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -50,31 +50,21 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       for(auto& c : lowercase) c = tolower(c);
 
       if(P::systemWriteAllDROs || lowercase == "fg_b" || lowercase == "b") { // Bulk magnetic field at Yee-Lattice locations
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
 
                // Iterate through fsgrid cells and extract total magnetic field
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*BgBGrid.get(x,y,z))[fsgrids::BGBX]
-                           + (*perBGrid.get(x,y,z))[fsgrids::PERBX];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*BgBGrid.get(x,y,z))[fsgrids::BGBY]
-                           + (*perBGrid.get(x,y,z))[fsgrids::PERBY];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*BgBGrid.get(x,y,z))[fsgrids::BGBZ]
-                           + (*perBGrid.get(x,y,z))[fsgrids::PERBZ];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*fsgrids.BgBGrid.get(x,y,z))[fsgrids::BGBX]
+                           + (*fsgrids.perBGrid.get(x,y,z))[fsgrids::PERBX];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*fsgrids.BgBGrid.get(x,y,z))[fsgrids::BGBY]
+                           + (*fsgrids.perBGrid.get(x,y,z))[fsgrids::PERBY];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*fsgrids.BgBGrid.get(x,y,z))[fsgrids::BGBZ]
+                           + (*fsgrids.perBGrid.get(x,y,z))[fsgrids::PERBZ];
                      }
                   }
                }
@@ -87,28 +77,18 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_backgroundb" || lowercase == "backgroundb" || lowercase == "fg_b_background") { // Static (typically dipole) magnetic field part
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_background",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_background",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
 
                // Iterate through fsgrid cells and extract background B
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*BgBGrid.get(x,y,z))[fsgrids::BGBX];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*BgBGrid.get(x,y,z))[fsgrids::BGBY];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*BgBGrid.get(x,y,z))[fsgrids::BGBZ];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*fsgrids.BgBGrid.get(x,y,z))[fsgrids::BGBX];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*fsgrids.BgBGrid.get(x,y,z))[fsgrids::BGBY];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*fsgrids.BgBGrid.get(x,y,z))[fsgrids::BGBZ];
                      }
                   }
                }
@@ -121,28 +101,18 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_backgroundbvol" || lowercase == "backgroundbvol" || lowercase == "fg_b_background_vol") { // Static (typically dipole) magnetic field part, volume-averaged
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_background_vol",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_background_vol",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
 
                // Iterate through fsgrid cells and extract total BVOL
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*BgBGrid.get(x,y,z))[fsgrids::BGBXVOL];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*BgBGrid.get(x,y,z))[fsgrids::BGBYVOL];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*BgBGrid.get(x,y,z))[fsgrids::BGBZVOL];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*fsgrids.BgBGrid.get(x,y,z))[fsgrids::BGBXVOL];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*fsgrids.BgBGrid.get(x,y,z))[fsgrids::BGBYVOL];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*fsgrids.BgBGrid.get(x,y,z))[fsgrids::BGBZVOL];
                      }
                   }
                }
@@ -156,28 +126,18 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
 
       if(P::systemWriteAllDROs || lowercase == "fg_perturbedb" || lowercase == "perturbedb" || lowercase == "fg_b_perturbed") { // Fluctuating magnetic field part
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_perturbed",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_perturbed",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
 
                // Iterate through fsgrid cells and extract values
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*perBGrid.get(x,y,z))[fsgrids::PERBX];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*perBGrid.get(x,y,z))[fsgrids::PERBY];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*perBGrid.get(x,y,z))[fsgrids::PERBZ];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*fsgrids.perBGrid.get(x,y,z))[fsgrids::PERBX];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*fsgrids.perBGrid.get(x,y,z))[fsgrids::PERBY];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*fsgrids.perBGrid.get(x,y,z))[fsgrids::PERBZ];
                      }
                   }
                }
@@ -190,28 +150,17 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_e" || lowercase == "e") { // Bulk electric field at Yee-lattice locations
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_e",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
-
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_e",[](FsGridWrapper& fsgrids)->std::vector<double> {
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
 
                // Iterate through fsgrid cells and extract E values
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*EGrid.get(x,y,z))[fsgrids::EX];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*EGrid.get(x,y,z))[fsgrids::EY];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*EGrid.get(x,y,z))[fsgrids::EZ];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*fsgrids.EGrid.get(x,y,z))[fsgrids::EX];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*fsgrids.EGrid.get(x,y,z))[fsgrids::EY];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*fsgrids.EGrid.get(x,y,z))[fsgrids::EZ];
                      }
                   }
                }
@@ -238,26 +187,16 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_rhom") { // Overall mass density (summed over all populations)
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rhom",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rhom",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                // Iterate through fsgrid cells and extract rho valuesg
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = (*momentsGrid.get(x,y,z))[fsgrids::RHOM];
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = (*fsgrids.momentsGrid.get(x,y,z))[fsgrids::RHOM];
                      }
                   }
                }
@@ -277,26 +216,16 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_rhoq") { // Overall charge density (summed over all populations)
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rhoq",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rhoq",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                // Iterate through fsgrid cells and extract charge density
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = (*momentsGrid.get(x,y,z))[fsgrids::RHOQ];
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = (*fsgrids.momentsGrid.get(x,y,z))[fsgrids::RHOQ];
                      }
                   }
                }
@@ -328,28 +257,19 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_v") { // Overall effective bulk density defining the center-of-mass frame from all populations
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_v",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_v",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
 
                // Iterate through fsgrid cells and extract bulk Velocity
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*momentsGrid.get(x,y,z))[fsgrids::VX];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*momentsGrid.get(x,y,z))[fsgrids::VY];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*momentsGrid.get(x,y,z))[fsgrids::VZ];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*fsgrids.momentsGrid.get(x,y,z))[fsgrids::VX];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*fsgrids.momentsGrid.get(x,y,z))[fsgrids::VY];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*fsgrids.momentsGrid.get(x,y,z))[fsgrids::VZ];
                      }
                   }
                }
@@ -547,26 +467,16 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "maxfieldsdt" || lowercase == "fg_maxfieldsdt" || lowercase == "fg_maxdt_fieldsolver") {
          // Maximum timestep constraint as calculated by the fieldsolver
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_maxdt_fieldsolver",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_maxdt_fieldsolver",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                // Iterate through fsgrid cells and extract field solver timestep limit
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.get(x,y,z)->maxFsDt;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.technicalGrid.get(x,y,z)->maxFsDt;
                      }
                   }
                }
@@ -588,20 +498,10 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "fsgridrank" || lowercase == "fg_rank") {
          // Map of spatial decomposition of the FsGrid into MPI ranks
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rank",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_rank",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2],technicalGrid.getRank());
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
+               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2],fsgrids.technicalGrid.getRank());
                return retval;
              }
          ));
@@ -612,27 +512,17 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "fg_amr_level") {
          // Map of spatial decomposition of the FsGrid into MPI ranks
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_amr_level",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH>& EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH>& EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>& momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH>& dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>& dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH>& volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_amr_level",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                // Iterate through fsgrid cells and extract corresponding AMR level
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.get(x,y,z)->refLevel;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.technicalGrid.get(x,y,z)->refLevel;
                      }
                   }
                }
@@ -654,26 +544,16 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "fsgridboundarytype" || lowercase == "fg_boundarytype") {
          // Type of boundarycells as stored in FSGrid
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_boundarytype",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_boundarytype",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                // Iterate through fsgrid cells and extract boundary flag
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.get(x,y,z)->sysBoundaryFlag;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.technicalGrid.get(x,y,z)->sysBoundaryFlag;
                      }
                   }
                }
@@ -695,26 +575,16 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "fsgridboundarylayer" || lowercase == "fg_boundarylayer") {
          // Type of boundarycells as stored in FSGrid
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_boundarylayer",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_boundarylayer",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                // Iterate through fsgrid cells and extract boundary layer
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.get(x,y,z)->sysBoundaryLayer;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.technicalGrid.get(x,y,z)->sysBoundaryLayer;
                      }
                   }
                }
@@ -767,28 +637,18 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_vole" || lowercase == "fg_e_vol" || lowercase == "fg_evol") {
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_e_vol",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_e_vol",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
 
                // Iterate through fsgrid cells and extract EVOL
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =  (*volGrid.get(x,y,z))[fsgrids::volfields::EXVOL];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*volGrid.get(x,y,z))[fsgrids::volfields::EYVOL];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*volGrid.get(x,y,z))[fsgrids::volfields::EZVOL];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =  (*fsgrids.volGrid.get(x,y,z))[fsgrids::volfields::EXVOL];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*fsgrids.volGrid.get(x,y,z))[fsgrids::volfields::EYVOL];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*fsgrids.volGrid.get(x,y,z))[fsgrids::volfields::EZVOL];
                      }
                   }
                }
@@ -803,26 +663,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       if(P::systemWriteAllDROs || lowercase == "halle" || lowercase == "fg_halle" || lowercase == "fg_e_hall") {
          for(int index=0; index<fsgrids::N_EHALL; index++) {
             std::string reducer_name = "fg_e_hall_" + std::to_string(index);
-            outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(reducer_name,[index](
-                         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                         FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                         FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                         FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                         FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                         FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                         FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                         FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
-
-                  std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+            outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid(reducer_name,[index](FsGridWrapper& fsgrids)->std::vector<double> {
+                  std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                   std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                   // Iterate through fsgrid cells and extract EHall
                   for(int z=0; z<gridSize[2]; z++) {
                      for(int y=0; y<gridSize[1]; y++) {
                         for(int x=0; x<gridSize[0]; x++) {
-                           retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = (*EHallGrid.get(x,y,z))[index];
+                           retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = (*fsgrids.EHallGrid.get(x,y,z))[index];
                         }
                      }
                   }
@@ -852,31 +701,21 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_volb" || lowercase == "fg_bvol" || lowercase == "fg_b_vol") { // Static (typically dipole) magnetic field part
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_vol",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b_vol",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
 
                // Iterate through fsgrid cells and extract total BVOL
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*BgBGrid.get(x,y,z))[fsgrids::BGBXVOL]
-                           + (*volGrid.get(x,y,z))[fsgrids::PERBXVOL];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*BgBGrid.get(x,y,z))[fsgrids::BGBYVOL]
-                           + (*volGrid.get(x,y,z))[fsgrids::PERBYVOL];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*BgBGrid.get(x,y,z))[fsgrids::BGBZVOL]
-                           + (*volGrid.get(x,y,z))[fsgrids::PERBZVOL];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*fsgrids.BgBGrid.get(x,y,z))[fsgrids::BGBXVOL]
+                           + (*fsgrids.volGrid.get(x,y,z))[fsgrids::PERBXVOL];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*fsgrids.BgBGrid.get(x,y,z))[fsgrids::BGBYVOL]
+                           + (*fsgrids.volGrid.get(x,y,z))[fsgrids::PERBYVOL];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*fsgrids.BgBGrid.get(x,y,z))[fsgrids::BGBZVOL]
+                           + (*fsgrids.volGrid.get(x,y,z))[fsgrids::PERBZVOL];
                      }
                   }
                }
@@ -912,26 +751,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "fg_pressure") {
          // Overall scalar pressure from all populations
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_pressure",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
-
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_pressure",[](FsGridWrapper& fsgrids)->std::vector<double> {
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                // Iterate through fsgrid cells and extract boundary flag
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        auto& moments=(*momentsGrid.get(x,y,z));
+                        auto& moments=(*fsgrids.momentsGrid.get(x,y,z));
                         retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = 1./3. * (moments[fsgrids::P_11] + moments[fsgrids::P_22] + moments[fsgrids::P_33]);
                      }
                   }
@@ -992,25 +820,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       // As of summer 2023 they are proper derivatives in DROs, unlike in the code where they are differences.
       // Search for "fg_derivs" to find the end of this block.
       if(P::systemWriteAllDROs || lowercase == "fg_derivs") {
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdy) / dPerBGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdy) / fsgrids.dPerBGrid.DY;
                      }
                   }
                }
@@ -1018,25 +836,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{per,fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdz) / dPerBGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdz) / fsgrids.dPerBGrid.DZ;
                      }
                   }
                }
@@ -1044,25 +852,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{per,fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydx) / dPerBGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydx) / fsgrids.dPerBGrid.DX;
                      }
                   }
                }
@@ -1070,25 +868,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{per,fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydz) / dPerBGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydz) / fsgrids.dPerBGrid.DZ;
                      }
                   }
                }
@@ -1096,25 +884,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{per,fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdx) / dPerBGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdx) / fsgrids.dPerBGrid.DX;
                      }
                   }
                }
@@ -1122,25 +900,16 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{per,fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdy) / dPerBGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdy) / fsgrids.dPerBGrid.DY;
                      }
                   }
                }
@@ -1148,25 +917,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{per,fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdyy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdyy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdyy) / dPerBGrid.DY / dPerBGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdyy) / fsgrids.dPerBGrid.DY / fsgrids.dPerBGrid.DY;
                      }
                   }
                }
@@ -1174,25 +933,14 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{X,\\mathrm{per,fg}} (\\Delta Y)^{-2}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdzz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
-
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdzz",[](FsGridWrapper& fsgrids)->std::vector<double> {
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdzz) / dPerBGrid.DZ / dPerBGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdzz) / fsgrids.dPerBGrid.DZ / fsgrids.dPerBGrid.DZ;
                      }
                   }
                }
@@ -1200,25 +948,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{X,\\mathrm{per,fg}} (\\Delta Z)^{-2}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdyz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxdyz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdyz) / dPerBGrid.DY / dPerBGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBxdyz) / fsgrids.dPerBGrid.DY / fsgrids.dPerBGrid.DZ;
                      }
                   }
                }
@@ -1226,25 +964,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{X,\\mathrm{per,fg}} (\\Delta Y \\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydxx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydxx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydxx) / dPerBGrid.DX / dPerBGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydxx) / fsgrids.dPerBGrid.DX / fsgrids.dPerBGrid.DX;
                      }
                   }
                }
@@ -1252,25 +980,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{Y,\\mathrm{per,fg}} (\\Delta X)^{-2}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydzz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydzz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydzz) / dPerBGrid.DZ / dPerBGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydzz) / fsgrids.dPerBGrid.DZ / fsgrids.dPerBGrid.DZ;
                      }
                   }
                }
@@ -1278,25 +996,14 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{Y,\\mathrm{per,fg}} (\\Delta Z)^{-2}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydxz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
-
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbydxz",[](FsGridWrapper& fsgrids)->std::vector<double> {
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydxz) / dPerBGrid.DX / dPerBGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBydxz) / fsgrids.dPerBGrid.DX / fsgrids.dPerBGrid.DZ;
                      }
                   }
                }
@@ -1304,25 +1011,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{Y,\\mathrm{per,fg}} (\\Delta X \\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdxx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdxx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdxx) / dPerBGrid.DX / dPerBGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdxx) / fsgrids.dPerBGrid.DX / fsgrids.dPerBGrid.DX;
                      }
                   }
                }
@@ -1330,25 +1027,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{Z,\\mathrm{per,fg}} (\\Delta Z)^{-2}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdyy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdyy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdyy) / dPerBGrid.DY / dPerBGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdyy) / fsgrids.dPerBGrid.DY / fsgrids.dPerBGrid.DY;
                      }
                   }
                }
@@ -1356,25 +1043,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{Z,\\mathrm{per,fg}} (\\Delta Y)^{-2}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdxy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzdxy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdxy) / dPerBGrid.DX / dPerBGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dPerBGrid.get(x,y,z)->at(fsgrids::dperb::dPERBzdxy) / fsgrids.dPerBGrid.DX / fsgrids.dPerBGrid.DY;
                      }
                   }
                }
@@ -1384,25 +1061,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-2}$","$\\Delta B_{Z,\\mathrm{per,fg}} (\\Delta X \\Delta Y)^{-1}$","1.0");
 
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhomdx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhomdx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhomdx) / dMomentsGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhomdx) / fsgrids.dMomentsGrid.DX;
                      }
                   }
                }
@@ -1410,25 +1077,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"kg/m^4","$\\mathrm{kg}\\mathrm{m}^{-4}$","$\\Delta \\rho_{m,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhomdy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhomdy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhomdy) / dMomentsGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhomdy) / fsgrids.dMomentsGrid.DY;
                      }
                   }
                }
@@ -1436,25 +1093,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"kg/m^4","$\\mathrm{kg}\\mathrm{m}^{-4}$","$\\Delta \\rho_{m,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhomdz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhomdz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhomdz) / dMomentsGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhomdz) / fsgrids.dMomentsGrid.DZ;
                      }
                   }
                }
@@ -1462,25 +1109,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"kg/m^4","$\\mathrm{kg}\\mathrm{m}^{-4}$","$\\Delta \\rho_{m,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhoqdx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhoqdx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhoqdx) / dMomentsGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhoqdx) / fsgrids.dMomentsGrid.DX;
                      }
                   }
                }
@@ -1488,25 +1125,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"C/m^4","$\\mathrm{C}\\mathrm{m}^{-4}$","$\\Delta \\rho_{q,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhoqdy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhoqdy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhoqdy) / dMomentsGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhoqdy) / fsgrids.dMomentsGrid.DY;
                      }
                   }
                }
@@ -1514,25 +1141,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"C/m^4","$\\mathrm{C}\\mathrm{m}^{-4}$","$\\Delta \\rho_{q,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhoqdz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_drhoqdz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhoqdz) / dMomentsGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::drhoqdz) / fsgrids.dMomentsGrid.DZ;
                      }
                   }
                }
@@ -1540,25 +1157,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"C/m^4","$\\mathrm{C}\\mathrm{m}^{-4}$","$\\Delta \\rho_{q,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp11dx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp11dx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp11dx) / dMomentsGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp11dx) / fsgrids.dMomentsGrid.DX;
                      }
                   }
                }
@@ -1566,25 +1173,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{11,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp11dy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp11dy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp11dy) / dMomentsGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp11dy) / fsgrids.dMomentsGrid.DY;
                      }
                   }
                }
@@ -1592,25 +1189,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{11,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp11dz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp11dz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp11dz) / dMomentsGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp11dz) / fsgrids.dMomentsGrid.DZ;
                      }
                   }
                }
@@ -1618,25 +1205,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{11,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp22dx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp22dx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp22dx) / dMomentsGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp22dx) / fsgrids.dMomentsGrid.DX;
                      }
                   }
                }
@@ -1644,25 +1221,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{22,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp22dy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp22dy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp22dy) / dMomentsGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp22dy) / fsgrids.dMomentsGrid.DY;
                      }
                   }
                }
@@ -1670,25 +1237,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{22,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp22dz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp22dz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp22dz) / dMomentsGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp22dz) / fsgrids.dMomentsGrid.DZ;
                      }
                   }
                }
@@ -1696,25 +1253,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{22,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp33dx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp33dx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp33dx) / dMomentsGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp33dx) / fsgrids.dMomentsGrid.DX;
                      }
                   }
                }
@@ -1722,25 +1269,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{33,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp33dy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp33dy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp33dy) / dMomentsGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp33dy) / fsgrids.dMomentsGrid.DY;
                      }
                   }
                }
@@ -1748,25 +1285,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{33,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp33dz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dp33dz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp33dz) / dMomentsGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dp33dz) / fsgrids.dMomentsGrid.DZ;
                      }
                   }
                }
@@ -1774,25 +1301,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_{33,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvxdx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvxdx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVxdx) / dMomentsGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVxdx) / fsgrids.dMomentsGrid.DX;
                      }
                   }
                }
@@ -1800,25 +1317,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{X,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvxdy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvxdy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVxdy) / dMomentsGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVxdy) / fsgrids.dMomentsGrid.DY;
                      }
                   }
                }
@@ -1826,25 +1333,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{X,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvxdz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvxdz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVxdz) / dMomentsGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVxdz) / fsgrids.dMomentsGrid.DZ;
                      }
                   }
                }
@@ -1852,25 +1349,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{X,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvydx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvydx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVydx) / dMomentsGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVydx) / fsgrids.dMomentsGrid.DX;
                      }
                   }
                }
@@ -1878,25 +1365,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{Y,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvydy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvydy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVydy) / dMomentsGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVydy) / fsgrids.dMomentsGrid.DY;
                      }
                   }
                }
@@ -1904,25 +1381,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{Y,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvydz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvydz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVydz) / dMomentsGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVydz) / fsgrids.dMomentsGrid.DZ;
                      }
                   }
                }
@@ -1930,25 +1397,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{Y,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvzdx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvzdx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVzdx) / dMomentsGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVzdx) / fsgrids.dMomentsGrid.DX;
                      }
                   }
                }
@@ -1956,25 +1413,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{Z,\\mathrm{fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvzdy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvzdy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVzdy) / dMomentsGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVzdy) / fsgrids.dMomentsGrid.DY;
                      }
                   }
                }
@@ -1982,25 +1429,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{Z,\\mathrm{fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvzdz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dvzdz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVzdz) / dMomentsGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dVzdz) / fsgrids.dMomentsGrid.DZ;
                      }
                   }
                }
@@ -2008,25 +1445,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\Delta V_{Z,\\mathrm{fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dpedx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dpedx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dPedx) / dMomentsGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dPedx) / fsgrids.dMomentsGrid.DX;
                      }
                   }
                }
@@ -2034,25 +1461,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_\\mathrm{e,fg} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dpedy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dpedy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dPedy) / dMomentsGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dPedy) / fsgrids.dMomentsGrid.DY;
                      }
                   }
                }
@@ -2060,25 +1477,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_\\mathrm{e,fg} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dpedz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dpedz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dPedz) / dMomentsGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.dMomentsGrid.get(x,y,z)->at(fsgrids::dmoments::dPedz) / fsgrids.dMomentsGrid.DZ;
                      }
                   }
                }
@@ -2087,25 +1494,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"Pa/m","$\\mathrm{Pa}\\mathrm{m}^{-1}$","$\\Delta P_\\mathrm{e,fg} (\\Delta Z)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxvoldx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxvoldx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBXVOLdx) / BgBGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBXVOLdx) / fsgrids.BgBGrid.DX;
                      }
                   }
                }
@@ -2113,25 +1510,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{per,vol,fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxvoldy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxvoldy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBXVOLdy) / BgBGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBXVOLdy) / fsgrids.BgBGrid.DY;
                      }
                   }
                }
@@ -2139,25 +1526,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{per,vol,fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxvoldz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbxvoldz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBXVOLdz) / BgBGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBXVOLdz) /fsgrids.BgBGrid.DZ;
                      }
                   }
                }
@@ -2165,25 +1542,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{per,vol,fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbyvoldx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbyvoldx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBYVOLdx) / BgBGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBYVOLdx) /fsgrids.BgBGrid.DX;
                      }
                   }
                }
@@ -2191,25 +1558,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{per,vol,fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbyvoldy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbyvoldy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBYVOLdy) / BgBGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBYVOLdy) /fsgrids.BgBGrid.DY;
                      }
                   }
                }
@@ -2218,25 +1575,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{per,vol,fg}} (\\Delta Y)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbyvoldz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbyvoldz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBYVOLdz) / BgBGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBYVOLdz) /fsgrids.BgBGrid.DZ;
                      }
                   }
                }
@@ -2244,25 +1591,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{per,vol,fg}} (\\Delta Z)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzvoldx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzvoldx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBZVOLdx) / BgBGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBZVOLdx) /fsgrids.BgBGrid.DX;
                      }
                   }
                }
@@ -2270,25 +1607,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{per,vol,fg}} (\\Delta X)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzvoldy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzvoldy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBZVOLdy) / BgBGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBZVOLdy) /fsgrids.BgBGrid.DY;
                      }
                   }
                }
@@ -2296,25 +1623,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{per,vol,fg}} (\\Delta Y)^{-1}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzvoldz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dperbzvoldz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBZVOLdz) / BgBGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.volGrid.get(x,y,z)->at(fsgrids::volfields::dPERBZVOLdz) /fsgrids.BgBGrid.DZ;
                      }
                   }
                }
@@ -2335,25 +1652,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       // They are derivatives in these DROs, not differences as in the code.
       // Search for "fg_derivs_b_background" to find the end of the block.
       if(P::systemWriteAllDROs || lowercase == "fg_derivs_b_background") { // includes all face and volume-averaged derivatives of BGB on fg
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxdy",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxdy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBxdy) / technicalGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBxdy) / fsgrids.technicalGrid.DY;
                      }
                   }
                }
@@ -2362,25 +1669,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{bg,fg}} (\\Delta Y)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxdz",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxdz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBxdz) / technicalGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBxdz) / fsgrids.technicalGrid.DZ;
                      }
                   }
                }
@@ -2389,25 +1686,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{bg,fg}} (\\Delta Z)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbydx",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbydx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBydx) / technicalGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBydx) / fsgrids.technicalGrid.DX;
                      }
                   }
                }
@@ -2416,25 +1703,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{bg,fg}} (\\Delta X)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbydz",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbydz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBydz) / technicalGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBydz) / fsgrids.technicalGrid.DZ;
                      }
                   }
                }
@@ -2443,25 +1720,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{bg,fg}} (\\Delta Z)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzdx",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzdx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBzdx) / technicalGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBzdx) / fsgrids.technicalGrid.DX;
                      }
                   }
                }
@@ -2470,25 +1737,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{bg,fg}} (\\Delta X)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzdy",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzdy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBzdy) / technicalGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBzdy) / fsgrids.technicalGrid.DY;
                      }
                   }
                }
@@ -2497,25 +1754,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{bg,fg}} (\\Delta Y)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxvoldx",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxvoldx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBXVOLdx) / technicalGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBXVOLdx) / fsgrids.technicalGrid.DX;
                      }
                   }
                }
@@ -2524,25 +1771,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{bg,vol,fg}} (\\Delta X)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxvoldy",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxvoldy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBXVOLdy) / technicalGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBXVOLdy) / fsgrids.technicalGrid.DY;
                      }
                   }
                }
@@ -2551,25 +1788,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{bg,vol,fg}} (\\Delta Y)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxvoldz",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbxvoldz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBXVOLdz) / technicalGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBXVOLdz) / fsgrids.technicalGrid.DZ;
                      }
                   }
                }
@@ -2578,25 +1805,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{X,\\mathrm{bg,vol,fg}} (\\Delta Z)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbyvoldx",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbyvoldx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBYVOLdx) / technicalGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBYVOLdx) / fsgrids.technicalGrid.DX;
                      }
                   }
                }
@@ -2605,25 +1822,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{bg,vol,fg}} (\\Delta X)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbyvoldy",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbyvoldy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBYVOLdy) / technicalGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBYVOLdy) / fsgrids.technicalGrid.DY;
                      }
                   }
                }
@@ -2632,25 +1839,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{bg,vol,fg}} (\\Delta Y)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbyvoldz",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbyvoldz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBYVOLdz) / technicalGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBYVOLdz) / fsgrids.technicalGrid.DZ;
                      }
                   }
                }
@@ -2659,25 +1856,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Y,\\mathrm{bg,vol,fg}} (\\Delta Z)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzvoldx",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzvoldx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBZVOLdx) / technicalGrid.DX;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBZVOLdx) / fsgrids.technicalGrid.DX;
                      }
                   }
                }
@@ -2686,25 +1873,15 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{bg,vol,fg}} (\\Delta X)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzvoldy",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzvoldy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBZVOLdy) / technicalGrid.DY;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBZVOLdy) / fsgrids.technicalGrid.DY;
                      }
                   }
                }
@@ -2713,25 +1890,16 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"T/m","$\\mathrm{T}\\,\\mathrm{m}^{-1}$","$\\Delta B_{Z,\\mathrm{bg,vol,fg}} (\\Delta Y)^{-1}$","1.0");
 
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzvoldz",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_derivatives/fg_dbgbzvoldz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBZVOLdz) / technicalGrid.DZ;
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] =fsgrids.BgBGrid.get(x,y,z)->at(fsgrids::bgbfield::dBGBZVOLdz) / fsgrids.technicalGrid.DZ;
                      }
                   }
                }
@@ -2765,26 +1933,16 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
       }
       if(P::systemWriteAllDROs || lowercase == "fg_gridcoordinates") {
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_x",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_x",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                // Iterate through fsgrid cells and extract X coordinate
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.getPhysicalCoords(x,y,z)[0];
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.technicalGrid.getPhysicalCoords(x,y,z)[0];
                      }
                   }
                }
@@ -2792,26 +1950,16 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$X_\\mathrm{fg}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_y",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_y",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                // Iterate through fsgrid cells and extract Y coordinate
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.getPhysicalCoords(x,y,z)[1];
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.technicalGrid.getPhysicalCoords(x,y,z)[1];
                      }
                   }
                }
@@ -2819,26 +1967,16 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$Y_\\mathrm{fg}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_z",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_z",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
 
                // Iterate through fsgrid cells and extract Z coordinate
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = technicalGrid.getPhysicalCoords(x,y,z)[2];
+                        retval[gridSize[1]*gridSize[0]*z + gridSize[0]*y + x] = fsgrids.technicalGrid.getPhysicalCoords(x,y,z)[2];
                      }
                   }
                }
@@ -2846,56 +1984,26 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$Z_\\mathrm{fg}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_dx",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_dx",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2], technicalGrid.DX);
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
+               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2], fsgrids.technicalGrid.DX);
                return retval;
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$\\delta X_\\mathrm{fg}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_dy",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_dy",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2], technicalGrid.DY);
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
+               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2], fsgrids.technicalGrid.DY);
                return retval;
          }
          ));
          outputReducer->addMetadata(outputReducer->size()-1,"m","$\\mathrm{m}$","$\\delta Y_\\mathrm{fg}$","1.0");
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_dz",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_dz",[](FsGridWrapper& fsgrids)->std::vector<double> {
 
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
-               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2], technicalGrid.DZ);
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
+               std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2], fsgrids.technicalGrid.DZ);
                return retval;
          }
          ));
@@ -3565,27 +2673,16 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       }
       if(P::systemWriteAllDROs || lowercase == "fg_curvature") {
          Parameters::computeCurvature = true;
-         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_curvature",[](
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-            FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-            FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-            FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-            FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-            FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-            FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<double> {
-
-               std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+         outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_curvature", [](FsGridWrapper& fsgrids)->std::vector<double> {
+               std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]*3);
 
                for(int z=0; z<gridSize[2]; z++) {
                   for(int y=0; y<gridSize[1]; y++) {
                      for(int x=0; x<gridSize[0]; x++) {
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*volGrid.get(x,y,z))[fsgrids::volfields::CURVATUREX];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*volGrid.get(x,y,z))[fsgrids::volfields::CURVATUREY];
-                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*volGrid.get(x,y,z))[fsgrids::volfields::CURVATUREZ];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x)] =     (*fsgrids.volGrid.get(x,y,z))[fsgrids::volfields::CURVATUREX];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 1] = (*fsgrids.volGrid.get(x,y,z))[fsgrids::volfields::CURVATUREY];
+                        retval[3*(gridSize[1]*gridSize[0]*z + gridSize[0]*y + x) + 2] = (*fsgrids.volGrid.get(x,y,z))[fsgrids::volfields::CURVATUREZ];
                      }
                   }
                }
@@ -3853,16 +2950,7 @@ bool DataReducer::writeParameters(const unsigned int& operatorID, vlsv::Writer& 
 /** Write all data thet the given DataReductionOperator wants to obtain from fsgrid into the output file.
  */
 bool DataReducer::writeFsGridData(
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+                      FsGridWrapper& fsgrids,
                       const std::string& meshName, const unsigned int operatorID,
                       vlsv::Writer& vlsvWriter,
                       const bool writeAsFloat) {
@@ -3872,7 +2960,7 @@ bool DataReducer::writeFsGridData(
    if(!DROf) {
       return false;
    } else {
-      return DROf->writeFsGridData(perBGrid, EGrid, EHallGrid, EGradPeGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, volGrid, technicalGrid, meshName, vlsvWriter, writeAsFloat);
+      return DROf->writeFsGridData(fsgrids, meshName, vlsvWriter, writeAsFloat);
    }
 }
 

--- a/datareduction/datareducer.h
+++ b/datareduction/datareducer.h
@@ -56,16 +56,7 @@ class DataReducer {
    unsigned int size() const;
    bool writeParameters(const unsigned int& operatorID, vlsv::Writer& vlsvWriter);
    bool writeFsGridData(
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+                      FsGridWrapper& fsgrids,
                       const std::string& meshName, const unsigned int operatorID,
                       vlsv::Writer& vlsvWriter,
                       const bool writeAsFloat = false);

--- a/datareduction/datareductionoperator.cpp
+++ b/datareduction/datareductionoperator.cpp
@@ -127,16 +127,7 @@ namespace DRO {
    }
 
    bool DataReductionOperatorFsGrid::writeFsGridData(
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+                      FsGridWrapper& fsgrids,
                       const std::string& meshName, vlsv::Writer& vlsvWriter,
                       const bool writeAsFloat) {
 
@@ -148,10 +139,9 @@ namespace DRO {
       attribs["unitConversion"]=unitConversion;
       attribs["variableLaTeX"]=variableLaTeX;
 
-      std::vector<double> varBuffer =
-         lambda(perBGrid,EGrid,EHallGrid,EGradPeGrid,momentsGrid,dPerBGrid,dMomentsGrid,BgBGrid,volGrid,technicalGrid);
+      std::vector<double> varBuffer = lambda(fsgrids);
 
-      std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+      std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
       int vectorSize;
 
       // Check if there is anything to write (eg, we are a non-FS process)

--- a/datareduction/datareductionoperator.h
+++ b/datareduction/datareductionoperator.h
@@ -93,17 +93,7 @@ namespace DRO {
    class DataReductionOperatorFsGrid : public DataReductionOperator {
 
       public:
-        typedef std::function<std::vector<double>(
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)> ReductionLambda;
+        typedef std::function<std::vector<double>(FsGridWrapper& fsgrids)> ReductionLambda;
       private:
          ReductionLambda lambda;
          std::string variableName;
@@ -116,16 +106,7 @@ namespace DRO {
          virtual bool reduceData(const SpatialCell* cell,char* buffer);
          virtual bool reduceDiagnostic(const SpatialCell* cell,Real * result);
          virtual bool writeFsGridData(
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+                      FsGridWrapper& fsgrids,
                       const std::string& meshName, vlsv::Writer& vlsvWriter,
                       const bool writeAsFloat=false);
    };

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -26,6 +26,7 @@
 #include "derivatives.hpp"
 #include "fs_limiters.h"
 #include <Eigen/Geometry>
+#include "../object_wrapper.h"
 
 /*! \brief Low-level spatial derivatives calculation.
  *
@@ -52,20 +53,22 @@ void calculateDerivatives(
    cint i,
    cint j,
    cint k,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
-   const bool calculateMoments
+   const bool calculateMoments,
+   const bool dt2
 ) {
-   std::array<Real, fsgrids::dperb::N_DPERB> * dPerB = dPerBGrid.get(i,j,k);
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dMoments = dMomentsGrid.get(i,j,k);
+   std::array<Real, fsgrids::dperb::N_DPERB> * dPerB = fsgrids.dPerBGrid.get(i,j,k);
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dMoments;
+   if(!dt2) {
+      dMoments = fsgrids.dMomentsGrid.get(i,j,k);
+   } else {
+      dMoments = fsgrids.dMomentsDt2Grid.get(i,j,k);
+   }
 
    // Get boundary flag for the cell:
-   cuint sysBoundaryFlag  = technicalGrid.get(i,j,k)->sysBoundaryFlag;
-   cuint sysBoundaryLayer = technicalGrid.get(i,j,k)->sysBoundaryLayer;
+   cuint sysBoundaryFlag  = fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag;
+   cuint sysBoundaryLayer = fsgrids.technicalGrid.get(i,j,k)->sysBoundaryLayer;
 
    // Constants for electron pressure derivatives
    // Upstream pressure
@@ -74,8 +77,8 @@ void calculateDerivatives(
 
    std::array<Real, fsgrids::moments::N_MOMENTS> * leftMoments = NULL;
    std::array<Real, fsgrids::bfield::N_BFIELD> * leftPerB = NULL;
-   std::array<Real, fsgrids::moments::N_MOMENTS> * centMoments = momentsGrid.get(i,j,k);
-   std::array<Real, fsgrids::bfield::N_BFIELD> * centPerB = perBGrid.get(i,j,k);
+   std::array<Real, fsgrids::moments::N_MOMENTS> * centMoments = fsgrids.momentsGrid.get(i,j,k);
+   std::array<Real, fsgrids::bfield::N_BFIELD> * centPerB = fsgrids.perBGrid.get(i,j,k);
    #ifdef DEBUG_SOLVERS
    if (centMoments->at(fsgrids::moments::RHOM) <= 0) {
       std::cerr << __FILE__ << ":" << __LINE__
@@ -92,10 +95,10 @@ void calculateDerivatives(
    std::array<Real, fsgrids::bfield::N_BFIELD>  * topRght = NULL;
 
    // Calculate x-derivatives (is not TVD for AMR mesh):
-   leftPerB = perBGrid.get(i-1,j,k);
-   rghtPerB = perBGrid.get(i+1,j,k);
-   leftMoments = momentsGrid.get(i-1,j,k);
-   rghtMoments = momentsGrid.get(i+1,j,k);
+   leftPerB = fsgrids.perBGrid.get(i-1,j,k);
+   rghtPerB = fsgrids.perBGrid.get(i+1,j,k);
+   leftMoments = fsgrids.momentsGrid.get(i-1,j,k);
+   rghtMoments = fsgrids.momentsGrid.get(i+1,j,k);
    if(leftPerB == NULL) {
       leftPerB = centPerB;
       leftMoments = centMoments;
@@ -161,10 +164,10 @@ void calculateDerivatives(
    }
 
    // Calculate y-derivatives (is not TVD for AMR mesh):
-   leftPerB = perBGrid.get(i,j-1,k);
-   rghtPerB = perBGrid.get(i,j+1,k);
-   leftMoments = momentsGrid.get(i,j-1,k);
-   rghtMoments = momentsGrid.get(i,j+1,k);
+   leftPerB = fsgrids.perBGrid.get(i,j-1,k);
+   rghtPerB = fsgrids.perBGrid.get(i,j+1,k);
+   leftMoments = fsgrids.momentsGrid.get(i,j-1,k);
+   rghtMoments = fsgrids.momentsGrid.get(i,j+1,k);
    if(leftPerB == NULL) {
       leftPerB = centPerB;
       leftMoments = centMoments;
@@ -213,10 +216,10 @@ void calculateDerivatives(
    }
 
    // Calculate z-derivatives (is not TVD for AMR mesh):
-   leftPerB = perBGrid.get(i,j,k-1);
-   rghtPerB = perBGrid.get(i,j,k+1);
-   leftMoments = momentsGrid.get(i,j,k-1);
-   rghtMoments = momentsGrid.get(i,j,k+1);
+   leftPerB = fsgrids.perBGrid.get(i,j,k-1);
+   rghtPerB = fsgrids.perBGrid.get(i,j,k+1);
+   leftMoments = fsgrids.momentsGrid.get(i,j,k-1);
+   rghtMoments = fsgrids.momentsGrid.get(i,j,k+1);
    if(leftPerB == NULL) {
       leftPerB = centPerB;
       leftMoments = centMoments;
@@ -274,35 +277,35 @@ void calculateDerivatives(
    } else {
       // Calculate xy mixed derivatives:
       if (sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) {
-         botLeft = perBGrid.get(i-1,j-1,k);
-         botRght = perBGrid.get(i+1,j-1,k);
-         topLeft = perBGrid.get(i-1,j+1,k);
-         topRght = perBGrid.get(i+1,j+1,k);
+         botLeft = fsgrids.perBGrid.get(i-1,j-1,k);
+         botRght = fsgrids.perBGrid.get(i+1,j-1,k);
+         topLeft = fsgrids.perBGrid.get(i-1,j+1,k);
+         topRght = fsgrids.perBGrid.get(i+1,j+1,k);
          dPerB->at(fsgrids::dperb::dPERBzdxy) = FOURTH * (botLeft->at(fsgrids::bfield::PERBZ) + topRght->at(fsgrids::bfield::PERBZ) - botRght->at(fsgrids::bfield::PERBZ) - topLeft->at(fsgrids::bfield::PERBZ));
       } else {
-         SBC::SysBoundaryCondition::setCellDerivativesToZero(dPerBGrid, dMomentsGrid, i, j, k, 3);
+         SBC::SysBoundaryCondition::setCellDerivativesToZero(fsgrids.dPerBGrid, fsgrids.dMomentsGrid, i, j, k, 3);
       }
 
       // Calculate xz mixed derivatives:
       if (sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) {
-         botLeft = perBGrid.get(i-1,j,k-1);
-         botRght = perBGrid.get(i+1,j,k-1);
-         topLeft = perBGrid.get(i-1,j,k+1);
-         topRght = perBGrid.get(i+1,j,k+1);
+         botLeft = fsgrids.perBGrid.get(i-1,j,k-1);
+         botRght = fsgrids.perBGrid.get(i+1,j,k-1);
+         topLeft = fsgrids.perBGrid.get(i-1,j,k+1);
+         topRght = fsgrids.perBGrid.get(i+1,j,k+1);
          dPerB->at(fsgrids::dperb::dPERBydxz) = FOURTH * (botLeft->at(fsgrids::bfield::PERBY) + topRght->at(fsgrids::bfield::PERBY) - botRght->at(fsgrids::bfield::PERBY) - topLeft->at(fsgrids::bfield::PERBY));
       } else {
-         SBC::SysBoundaryCondition::setCellDerivativesToZero(dPerBGrid, dMomentsGrid, i, j, k, 4);
+         SBC::SysBoundaryCondition::setCellDerivativesToZero(fsgrids.dPerBGrid, fsgrids.dMomentsGrid, i, j, k, 4);
       }
 
       // Calculate yz mixed derivatives:
       if (sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) {
-         botLeft = perBGrid.get(i,j-1,k-1);
-         botRght = perBGrid.get(i,j+1,k-1);
-         topLeft = perBGrid.get(i,j-1,k+1);
-         topRght = perBGrid.get(i,j+1,k+1);
+         botLeft = fsgrids.perBGrid.get(i,j-1,k-1);
+         botRght = fsgrids.perBGrid.get(i,j+1,k-1);
+         topLeft = fsgrids.perBGrid.get(i,j-1,k+1);
+         topRght = fsgrids.perBGrid.get(i,j+1,k+1);
          dPerB->at(fsgrids::dperb::dPERBxdyz) = FOURTH * (botLeft->at(fsgrids::bfield::PERBX) + topRght->at(fsgrids::bfield::PERBX) - botRght->at(fsgrids::bfield::PERBX) - topLeft->at(fsgrids::bfield::PERBX));
       } else {
-         SBC::SysBoundaryCondition::setCellDerivativesToZero(dPerBGrid, dMomentsGrid, i, j, k, 5);
+         SBC::SysBoundaryCondition::setCellDerivativesToZero(fsgrids.dPerBGrid, fsgrids.dMomentsGrid, i, j, k, 5);
       }
    }
 }
@@ -330,19 +333,12 @@ void calculateDerivatives(
  * \sa calculateDerivatives calculateBVOLDerivativesSimple calculateBVOLDerivatives
  */
 void calculateDerivativesSimple(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsDt2Grid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    cint& RKCase,
    const bool doMoments) {
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
-   const FsGridTools::FsIndex_t* gridDims = &technicalGrid.getLocalSize()[0];
+   const FsGridTools::FsIndex_t* gridDims = &fsgrids.technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    phiprof::Timer derivativesTimer {"Calculate face derivatives"};
    int computeTimerId {phiprof::initializeTimer("FS derivatives compute cells")};
@@ -354,27 +350,27 @@ void calculateDerivativesSimple(
       // standard case Exchange PERB* with neighbours
       // The update of PERB[XYZ] is needed after the system
       // boundary update of propagateMagneticFieldSimple.
-       perBGrid.updateGhostCells();
+       fsgrids.perBGrid.updateGhostCells();
        if(doMoments) {
-         momentsGrid.updateGhostCells();
+         fsgrids.momentsGrid.updateGhostCells();
        }
        break;
     case RK_ORDER2_STEP1:
       // Exchange PERB*_DT2,RHO_DT2,V*_DT2 with neighbours The
       // update of PERB[XYZ]_DT2 is needed after the system
       // boundary update of propagateMagneticFieldSimple.
-       perBDt2Grid.updateGhostCells();
+       fsgrids.perBDt2Grid.updateGhostCells();
        if(doMoments) {
-         momentsDt2Grid.updateGhostCells();
+         fsgrids.momentsDt2Grid.updateGhostCells();
        }
        break;
     case RK_ORDER2_STEP2:
       // Exchange PERB*,RHO,V* with neighbours The update of B
       // is needed after the system boundary update of
       // propagateMagneticFieldSimple.
-       perBGrid.updateGhostCells();
+       fsgrids.perBGrid.updateGhostCells();
        if(doMoments) {
-         momentsGrid.updateGhostCells();
+         fsgrids.momentsGrid.updateGhostCells();
        }
       break;
     default:
@@ -392,9 +388,9 @@ void calculateDerivativesSimple(
          for (FsGridTools::FsIndex_t j=0; j<gridDims[1]; j++) {
             for (FsGridTools::FsIndex_t i=0; i<gridDims[0]; i++) {
                if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-                  calculateDerivatives(i,j,k, perBGrid, momentsGrid, dPerBGrid, dMomentsGrid, technicalGrid, sysBoundaries, doMoments);
+                  calculateDerivatives(i,j,k, fsgrids, sysBoundaries, doMoments, false);
                } else {
-                  calculateDerivatives(i,j,k, perBDt2Grid, momentsDt2Grid, dPerBGrid, dMomentsDt2Grid, technicalGrid, sysBoundaries, doMoments);
+                  calculateDerivatives(i,j,k, fsgrids, sysBoundaries, doMoments, true);
                }
             }
          }
@@ -506,25 +502,23 @@ void calculateBVOLDerivatives(
  * BVOL has been calculated locally by calculateVolumeAveragedFields but not communicated.
  * For the acceleration step one needs the cross-derivatives of BVOL
  *
- * \param volGrid fsGrid holding the volume averaged fields
- * \param technicalGrid fsGrid holding technical information (such as boundary types)
+ * \param fsgrids The container holding all fieldsolver grids
  * \param sysBoundaries System boundary conditions existing
  *
  * \sa calculateDerivatives calculateBVOLDerivatives calculateDerivativesSimple
  */
 void calculateBVOLDerivativesSimple(
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries
 ) {
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
-   const FsGridTools::FsIndex_t* gridDims = &technicalGrid.getLocalSize()[0];
+   const FsGridTools::FsIndex_t* gridDims = &fsgrids.technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    phiprof::Timer derivsTimer {"Calculate volume derivatives"};
    int computeTimerId {phiprof::initializeTimer("FS derivatives BVOL compute cells")};
 
    phiprof::Timer commTimer {"BVOL derivatives ghost updates MPI", {"MPI"}};
-   volGrid.updateGhostCells();
+   fsgrids.volGrid.updateGhostCells();
    commTimer.stop(N_cells,"Spatial Cells");
 
    // Calculate derivatives
@@ -535,7 +529,7 @@ void calculateBVOLDerivativesSimple(
       for (FsGridTools::FsIndex_t k=0; k<gridDims[2]; k++) {
          for (FsGridTools::FsIndex_t j=0; j<gridDims[1]; j++) {
             for (FsGridTools::FsIndex_t i=0; i<gridDims[0]; i++) {
-               calculateBVOLDerivatives(volGrid,technicalGrid,i,j,k,sysBoundaries);
+               calculateBVOLDerivatives(fsgrids.volGrid,fsgrids.technicalGrid,i,j,k,sysBoundaries);
             }
          }
       }
@@ -548,9 +542,7 @@ void calculateBVOLDerivativesSimple(
 /*! \brief Low-level curvature calculation.
  *
  *
- * \param volGrid fsGrid holding the volume averaged fields
- * \param bgbGrid fsGrid holding the background fields
- * \param technicalGrid fsGrid holding technical information (such as boundary types)
+ * \param fsgrids The container holding all fieldsolver grids
  * \param i,j,k fsGrid cell coordinates for the current cell
  * \param sysBoundaries System boundary conditions existing
  *
@@ -560,30 +552,28 @@ void calculateBVOLDerivativesSimple(
  */
 
 void calculateCurvature(
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    cint i,
    cint j,
    cint k,
    SysBoundary& sysBoundaries
 ) {
-   if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY && technicalGrid.get(i,j,k)->sysBoundaryLayer != 1 && technicalGrid.get(i,j,k)->sysBoundaryLayer != 2) {
-      std::array<Real, fsgrids::volfields::N_VOL> * vol = volGrid.get(i,j,k);
-      std::array<Real, fsgrids::bgbfield::N_BGB> * bg = bgbGrid.get(i,j,k);
+   if (fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY && fsgrids.technicalGrid.get(i,j,k)->sysBoundaryLayer != 1 && fsgrids.technicalGrid.get(i,j,k)->sysBoundaryLayer != 2) {
+      std::array<Real, fsgrids::volfields::N_VOL> * vol = fsgrids.volGrid.get(i,j,k);
+      std::array<Real, fsgrids::bgbfield::N_BGB> * bg = fsgrids.BgBGrid.get(i,j,k);
 
-      std::array<Real, fsgrids::volfields::N_VOL> * vol_left_x = volGrid.get(i-1,j,k);
-      std::array<Real, fsgrids::volfields::N_VOL> * vol_rght_x = volGrid.get(i+1,j,k);
-      std::array<Real, fsgrids::volfields::N_VOL> * vol_left_y = volGrid.get(i,j-1,k);
-      std::array<Real, fsgrids::volfields::N_VOL> * vol_rght_y = volGrid.get(i,j+1,k);
-      std::array<Real, fsgrids::volfields::N_VOL> * vol_left_z = volGrid.get(i,j,k-1);
-      std::array<Real, fsgrids::volfields::N_VOL> * vol_rght_z = volGrid.get(i,j,k+1);
-      std::array<Real, fsgrids::bgbfield::N_BGB> * bg_left_x = bgbGrid.get(i-1,j,k);
-      std::array<Real, fsgrids::bgbfield::N_BGB> * bg_rght_x = bgbGrid.get(i+1,j,k);
-      std::array<Real, fsgrids::bgbfield::N_BGB> * bg_left_y = bgbGrid.get(i,j-1,k);
-      std::array<Real, fsgrids::bgbfield::N_BGB> * bg_rght_y = bgbGrid.get(i,j+1,k);
-      std::array<Real, fsgrids::bgbfield::N_BGB> * bg_left_z = bgbGrid.get(i,j,k-1);
-      std::array<Real, fsgrids::bgbfield::N_BGB> * bg_rght_z = bgbGrid.get(i,j,k+1);
+      std::array<Real, fsgrids::volfields::N_VOL> * vol_left_x = fsgrids.volGrid.get(i-1,j,k);
+      std::array<Real, fsgrids::volfields::N_VOL> * vol_rght_x = fsgrids.volGrid.get(i+1,j,k);
+      std::array<Real, fsgrids::volfields::N_VOL> * vol_left_y = fsgrids.volGrid.get(i,j-1,k);
+      std::array<Real, fsgrids::volfields::N_VOL> * vol_rght_y = fsgrids.volGrid.get(i,j+1,k);
+      std::array<Real, fsgrids::volfields::N_VOL> * vol_left_z = fsgrids.volGrid.get(i,j,k-1);
+      std::array<Real, fsgrids::volfields::N_VOL> * vol_rght_z = fsgrids.volGrid.get(i,j,k+1);
+      std::array<Real, fsgrids::bgbfield::N_BGB> * bg_left_x = fsgrids.BgBGrid.get(i-1,j,k);
+      std::array<Real, fsgrids::bgbfield::N_BGB> * bg_rght_x = fsgrids.BgBGrid.get(i+1,j,k);
+      std::array<Real, fsgrids::bgbfield::N_BGB> * bg_left_y = fsgrids.BgBGrid.get(i,j-1,k);
+      std::array<Real, fsgrids::bgbfield::N_BGB> * bg_rght_y = fsgrids.BgBGrid.get(i,j+1,k);
+      std::array<Real, fsgrids::bgbfield::N_BGB> * bg_left_z = fsgrids.BgBGrid.get(i,j,k-1);
+      std::array<Real, fsgrids::bgbfield::N_BGB> * bg_rght_z = fsgrids.BgBGrid.get(i,j,k+1);
 
       Real bx = bg->at(fsgrids::bgbfield::BGBXVOL) + vol->at(fsgrids::volfields::PERBXVOL);
       Real by = bg->at(fsgrids::bgbfield::BGBYVOL) + vol->at(fsgrids::volfields::PERBYVOL);
@@ -640,35 +630,31 @@ void calculateCurvature(
       rght_z_by /= rght_z_bnorm;
       rght_z_bz /= rght_z_bnorm;
 
-      vol->at(fsgrids::volfields::CURVATUREX) = bx * 0.5*(rght_x_bx-left_x_bx) / technicalGrid.DX + by * 0.5*(rght_y_bx-left_y_bx) / technicalGrid.DY + bz * 0.5*(rght_z_bx-left_z_bx) / technicalGrid.DZ;
-      vol->at(fsgrids::volfields::CURVATUREY) = bx * 0.5*(rght_x_by-left_x_by) / technicalGrid.DX + by * 0.5*(rght_y_by-left_y_by) / technicalGrid.DY + bz * 0.5*(rght_z_by-left_z_by) / technicalGrid.DZ;
-      vol->at(fsgrids::volfields::CURVATUREZ) = bx * 0.5*(rght_x_bz-left_x_bz) / technicalGrid.DX + by * 0.5*(rght_y_bz-left_y_bz) / technicalGrid.DY + bz * 0.5*(rght_z_bz-left_z_bz) / technicalGrid.DZ;
+      vol->at(fsgrids::volfields::CURVATUREX) = bx * 0.5*(rght_x_bx-left_x_bx) / fsgrids.technicalGrid.DX + by * 0.5*(rght_y_bx-left_y_bx) / fsgrids.technicalGrid.DY + bz * 0.5*(rght_z_bx-left_z_bx) / fsgrids.technicalGrid.DZ;
+      vol->at(fsgrids::volfields::CURVATUREY) = bx * 0.5*(rght_x_by-left_x_by) / fsgrids.technicalGrid.DX + by * 0.5*(rght_y_by-left_y_by) / fsgrids.technicalGrid.DY + bz * 0.5*(rght_z_by-left_z_by) / fsgrids.technicalGrid.DZ;
+      vol->at(fsgrids::volfields::CURVATUREZ) = bx * 0.5*(rght_x_bz-left_x_bz) / fsgrids.technicalGrid.DX + by * 0.5*(rght_y_bz-left_y_bz) / fsgrids.technicalGrid.DY + bz * 0.5*(rght_z_bz-left_z_bz) / fsgrids.technicalGrid.DZ;
    }
 }
 
 /*! \brief High-level curvature calculation wrapper function.
  *
- * \param volGrid fsGrid holding the volume averaged fields
- * \param bgbGrid fsGrid holding the background fields
- * \param technicalGrid fsGrid holding technical information (such as boundary types)
+ * \param fsgrids The container holding all fieldsolver grids
  * \param sysBoundaries System boundary conditions existing
  *
  * \sa calculateDerivatives calculateBVOLDerivatives calculateDerivativesSimple
  */
 void calculateCurvatureSimple(
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries
 ) {
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
-   const FsGridTools::FsIndex_t* gridDims = &technicalGrid.getLocalSize()[0];
+   const FsGridTools::FsIndex_t* gridDims = &fsgrids.technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    phiprof::Timer curvatureTimer {"Calculate curvature"};
    int computeTimerId {phiprof::initializeTimer("Calculate curvature compute cells")};
 
    phiprof::Timer commTimer {"Calculate curvature ghost updates MPI", {"MPI"}};
-   volGrid.updateGhostCells();
+   fsgrids.volGrid.updateGhostCells();
    commTimer.stop(N_cells,"Spatial Cells");
 
    #pragma omp parallel
@@ -678,11 +664,13 @@ void calculateCurvatureSimple(
       for (FsGridTools::FsIndex_t k=0; k<gridDims[2]; k++) {
          for (FsGridTools::FsIndex_t j=0; j<gridDims[1]; j++) {
             for (FsGridTools::FsIndex_t i=0; i<gridDims[0]; i++) {
-               if (technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
-                   technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) {
+               if (fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE ||
+                   fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) {
                   continue;
                }
-               calculateCurvature(volGrid,bgbGrid,technicalGrid,i,j,k,sysBoundaries);
+
+               // TODO: If this were properly inlined, this could probably be SIMD'd over
+               calculateCurvature(fsgrids,i,j,k,sysBoundaries);
             }
          }
       }

--- a/fieldsolver/derivatives.hpp
+++ b/fieldsolver/derivatives.hpp
@@ -30,28 +30,18 @@
 #include "fs_limiters.h"
 
 void calculateDerivativesSimple(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsDt2Grid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    cint& RKCase,
    const bool communicateMoments);
 
 void calculateBVOLDerivativesSimple(
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries
 );
 
 void calculateCurvatureSimple(
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries
 );
 

--- a/fieldsolver/fs_common.cpp
+++ b/fieldsolver/fs_common.cpp
@@ -22,6 +22,7 @@
 
 #include "fs_common.h"
 #include "../fieldtracing/fieldtracing.h"
+#include "../object_wrapper.h"
 
 /*! \brief Helper function
  * 
@@ -205,32 +206,28 @@ void reconstructionCoefficients(
  *  D.S. Balsara, J. Comp. Phys., 228, 2009
  *  doi:10.1016/j.jcp.2009.03.038
  *
- * \param perBGrid perturbed B fsGrid
- * \param dPerBGrid perturbed B derivatives fsGrid
- * \param technicalGrid technical fsGrid
+ * \param fsgrids The wrapper containing all fieldsolver grids.
  * \param i local fsGrid x-index
  * \param j local fsGrid y-index
  * \param k local fsGrid z-index
  * \param x 3D global simulation x,y,z coordinates of point to interpolate to
  */
 std::array<Real, 3> interpolatePerturbedB(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    std::map< std::array<int, 3>, std::array<Real, Rec::N_REC_COEFFICIENTS> > & reconstructionCoefficientsCache,
    cint i,
    cint j,
    cint k,
    const std::array<Real, 3> x
 ) {
-   cuint cellSysBoundaryFlag = technicalGrid.get(i,j,k)->sysBoundaryFlag;
+   cuint cellSysBoundaryFlag = fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag;
    if (cellSysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY) {
       std::array<Real, 3> zero = {0,0,0};
       return zero;
    }
 
    // Balsara reconstruction formulas: x,y,z are in [-1/2, 1/2] local coordinates
-   std::array<Real, 3> xLocal = getFractionalFsGridCellForCoord(technicalGrid, x);
+   std::array<Real, 3> xLocal = getFractionalFsGridCellForCoord(fsgrids.technicalGrid, x);
    xLocal[0] -= 0.5;
    xLocal[1] -= 0.5;
    xLocal[2] -= 0.5;
@@ -248,8 +245,8 @@ std::array<Real, 3> interpolatePerturbedB(
       {
          if (reconstructionCoefficientsCache.find(cellIds) == reconstructionCoefficientsCache.end()) {
             reconstructionCoefficients(
-               perBGrid,
-               dPerBGrid,
+               fsgrids.perBGrid,
+               fsgrids.dPerBGrid,
                rc,
                i,
                j,
@@ -263,8 +260,8 @@ std::array<Real, 3> interpolatePerturbedB(
       }
    } else {
       reconstructionCoefficients(
-         perBGrid,
-         dPerBGrid,
+         fsgrids.perBGrid,
+         fsgrids.dPerBGrid,
          rc,
          i,
          j,
@@ -294,25 +291,21 @@ std::array<Real, 3> interpolatePerturbedB(
  *  and the wxMaxima file at
  *  doc/fieldsolver/Balsara_curlB_at_arbitrary_xyz.wxmx
  *
- * \param perBGrid perturbed B fsGrid
- * \param dPerBGrid perturbed B derivatives fsGrid
- * \param technicalGrid technical fsGrid
+ * \param fsgrids The wrapper containing all fieldsolver grids.
  * \param i local fsGrid x-index
  * \param j local fsGrid y-index
  * \param k local fsGrid z-index
  * \param x 3D global simulation x,y,z coordinates of point to interpolate to
  */
 std::array<Real, 3> interpolateCurlB(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    std::map< std::array<int, 3>, std::array<Real, Rec::N_REC_COEFFICIENTS> > & reconstructionCoefficientsCache,
    cint i,
    cint j,
    cint k,
    const std::array<Real, 3> x
 ) {
-   cuint cellSysBoundaryFlag = technicalGrid.get(i,j,k)->sysBoundaryFlag;
+   cuint cellSysBoundaryFlag = fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag;
    if (cellSysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY) {
       std::array<Real, 3> zero = {0,0,0};
       return zero;
@@ -321,7 +314,7 @@ std::array<Real, 3> interpolateCurlB(
 #define BALSARA_CURLB_IMPLEMENTATION
 #ifdef BALSARA_CURLB_IMPLEMENTATION
    // Balsara reconstruction formulas: x,y,z are in [-1/2, 1/2] local coordinates
-   std::array<Real, 3> xLocal = getFractionalFsGridCellForCoord(technicalGrid, x);
+   std::array<Real, 3> xLocal = getFractionalFsGridCellForCoord(fsgrids.technicalGrid, x);
    xLocal[0] -= 0.5;
    xLocal[1] -= 0.5;
    xLocal[2] -= 0.5;
@@ -340,8 +333,8 @@ std::array<Real, 3> interpolateCurlB(
       {
          if (reconstructionCoefficientsCache.find(cellIds) == reconstructionCoefficientsCache.end()) {
             reconstructionCoefficients(
-               perBGrid,
-               dPerBGrid,
+               fsgrids.perBGrid,
+               fsgrids.dPerBGrid,
                rc,
                i,
                j,
@@ -355,8 +348,8 @@ std::array<Real, 3> interpolateCurlB(
       }
    } else {
       reconstructionCoefficients(
-         perBGrid,
-         dPerBGrid,
+         fsgrids.perBGrid,
+         fsgrids.dPerBGrid,
          rc,
          i,
          j,
@@ -428,14 +421,14 @@ std::array<Real, 3> interpolateCurlB(
    std::array<Real,3> cell;
    std::array<int,3> fsc,lfsc;
    // Convert physical coordinate to cell index
-   cell[0] =  (x[0] - P::xmin) / technicalGrid.DX;
-   cell[1] =  (x[1] - P::ymin) / technicalGrid.DY;
-   cell[2] =  (x[2] - P::zmin) / technicalGrid.DZ;
+   cell[0] =  (x[0] - P::xmin) / fsgrids.technicalGrid.DX;
+   cell[1] =  (x[1] - P::ymin) / fsgrids.technicalGrid.DY;
+   cell[2] =  (x[2] - P::zmin) / fsgrids.technicalGrid.DZ;
    for(int c=0; c<3; c++) {
       fsc[c] = floor(cell[c]);
    }
    // Local cell
-   lfsc = technicalGrid.globalToLocal(fsc[0],fsc[1],fsc[2]);
+   lfsc = fsgrids.technicalGrid.globalToLocal(fsc[0],fsc[1],fsc[2]);
    if(lfsc[0] == -1 || lfsc[1] == -1 || lfsc[2] == -1) {
       cerr << "interpolateCurlB: Trying to access nonlocal cell at " << x[0] << ", " << x[1] << ", " << x[2] << ", which would be local coordinate "
          << lfsc[0] << ", " << lfsc[1] << ", " << lfsc[2] << endl;
@@ -461,7 +454,7 @@ std::array<Real, 3> interpolateCurlB(
             Real coupling = abs(xoffset - (cell[0]-fsc[0])) * abs(yoffset - (cell[1]-fsc[1])) * abs(zoffset - (cell[2]-fsc[2]));
 
             // Only couple to actual simulation cells
-            if(technicalGrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) {
+            if(fsgrids.technicalGrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) {
                couplingSum += coupling;
             } else {
                continue;

--- a/fieldsolver/fs_common.h
+++ b/fieldsolver/fs_common.h
@@ -63,21 +63,7 @@ static creal EPS = 1.0e-30;
 using namespace std;
 
 bool propagateFields(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EDt2Grid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeDt2Grid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    creal& dt,
    cuint subcycles
@@ -107,9 +93,7 @@ void reconstructionCoefficients(
 );
 
 std::array<Real, 3> interpolatePerturbedB(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    std::map< std::array<int, 3>, std::array<Real, Rec::N_REC_COEFFICIENTS> > & reconstructionCoefficientsCache,
    cint i,
    cint j,
@@ -118,9 +102,7 @@ std::array<Real, 3> interpolatePerturbedB(
 );
 
 std::array<Real, 3> interpolateCurlB(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    std::map< std::array<int, 3>, std::array<Real, Rec::N_REC_COEFFICIENTS> > & reconstructionCoefficientsCache,
    cint i,
    cint j,

--- a/fieldsolver/gridGlue.cpp
+++ b/fieldsolver/gridGlue.cpp
@@ -133,8 +133,7 @@ void filterMoments(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
 
 void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                            const std::vector<CellID>& cells,
-                           FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                           FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+                           FsGridWrapper& fsgrids,
                            bool dt2 /*=false*/) {
 
   int ii;
@@ -174,21 +173,21 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
       auto cellParams = mpiGrid[sendCell]->get_cell_parameters();
       if(!dt2) {
         sendBuffer.push_back(cellParams[CellParams::RHOM]);
-	sendBuffer.push_back(cellParams[CellParams::RHOQ]);
-	sendBuffer.push_back(cellParams[CellParams::VX]);
-	sendBuffer.push_back(cellParams[CellParams::VY]);
+        sendBuffer.push_back(cellParams[CellParams::RHOQ]);
+        sendBuffer.push_back(cellParams[CellParams::VX]);
+        sendBuffer.push_back(cellParams[CellParams::VY]);
         sendBuffer.push_back(cellParams[CellParams::VZ]);
-	sendBuffer.push_back(cellParams[CellParams::P_11]);
-	sendBuffer.push_back(cellParams[CellParams::P_22]);
+        sendBuffer.push_back(cellParams[CellParams::P_11]);
+        sendBuffer.push_back(cellParams[CellParams::P_22]);
         sendBuffer.push_back(cellParams[CellParams::P_33]);
       } else {
         sendBuffer.push_back(cellParams[CellParams::RHOM_DT2]);
-	sendBuffer.push_back(cellParams[CellParams::RHOQ_DT2]);
-	sendBuffer.push_back(cellParams[CellParams::VX_DT2]);
-	sendBuffer.push_back(cellParams[CellParams::VY_DT2]);
+        sendBuffer.push_back(cellParams[CellParams::RHOQ_DT2]);
+        sendBuffer.push_back(cellParams[CellParams::VX_DT2]);
+        sendBuffer.push_back(cellParams[CellParams::VY_DT2]);
         sendBuffer.push_back(cellParams[CellParams::VZ_DT2]);
-	sendBuffer.push_back(cellParams[CellParams::P_11_DT2]);
-	sendBuffer.push_back(cellParams[CellParams::P_22_DT2]);
+        sendBuffer.push_back(cellParams[CellParams::P_11_DT2]);
+        sendBuffer.push_back(cellParams[CellParams::P_22_DT2]);
         sendBuffer.push_back(cellParams[CellParams::P_33_DT2]);
       }
     }
@@ -205,12 +204,17 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
     Real* receiveBuffer = receivedData[process].data(); // data received from process
     for(auto const &cell: receives.second){ //loop over cellids (dccrg) for receive
       // this part heavily relies on both sender and receiver having cellids sorted!
-      for(auto lid: onFsgridMapCellsGlobal[cell]){
-	std::array<Real, fsgrids::moments::N_MOMENTS> * fsgridData = momentsGrid.get(lid);
-	for(int l = 0; l < fsgrids::moments::N_MOMENTS; l++)   {
-	  fsgridData->at(l) = receiveBuffer[l];
-	}
-      }
+       for(auto lid: onFsgridMapCellsGlobal[cell]){
+          std::array<Real, fsgrids::moments::N_MOMENTS> * fsgridData;
+          if(!dt2) {
+            fsgridData = fsgrids.momentsGrid.get(lid);
+          } else {
+            fsgridData = fsgrids.momentsDt2Grid.get(lid);
+          }
+          for(int l = 0; l < fsgrids::moments::N_MOMENTS; l++)   {
+             fsgridData->at(l) = receiveBuffer[l];
+          }
+       }
       
       receiveBuffer+=fsgrids::moments::N_MOMENTS;
     }
@@ -221,16 +225,16 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
    //Filter Moments if this is a 3D AMR run.
   if (P::amrMaxSpatialRefLevel>0) { 
       phiprof::Timer filteringTimer {"AMR Filtering-Triangle-3D"};
-      filterMoments(mpiGrid,momentsGrid,technicalGrid);
+      if(!dt2) {
+         filterMoments(mpiGrid,fsgrids.momentsGrid,fsgrids.technicalGrid);
+      } else {
+         filterMoments(mpiGrid,fsgrids.momentsDt2Grid,fsgrids.technicalGrid);
+      }
    }   
 }
 
 void getFieldsFromFsGrid(
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volumeFieldsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    const std::vector<CellID>& cells
 ) {
@@ -299,7 +303,7 @@ void getFieldsFromFsGrid(
          auto const &fsgridCells = onFsgridMapCellsGlobal[dccrgCell];
          for (auto const fsgridCell: fsgridCells){
             //loop over fsgrid cells for which we compute the average that is sent to dccrgCell on rank remoteRank
-            if(technicalGrid.get(fsgridCell)->sysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) {
+            if(fsgrids.technicalGrid.get(fsgridCell)->sysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) {
                // We skip boundary padding cells on the outer boundaries here,
                // because their fields anyway don't contribute anything
                // meaningful (as there are never properly updated).
@@ -309,33 +313,33 @@ void getFieldsFromFsGrid(
                // cell's DCCRG volume averages.
                continue;
             }
-            std::array<Real, fsgrids::volfields::N_VOL> * volcell = volumeFieldsGrid.get(fsgridCell);
-            std::array<Real, fsgrids::bgbfield::N_BGB> * bgcell = BgBGrid.get(fsgridCell);
-            std::array<Real, fsgrids::egradpe::N_EGRADPE> * egradpecell = EGradPeGrid.get(fsgridCell);	
-            std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dMomentscell = dMomentsGrid.get(fsgridCell);	
+            std::array<Real, fsgrids::volfields::N_VOL> * volcell = fsgrids.volGrid.get(fsgridCell);
+            std::array<Real, fsgrids::bgbfield::N_BGB> * bgcell = fsgrids.BgBGrid.get(fsgridCell);
+            std::array<Real, fsgrids::egradpe::N_EGRADPE> * egradpecell = fsgrids.EGradPeGrid.get(fsgridCell);	
+            std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dMomentscell = fsgrids.dMomentsGrid.get(fsgridCell);	
             
             // TODO consider pruning these and communicating only when required
             sendBuffer[ii].sums[FieldsToCommunicate::PERBXVOL] += volcell->at(fsgrids::volfields::PERBXVOL);
             sendBuffer[ii].sums[FieldsToCommunicate::PERBYVOL] += volcell->at(fsgrids::volfields::PERBYVOL);
             sendBuffer[ii].sums[FieldsToCommunicate::PERBZVOL] += volcell->at(fsgrids::volfields::PERBZVOL);
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBXVOLdx] += volcell->at(fsgrids::volfields::dPERBXVOLdx) / technicalGrid.DX;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBXVOLdy] += volcell->at(fsgrids::volfields::dPERBXVOLdy) / technicalGrid.DY;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBXVOLdz] += volcell->at(fsgrids::volfields::dPERBXVOLdz) / technicalGrid.DZ;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBYVOLdx] += volcell->at(fsgrids::volfields::dPERBYVOLdx) / technicalGrid.DX;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBYVOLdy] += volcell->at(fsgrids::volfields::dPERBYVOLdy) / technicalGrid.DY;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBYVOLdz] += volcell->at(fsgrids::volfields::dPERBYVOLdz) / technicalGrid.DZ;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBZVOLdx] += volcell->at(fsgrids::volfields::dPERBZVOLdx) / technicalGrid.DX;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBZVOLdy] += volcell->at(fsgrids::volfields::dPERBZVOLdy) / technicalGrid.DY;
-            sendBuffer[ii].sums[FieldsToCommunicate::dPERBZVOLdz] += volcell->at(fsgrids::volfields::dPERBZVOLdz) / technicalGrid.DZ;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVxdx] += dMomentscell->at(fsgrids::dmoments::dVxdx) / technicalGrid.DX;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVxdy] += dMomentscell->at(fsgrids::dmoments::dVxdy) / technicalGrid.DY;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVxdz] += dMomentscell->at(fsgrids::dmoments::dVxdz) / technicalGrid.DZ;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVydx] += dMomentscell->at(fsgrids::dmoments::dVydx) / technicalGrid.DX;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVydy] += dMomentscell->at(fsgrids::dmoments::dVydy) / technicalGrid.DY;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVydz] += dMomentscell->at(fsgrids::dmoments::dVydz) / technicalGrid.DZ;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVzdx] += dMomentscell->at(fsgrids::dmoments::dVzdx) / technicalGrid.DX;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVzdy] += dMomentscell->at(fsgrids::dmoments::dVzdy) / technicalGrid.DY;
-            sendBuffer[ii].sums[FieldsToCommunicate::dVzdz] += dMomentscell->at(fsgrids::dmoments::dVzdz) / technicalGrid.DZ;
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBXVOLdx] += volcell->at(fsgrids::volfields::dPERBXVOLdx) / fsgrids.technicalGrid.DX;
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBXVOLdy] += volcell->at(fsgrids::volfields::dPERBXVOLdy) / fsgrids.technicalGrid.DY;
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBXVOLdz] += volcell->at(fsgrids::volfields::dPERBXVOLdz) / fsgrids.technicalGrid.DZ;
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBYVOLdx] += volcell->at(fsgrids::volfields::dPERBYVOLdx) / fsgrids.technicalGrid.DX;
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBYVOLdy] += volcell->at(fsgrids::volfields::dPERBYVOLdy) / fsgrids.technicalGrid.DY;
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBYVOLdz] += volcell->at(fsgrids::volfields::dPERBYVOLdz) / fsgrids.technicalGrid.DZ;
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBZVOLdx] += volcell->at(fsgrids::volfields::dPERBZVOLdx) / fsgrids.technicalGrid.DX;
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBZVOLdy] += volcell->at(fsgrids::volfields::dPERBZVOLdy) / fsgrids.technicalGrid.DY;
+            sendBuffer[ii].sums[FieldsToCommunicate::dPERBZVOLdz] += volcell->at(fsgrids::volfields::dPERBZVOLdz) / fsgrids.technicalGrid.DZ;
+            sendBuffer[ii].sums[FieldsToCommunicate::dVxdx] += dMomentscell->at(fsgrids::dmoments::dVxdx) / fsgrids.technicalGrid.DX;
+            sendBuffer[ii].sums[FieldsToCommunicate::dVxdy] += dMomentscell->at(fsgrids::dmoments::dVxdy) / fsgrids.technicalGrid.DY;
+            sendBuffer[ii].sums[FieldsToCommunicate::dVxdz] += dMomentscell->at(fsgrids::dmoments::dVxdz) / fsgrids.technicalGrid.DZ;
+            sendBuffer[ii].sums[FieldsToCommunicate::dVydx] += dMomentscell->at(fsgrids::dmoments::dVydx) / fsgrids.technicalGrid.DX;
+            sendBuffer[ii].sums[FieldsToCommunicate::dVydy] += dMomentscell->at(fsgrids::dmoments::dVydy) / fsgrids.technicalGrid.DY;
+            sendBuffer[ii].sums[FieldsToCommunicate::dVydz] += dMomentscell->at(fsgrids::dmoments::dVydz) / fsgrids.technicalGrid.DZ;
+            sendBuffer[ii].sums[FieldsToCommunicate::dVzdx] += dMomentscell->at(fsgrids::dmoments::dVzdx) / fsgrids.technicalGrid.DX;
+            sendBuffer[ii].sums[FieldsToCommunicate::dVzdy] += dMomentscell->at(fsgrids::dmoments::dVzdy) / fsgrids.technicalGrid.DY;
+            sendBuffer[ii].sums[FieldsToCommunicate::dVzdz] += dMomentscell->at(fsgrids::dmoments::dVzdz) / fsgrids.technicalGrid.DZ;
             sendBuffer[ii].sums[FieldsToCommunicate::BGBXVOL] += bgcell->at(fsgrids::bgbfield::BGBXVOL);
             sendBuffer[ii].sums[FieldsToCommunicate::BGBYVOL] += bgcell->at(fsgrids::bgbfield::BGBYVOL);
             sendBuffer[ii].sums[FieldsToCommunicate::BGBZVOL] += bgcell->at(fsgrids::bgbfield::BGBZVOL);

--- a/fieldsolver/gridGlue.hpp
+++ b/fieldsolver/gridGlue.hpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <map>
 #include <set>
+#include "../object_wrapper.h"
 
 // Datastructure for coupling
 extern std::map<int, std::set<CellID> > onDccrgMapRemoteProcessGlobal; 
@@ -62,8 +63,7 @@ std::vector<CellID> mapDccrgIdToFsGridGlobalID(dccrg::Dccrg<SpatialCell,dccrg::C
  */
 void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                            const std::vector<CellID>& cells,
-                           FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                           FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+                           FsGridWrapper& fsgrids,
                            bool dt2=false);
 
 /*! Copy field solver result (VOLB, VOLE, VOLPERB derivatives, gradpe) and store them back into DCCRG
@@ -74,11 +74,7 @@ void feedMomentsIntoFsGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
  * This function assumes that proper grid coupling has been set up.
  */
 void getFieldsFromFsGrid(
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volumeFieldsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    const std::vector<CellID>& cells
 );

--- a/fieldsolver/ldz_electric_field.cpp
+++ b/fieldsolver/ldz_electric_field.cpp
@@ -24,6 +24,7 @@
 
 #include "fs_common.h"
 #include "ldz_electric_field.hpp"
+#include "../object_wrapper.h"
 
 #ifndef NDEBUG
    #define DEBUG_FSOLVER
@@ -71,11 +72,7 @@ Real calculateCflSpeed(
  * 
  * If fields are not propagated, returns 0.0 as there is no information propagating.
  * 
- * \param perBGrid fsGrid holding the perturbed B quantities
- * \param momentsGrid fsGrid holding the moment quantities
- * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derviatives of moments
- * \param BgBGrid fsGrid holding the background B quantities
+ * \param fsgrids Field solver grid container
  * \param i,j,k fsGrid cell coordinates for the current cell
  * \param nbi,nbj,nbk fsGrid cell coordinates for the adjacent cell
  * \param By Current cell's By
@@ -93,11 +90,7 @@ Real calculateCflSpeed(
  * \param ret_vW Whistler speed returned
  */
 void calculateWaveSpeedYZ(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
+   FsGridWrapper& fsgrids,
    cint i,
    cint j,
    cint k,
@@ -118,14 +111,14 @@ void calculateWaveSpeedYZ(
    Real& ret_vS,
    Real& ret_vW
 ) {
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb = perBGrid.get(i,j,k);
-   std::array<Real, fsgrids::bfield::N_BFIELD> * nbr_perb = perBGrid.get(nbi,nbj,nbk);
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments = momentsGrid.get(i,j,k);
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments = dMomentsGrid.get(i,j,k);
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb = dPerBGrid.get(i,j,k);
-   std::array<Real, fsgrids::dperb::N_DPERB> * nbr_dperb = dPerBGrid.get(nbi,nbj,nbk);
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb = BgBGrid.get(i,j,k);
-   std::array<Real, fsgrids::bgbfield::N_BGB> *  nbr_bgb = BgBGrid.get(nbi,nbj,nbk);
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb = fsgrids.perBGrid.get(i,j,k);
+   std::array<Real, fsgrids::bfield::N_BFIELD> * nbr_perb = fsgrids.perBGrid.get(nbi,nbj,nbk);
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments = fsgrids.momentsGrid.get(i,j,k);
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments = fsgrids.dMomentsGrid.get(i,j,k);
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb = fsgrids.dPerBGrid.get(i,j,k);
+   std::array<Real, fsgrids::dperb::N_DPERB> * nbr_dperb = fsgrids.dPerBGrid.get(nbi,nbj,nbk);
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb = fsgrids.BgBGrid.get(i,j,k);
+   std::array<Real, fsgrids::bgbfield::N_BGB> *  nbr_bgb = fsgrids.BgBGrid.get(nbi,nbj,nbk);
    
    Real A_0, A_X, rhom, p11, p22, p33;
    A_0  = HALF*(nbr_perb->at(fsgrids::bfield::PERBX) + nbr_bgb->at(fsgrids::bgbfield::BGBX) + perb->at(fsgrids::bfield::PERBX) + bgb->at(fsgrids::bgbfield::BGBX));
@@ -176,8 +169,8 @@ void calculateWaveSpeedYZ(
    const Real vS2 = divideIfNonZero(p11+p22+p33, 2.0*rhom); // sound speed, adiabatic coefficient 3/2, P=1/3*trace in sound speed
 //   const Real vW = Parameters::ohmHallTerm > 0 ? divideIfNonZero(2.0*M_PI*vA2*pc::MASS_PROTON, perBGrid.DX*pc::CHARGE*sqrt(Bmag2)) : 0.0; // whistler speed
    const Real vW = Parameters::ohmHallTerm > 0 ?
-      sqrt(vA2) * (1 + divideIfNonZero(2*M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, perBGrid.DX*perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)
-            / sqrt(1 + divideIfNonZero(  M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, perBGrid.DX*perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)))
+      sqrt(vA2) * (1 + divideIfNonZero(2*M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, fsgrids.perBGrid.DX*fsgrids.perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)
+            / sqrt(1 + divideIfNonZero(  M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, fsgrids.perBGrid.DX*fsgrids.perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)))
       : 0.0; // whistler speed
    
    ret_vA = sqrt(vA2);
@@ -194,11 +187,7 @@ void calculateWaveSpeedYZ(
  * 
  * If fields are not propagated, returns 0.0 as there is no information propagating.
  * 
- * \param perBGrid fsGrid holding the perturbed B quantities
- * \param momentsGrid fsGrid holding the moment quantities
- * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derviatives of moments
- * \param BgBGrid fsGrid holding the background B quantities
+ * \param fsgrids Field solver grid container
  * \param i,j,k fsGrid cell coordinates for the current cell
  * \param nbi,nbj,nbk fsGrid cell coordinates for the adjacent cell
  * \param Bx Current cell's Bx
@@ -216,11 +205,7 @@ void calculateWaveSpeedYZ(
  * \param ret_vW Whistler speed returned
  */
 void calculateWaveSpeedXZ(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
+   FsGridWrapper& fsgrids,
    cint i,
    cint j,
    cint k,
@@ -241,14 +226,14 @@ void calculateWaveSpeedXZ(
    Real& ret_vS,
    Real& ret_vW
 ) {
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb = perBGrid.get(i,j,k);
-   std::array<Real, fsgrids::bfield::N_BFIELD> * nbr_perb = perBGrid.get(nbi,nbj,nbk);
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments = momentsGrid.get(i,j,k);
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments = dMomentsGrid.get(i,j,k);
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb = dPerBGrid.get(i,j,k);
-   std::array<Real, fsgrids::dperb::N_DPERB> * nbr_dperb = dPerBGrid.get(nbi,nbj,nbk);
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb = BgBGrid.get(i,j,k);
-   std::array<Real, fsgrids::bgbfield::N_BGB> *  nbr_bgb = BgBGrid.get(nbi,nbj,nbk);
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb = fsgrids.perBGrid.get(i,j,k);
+   std::array<Real, fsgrids::bfield::N_BFIELD> * nbr_perb = fsgrids.perBGrid.get(nbi,nbj,nbk);
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments = fsgrids.momentsGrid.get(i,j,k);
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments = fsgrids.dMomentsGrid.get(i,j,k);
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb = fsgrids.dPerBGrid.get(i,j,k);
+   std::array<Real, fsgrids::dperb::N_DPERB> * nbr_dperb = fsgrids.dPerBGrid.get(nbi,nbj,nbk);
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb = fsgrids.BgBGrid.get(i,j,k);
+   std::array<Real, fsgrids::bgbfield::N_BGB> *  nbr_bgb = fsgrids.BgBGrid.get(nbi,nbj,nbk);
    
    Real B_0, B_Y, rhom, p11, p22, p33;
    B_0  = HALF*(nbr_perb->at(fsgrids::bfield::PERBY) + nbr_bgb->at(fsgrids::bgbfield::BGBY) + perb->at(fsgrids::bfield::PERBY) + bgb->at(fsgrids::bgbfield::BGBY));
@@ -299,8 +284,8 @@ void calculateWaveSpeedXZ(
    const Real vS2 = divideIfNonZero(p11+p22+p33, 2.0*rhom); // sound speed, adiabatic coefficient 3/2, P=1/3*trace in sound speed
 //   const Real vW = Parameters::ohmHallTerm > 0 ? divideIfNonZero(2.0*M_PI*vA2*pc::MASS_PROTON, perBGrid.DX*pc::CHARGE*sqrt(Bmag2)) : 0.0; // whistler speed
    const Real vW = Parameters::ohmHallTerm > 0 ?
-      sqrt(vA2) * (1 + divideIfNonZero(2*M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, perBGrid.DX*perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)
-            / sqrt(1 + divideIfNonZero(  M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, perBGrid.DX*perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)))
+      sqrt(vA2) * (1 + divideIfNonZero(2*M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, fsgrids.perBGrid.DX*fsgrids.perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)
+            / sqrt(1 + divideIfNonZero(  M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, fsgrids.perBGrid.DX*fsgrids.perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)))
       : 0.0; // whistler speed
    
    ret_vA = sqrt(vA2);
@@ -317,11 +302,7 @@ void calculateWaveSpeedXZ(
  * 
  * If fields are not propagated, returns 0.0 as there is no information propagating.
  * 
- * \param perBGrid fsGrid holding the perturbed B quantities
- * \param momentsGrid fsGrid holding the moment quantities
- * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derviatives of moments
- * \param BgBGrid fsGrid holding the background B quantities
+ * \param fsgrids Field solver grid container
  * \param i,j,k fsGrid cell coordinates for the current cell
  * \param nbi,nbj,nbk fsGrid cell coordinates for the adjacent cell
  * \param Bx Current cell's Bx
@@ -339,11 +320,7 @@ void calculateWaveSpeedXZ(
  * \param ret_vW Whistler speed returned
  */
 void calculateWaveSpeedXY(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
+   FsGridWrapper& fsgrids,
    cint i,
    cint j,
    cint k,
@@ -364,14 +341,14 @@ void calculateWaveSpeedXY(
    Real& ret_vS,
    Real& ret_vW
 ) {
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb = perBGrid.get(i,j,k);
-   std::array<Real, fsgrids::bfield::N_BFIELD> * nbr_perb = perBGrid.get(nbi,nbj,nbk);
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments = momentsGrid.get(i,j,k);
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments = dMomentsGrid.get(i,j,k);
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb = dPerBGrid.get(i,j,k);
-   std::array<Real, fsgrids::dperb::N_DPERB> * nbr_dperb = dPerBGrid.get(nbi,nbj,nbk);
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb = BgBGrid.get(i,j,k);
-   std::array<Real, fsgrids::bgbfield::N_BGB> *  nbr_bgb = BgBGrid.get(nbi,nbj,nbk);
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb = fsgrids.perBGrid.get(i,j,k);
+   std::array<Real, fsgrids::bfield::N_BFIELD> * nbr_perb = fsgrids.perBGrid.get(nbi,nbj,nbk);
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments = fsgrids.momentsGrid.get(i,j,k);
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments = fsgrids.dMomentsGrid.get(i,j,k);
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb = fsgrids.dPerBGrid.get(i,j,k);
+   std::array<Real, fsgrids::dperb::N_DPERB> * nbr_dperb = fsgrids.dPerBGrid.get(nbi,nbj,nbk);
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb = fsgrids.BgBGrid.get(i,j,k);
+   std::array<Real, fsgrids::bgbfield::N_BGB> *  nbr_bgb = fsgrids.BgBGrid.get(nbi,nbj,nbk);
    
    Real C_0, C_Z, rhom, p11, p22, p33;
    C_0  = HALF*(nbr_perb->at(fsgrids::bfield::PERBZ) + nbr_bgb->at(fsgrids::bgbfield::BGBZ) + perb->at(fsgrids::bfield::PERBZ) + bgb->at(fsgrids::bgbfield::BGBZ));
@@ -422,8 +399,8 @@ void calculateWaveSpeedXY(
    const Real vS2 = divideIfNonZero(p11+p22+p33, 2.0*rhom); // sound speed, adiabatic coefficient 3/2, P=1/3*trace in sound speed
 //   const Real vW = Parameters::ohmHallTerm > 0 ? divideIfNonZero(2.0*M_PI*vA2*pc::MASS_PROTON, perBGrid.DX*pc::CHARGE*sqrt(Bmag2)) : 0.0; // whistler speed
    const Real vW = Parameters::ohmHallTerm > 0 ?
-      sqrt(vA2) * (1 + divideIfNonZero(2*M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, perBGrid.DX*perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)
-            / sqrt(1 + divideIfNonZero(  M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, perBGrid.DX*perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)))
+      sqrt(vA2) * (1 + divideIfNonZero(2*M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, fsgrids.perBGrid.DX*fsgrids.perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)
+            / sqrt(1 + divideIfNonZero(  M_PI*M_PI*pc::MASS_PROTON*pc::MASS_PROTON, fsgrids.perBGrid.DX*fsgrids.perBGrid.DX*rhom*pc::CHARGE*pc::CHARGE*pc::MU_0)))
       : 0.0; // whistler speed
    
    ret_vA = sqrt(vA2);
@@ -439,28 +416,12 @@ void calculateWaveSpeedXY(
  * 
  * Note that the background B field is excluded from the diffusive term calculations because they are equivalent to a current term and the background field is curl-free.
  * 
- * \param perBGrid fsGrid holding the perturbed B quantities
- * \param EGrid fsGrid holding the electric field
- * \param EHallGrid fsGrid holding the Hall contributions to the electric field
- * \param EGradPeGrid fsGrid holding the electron pressure gradient E field
- * \param momentsGrid fsGrid holding the moment quantities
- * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derviatives of moments
- * \param BgBGrid fsGrid holding the background B quantities
- * \param technicalGrid fsGrid holding technical information (such as boundary types)
+ * \param fsgrids Field solver grid container
  * \param i,j,k fsGrid cell coordinates for the current cell
  * \param RKCase Element in the enum defining the Runge-Kutta method steps
  */
 void calculateEdgeElectricFieldX(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    cint i,
    cint j,
    cint k,
@@ -488,28 +449,57 @@ void calculateEdgeElectricFieldX(
    Real c_y, c_z;                   // Wave speeds to yz-directions
 
    // Get values at all four neighbours, result is written to SW.
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_SW = perBGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_SE = perBGrid.get(i  ,j-1,k  );
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_NE = perBGrid.get(i  ,j-1,k-1);
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_NW = perBGrid.get(i  ,j  ,k-1);
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_SW = BgBGrid.get(i,j  ,k  );
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_SE = BgBGrid.get(i,j-1,k  );
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_NE = BgBGrid.get(i,j-1,k-1);
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_NW = BgBGrid.get(i,j  ,k-1);
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_SW = momentsGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_SE = momentsGrid.get(i  ,j-1,k  );
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_NE = momentsGrid.get(i  ,j-1,k-1);
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_NW = momentsGrid.get(i  ,j  ,k-1);
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_SW = dMomentsGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_SE = dMomentsGrid.get(i  ,j-1,k  );
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_NE = dMomentsGrid.get(i  ,j-1,k-1);
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_NW = dMomentsGrid.get(i  ,j  ,k-1);
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_SW = dPerBGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_SE = dPerBGrid.get(i  ,j-1,k  );
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_NE = dPerBGrid.get(i  ,j-1,k-1);
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_NW = dPerBGrid.get(i  ,j  ,k-1);
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_SW;
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_SE;
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_NE;
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_NW;
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_SW;
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_SE;
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_NE;
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_NW;
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_SW;
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_SE;
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_NE;
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_NW;
+   std::array<Real, fsgrids::efield::N_EFIELD> * efield_SW;
+   if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+      perb_SW = fsgrids.perBGrid.get(i  ,j  ,k  );
+      perb_SE = fsgrids.perBGrid.get(i  ,j-1,k  );
+      perb_NE = fsgrids.perBGrid.get(i  ,j-1,k-1);
+      perb_NW = fsgrids.perBGrid.get(i  ,j  ,k-1);
+      moments_SW = fsgrids.momentsGrid.get(i  ,j  ,k  );
+      moments_SE = fsgrids.momentsGrid.get(i  ,j-1,k  );
+      moments_NE = fsgrids.momentsGrid.get(i  ,j-1,k-1);
+      moments_NW = fsgrids.momentsGrid.get(i  ,j  ,k-1);
+      dmoments_SW = fsgrids.dMomentsGrid.get(i  ,j  ,k  );
+      dmoments_SE = fsgrids.dMomentsGrid.get(i  ,j-1,k  );
+      dmoments_NE = fsgrids.dMomentsGrid.get(i  ,j-1,k-1);
+      dmoments_NW = fsgrids.dMomentsGrid.get(i  ,j  ,k-1);
+      efield_SW = fsgrids.EGrid.get(i,j,k);
+   } else { // RKCase == RK_ORDER2_STEP1
+      perb_SW = fsgrids.perBDt2Grid.get(i  ,j  ,k  );
+      perb_SE = fsgrids.perBDt2Grid.get(i  ,j-1,k  );
+      perb_NE = fsgrids.perBDt2Grid.get(i  ,j-1,k-1);
+      perb_NW = fsgrids.perBDt2Grid.get(i  ,j  ,k-1);
+      moments_SW = fsgrids.momentsDt2Grid.get(i  ,j  ,k  );
+      moments_SE = fsgrids.momentsDt2Grid.get(i  ,j-1,k  );
+      moments_NE = fsgrids.momentsDt2Grid.get(i  ,j-1,k-1);
+      moments_NW = fsgrids.momentsDt2Grid.get(i  ,j  ,k-1);
+      dmoments_SW = fsgrids.dMomentsDt2Grid.get(i  ,j  ,k  );
+      dmoments_SE = fsgrids.dMomentsDt2Grid.get(i  ,j-1,k  );
+      dmoments_NE = fsgrids.dMomentsDt2Grid.get(i  ,j-1,k-1);
+      dmoments_NW = fsgrids.dMomentsDt2Grid.get(i  ,j  ,k-1);
+      efield_SW = fsgrids.EDt2Grid.get(i,j,k);
+   }
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_SW = fsgrids.BgBGrid.get(i,j  ,k  );
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_SE = fsgrids.BgBGrid.get(i,j-1,k  );
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_NE = fsgrids.BgBGrid.get(i,j-1,k-1);
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_NW = fsgrids.BgBGrid.get(i,j  ,k-1);
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_SW = fsgrids.dPerBGrid.get(i  ,j  ,k  );
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_SE = fsgrids.dPerBGrid.get(i  ,j-1,k  );
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_NE = fsgrids.dPerBGrid.get(i  ,j-1,k-1);
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_NW = fsgrids.dPerBGrid.get(i  ,j  ,k-1);
    
-   std::array<Real, fsgrids::efield::N_EFIELD> * efield_SW = EGrid.get(i,j,k);
    
    Real By_S, Bz_W, Bz_E, By_N, perBy_S, perBz_W, perBz_E, perBy_N;
    Real minRhom = std::numeric_limits<Real>::max();
@@ -571,17 +561,21 @@ void calculateEdgeElectricFieldX(
            ) /
        moments_SW->at(fsgrids::moments::RHOQ) /
        physicalconstants::MU_0 *
-       (dperb_SW->at(fsgrids::dperb::dPERBzdy)/technicalGrid.DY - dperb_SW->at(fsgrids::dperb::dPERBydz)/technicalGrid.DZ);
+       (dperb_SW->at(fsgrids::dperb::dPERBzdy)/fsgrids.technicalGrid.DY - dperb_SW->at(fsgrids::dperb::dPERBydz)/fsgrids.technicalGrid.DZ);
    }
    
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ex_SW += EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_000_100);
+      Ex_SW += fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_000_100);
    }
    
    // Electron pressure gradient term
    if(Parameters::ohmGradPeTerm > 0) {
-      Ex_SW += EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EXGRADPE);
+      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         Ex_SW += fsgrids.EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EXGRADPE);
+      } else {
+         Ex_SW += fsgrids.EGradPeDt2Grid.get(i,j,k)->at(fsgrids::egradpe::EXGRADPE);
+      }
    }
 
    #ifndef FS_1ST_ORDER_SPACE
@@ -590,11 +584,7 @@ void calculateEdgeElectricFieldX(
       Ex_SW += -HALF*((Bz_W - HALF*dBzdy_W)*(-dmoments_SW->at(fsgrids::dmoments::dVydy) - dmoments_SW->at(fsgrids::dmoments::dVydz)) - dBzdy_W*Vy0 + SIXTH*dBzdx_W*dmoments_SW->at(fsgrids::dmoments::dVydx));
    #endif
    calculateWaveSpeedYZ(
-      perBGrid,
-      momentsGrid,
-      dPerBGrid,
-      dMomentsGrid,
-      BgBGrid,
+      fsgrids,
       i  , j, k,
       i+1, j, k,
       By_S, Bz_W, dBydx_S, dBydz_S, dBzdx_W, dBzdy_W, MINUS, MINUS, minRhom, maxRhom, vA, vS, vW
@@ -626,17 +616,21 @@ void calculateEdgeElectricFieldX(
            ) /
        moments_SE->at(fsgrids::moments::RHOQ) /
        physicalconstants::MU_0 *
-       (dperb_SE->at(fsgrids::dperb::dPERBzdy)/technicalGrid.DY - dperb_SE->at(fsgrids::dperb::dPERBydz)/technicalGrid.DZ);
+       (dperb_SE->at(fsgrids::dperb::dPERBzdy)/fsgrids.technicalGrid.DY - dperb_SE->at(fsgrids::dperb::dPERBydz)/fsgrids.technicalGrid.DZ);
    }
 
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ex_SE += EHallGrid.get(i,j-1,k)->at(fsgrids::ehall::EXHALL_010_110);
+      Ex_SE += fsgrids.EHallGrid.get(i,j-1,k)->at(fsgrids::ehall::EXHALL_010_110);
    }
    
    // Electron pressure gradient term
    if(Parameters::ohmGradPeTerm > 0) {
-      Ex_SE += EGradPeGrid.get(i,j-1,k)->at(fsgrids::egradpe::EXGRADPE);
+      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         Ex_SE += fsgrids.EGradPeGrid.get(i,j-1,k)->at(fsgrids::egradpe::EXGRADPE);
+      } else {
+         Ex_SE += fsgrids.EGradPeDt2Grid.get(i,j-1,k)->at(fsgrids::egradpe::EXGRADPE);
+      }
    }
    
    #ifndef FS_1ST_ORDER_SPACE
@@ -646,11 +640,7 @@ void calculateEdgeElectricFieldX(
    #endif
    
    calculateWaveSpeedYZ(
-      perBGrid,
-      momentsGrid,
-      dPerBGrid,
-      dMomentsGrid,
-      BgBGrid,
+      fsgrids,
       i  , j-1, k,
       i+1, j-1, k,
       By_S, Bz_E, dBydx_S, dBydz_S, dBzdx_E, dBzdy_E, PLUS, MINUS, minRhom, maxRhom, vA, vS, vW
@@ -682,17 +672,21 @@ void calculateEdgeElectricFieldX(
            ) /
        moments_NW->at(fsgrids::moments::RHOQ) /
        physicalconstants::MU_0 *
-       (dperb_NW->at(fsgrids::dperb::dPERBzdy)/technicalGrid.DY - dperb_NW->at(fsgrids::dperb::dPERBydz)/technicalGrid.DZ);
+       (dperb_NW->at(fsgrids::dperb::dPERBzdy)/fsgrids.technicalGrid.DY - dperb_NW->at(fsgrids::dperb::dPERBydz)/fsgrids.technicalGrid.DZ);
    }
    
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ex_NW += EHallGrid.get(i,j,k-1)->at(fsgrids::ehall::EXHALL_001_101);
+      Ex_NW += fsgrids.EHallGrid.get(i,j,k-1)->at(fsgrids::ehall::EXHALL_001_101);
    }
    
    // Electron pressure gradient term
    if(Parameters::ohmGradPeTerm > 0) {
-      Ex_NW += EGradPeGrid.get(i,j,k-1)->at(fsgrids::egradpe::EXGRADPE);
+      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         Ex_NW += fsgrids.EGradPeGrid.get(i,j,k-1)->at(fsgrids::egradpe::EXGRADPE);
+      } else {
+         Ex_NW += fsgrids.EGradPeDt2Grid.get(i,j,k-1)->at(fsgrids::egradpe::EXGRADPE);
+      }
    }
    
    #ifndef FS_1ST_ORDER_SPACE
@@ -702,11 +696,7 @@ void calculateEdgeElectricFieldX(
    #endif
    
    calculateWaveSpeedYZ(
-      perBGrid,
-      momentsGrid,
-      dPerBGrid,
-      dMomentsGrid,
-      BgBGrid,
+      fsgrids,
       i  , j, k-1,
       i+1, j, k-1,
       By_N, Bz_W, dBydx_N, dBydz_N, dBzdx_W, dBzdy_W, MINUS, PLUS, minRhom, maxRhom, vA, vS, vW
@@ -738,17 +728,21 @@ void calculateEdgeElectricFieldX(
                    ) /
                moments_NE->at(fsgrids::moments::RHOQ) /
                physicalconstants::MU_0 *
-               (dperb_NE->at(fsgrids::dperb::dPERBzdy)/technicalGrid.DY - dperb_NE->at(fsgrids::dperb::dPERBydz)/technicalGrid.DZ);
+               (dperb_NE->at(fsgrids::dperb::dPERBzdy)/fsgrids.technicalGrid.DY - dperb_NE->at(fsgrids::dperb::dPERBydz)/fsgrids.technicalGrid.DZ);
    }
 
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ex_NE += EHallGrid.get(i,j-1,k-1)->at(fsgrids::ehall::EXHALL_011_111);
+      Ex_NE += fsgrids.EHallGrid.get(i,j-1,k-1)->at(fsgrids::ehall::EXHALL_011_111);
    }
    
    // Electron pressure gradient term
    if(Parameters::ohmGradPeTerm > 0) {
-      Ex_NE += EGradPeGrid.get(i,j-1,k-1)->at(fsgrids::egradpe::EXGRADPE);
+      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         Ex_NE += fsgrids.EGradPeGrid.get(i,j-1,k-1)->at(fsgrids::egradpe::EXGRADPE);
+      } else {
+         Ex_NE += fsgrids.EGradPeDt2Grid.get(i,j-1,k-1)->at(fsgrids::egradpe::EXGRADPE);
+      }
    }
    
    #ifndef FS_1ST_ORDER_SPACE
@@ -758,11 +752,7 @@ void calculateEdgeElectricFieldX(
    #endif
    
    calculateWaveSpeedYZ(
-      perBGrid,
-      momentsGrid,
-      dPerBGrid,
-      dMomentsGrid,
-      BgBGrid,
+      fsgrids,
       i  ,j-1,k-1,
       i+1,j-1,k-1,
       By_N, Bz_E, dBydx_N, dBydz_N, dBzdx_E, dBzdy_E, PLUS, PLUS, minRhom, maxRhom, vA, vS, vW
@@ -792,10 +782,10 @@ void calculateEdgeElectricFieldX(
    if ((RKCase == RK_ORDER1) || (RKCase == RK_ORDER2_STEP2)) {
       //compute maximum timestep for fieldsolver in this cell (CFL=1)
       Real min_dx=std::numeric_limits<Real>::max();
-      min_dx=min(min_dx,technicalGrid.DY);
-      min_dx=min(min_dx,technicalGrid.DZ);
+      min_dx=min(min_dx,fsgrids.technicalGrid.DY);
+      min_dx=min(min_dx,fsgrids.technicalGrid.DZ);
       //update max allowed timestep for field propagation in this cell, which is the minimum of CFL=1 timesteps
-      if (maxV != ZERO) technicalGrid.get(i,j,k)->maxFsDt = min(technicalGrid.get(i,j,k)->maxFsDt,min_dx/maxV);
+      if (maxV != ZERO) fsgrids.technicalGrid.get(i,j,k)->maxFsDt = min(fsgrids.technicalGrid.get(i,j,k)->maxFsDt,min_dx/maxV);
    }
 }
 
@@ -810,15 +800,7 @@ void calculateEdgeElectricFieldX(
  * \param RKCase Element in the enum defining the Runge-Kutta method steps
  */
 void calculateEdgeElectricFieldY(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    cint i,
    cint j,
    cint k,
@@ -826,10 +808,10 @@ void calculateEdgeElectricFieldY(
 ) {
    #ifdef DEBUG_FSOLVER
    bool ok = true;
-   if (technicalGrid.get(i,j,k) == NULL) ok = false;
-   if (technicalGrid.get(i,j,k-1) == NULL) ok = false;
-   if (technicalGrid.get(i-1,j,k) == NULL) ok = false;
-   if (technicalGrid.get(i-1,j,k-1) == NULL) ok = false;
+   if (fsgrids.technicalGrid.get(i,j,k) == NULL) ok = false;
+   if (fsgrids.technicalGrid.get(i,j,k-1) == NULL) ok = false;
+   if (fsgrids.technicalGrid.get(i-1,j,k) == NULL) ok = false;
+   if (fsgrids.technicalGrid.get(i-1,j,k-1) == NULL) ok = false;
    if (ok == false) {
       cerr << "NULL pointer in " << __FILE__ << ":" << __LINE__ << std::endl;
       exit(1);
@@ -844,29 +826,58 @@ void calculateEdgeElectricFieldY(
    Real vA, vS, vW;                 // Alfven, sound, whistler speed
    Real maxV = 0.0;                 // Max velocity for CFL purposes
    Real c_x,c_z;                    // Wave speeds to xz-directions
+
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_SW;
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_SE;
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_NE;
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_NW;
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_SW;
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_SE;
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_NE;
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_NW;
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_SW;
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_SE;
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_NE;
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_NW;
+   std::array<Real, fsgrids::efield::N_EFIELD> * efield_SW;
+   if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+      perb_SW = fsgrids.perBGrid.get(i  ,j  ,k  );
+      perb_SE = fsgrids.perBGrid.get(i  ,j  ,k-1);
+      perb_NW = fsgrids.perBGrid.get(i-1,j  ,k  );
+      perb_NE = fsgrids.perBGrid.get(i-1,j  ,k-1);
+      moments_SW = fsgrids.momentsGrid.get(i  ,j  ,k  );
+      moments_SE = fsgrids.momentsGrid.get(i  ,j  ,k-1);
+      moments_NW = fsgrids.momentsGrid.get(i-1,j  ,k  );
+      moments_NE = fsgrids.momentsGrid.get(i-1,j  ,k-1);
+      dmoments_SW = fsgrids.dMomentsGrid.get(i  ,j  ,k  );
+      dmoments_SE = fsgrids.dMomentsGrid.get(i  ,j  ,k-1);
+      dmoments_NW = fsgrids.dMomentsGrid.get(i-1,j  ,k  );
+      dmoments_NE = fsgrids.dMomentsGrid.get(i-1,j  ,k-1);
+      efield_SW = fsgrids.EGrid.get(i,j,k);
+   } else {
+      perb_SW = fsgrids.perBDt2Grid.get(i  ,j  ,k  );
+      perb_SE = fsgrids.perBDt2Grid.get(i  ,j  ,k-1);
+      perb_NW = fsgrids.perBDt2Grid.get(i-1,j  ,k  );
+      perb_NE = fsgrids.perBDt2Grid.get(i-1,j  ,k-1);
+      moments_SW = fsgrids.momentsDt2Grid.get(i  ,j  ,k  );
+      moments_SE = fsgrids.momentsDt2Grid.get(i  ,j  ,k-1);
+      moments_NW = fsgrids.momentsDt2Grid.get(i-1,j  ,k  );
+      moments_NE = fsgrids.momentsDt2Grid.get(i-1,j  ,k-1);
+      dmoments_SW = fsgrids.dMomentsDt2Grid.get(i  ,j  ,k  );
+      dmoments_SE = fsgrids.dMomentsDt2Grid.get(i  ,j  ,k-1);
+      dmoments_NW = fsgrids.dMomentsDt2Grid.get(i-1,j  ,k  );
+      dmoments_NE = fsgrids.dMomentsDt2Grid.get(i-1,j  ,k-1);
+      efield_SW = fsgrids.EDt2Grid.get(i,j,k);
+   }
    
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_SW = perBGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_SE = perBGrid.get(i  ,j  ,k-1);
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_NW = perBGrid.get(i-1,j  ,k  );
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_NE = perBGrid.get(i-1,j  ,k-1);
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_SW = BgBGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_SE = BgBGrid.get(i  ,j  ,k-1);
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_NW = BgBGrid.get(i-1,j  ,k  );
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_NE = BgBGrid.get(i-1,j  ,k-1);
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_SW = momentsGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_SE = momentsGrid.get(i  ,j  ,k-1);
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_NW = momentsGrid.get(i-1,j  ,k  );
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_NE = momentsGrid.get(i-1,j  ,k-1);
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_SW = dMomentsGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_SE = dMomentsGrid.get(i  ,j  ,k-1);
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_NW = dMomentsGrid.get(i-1,j  ,k  );
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_NE = dMomentsGrid.get(i-1,j  ,k-1);
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_SW = dPerBGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_SE = dPerBGrid.get(i  ,j  ,k-1);
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_NW = dPerBGrid.get(i-1,j  ,k  );
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_NE = dPerBGrid.get(i-1,j  ,k-1);
-   
-   std::array<Real, fsgrids::efield::N_EFIELD> * efield_SW = EGrid.get(i,j,k);
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_SW = fsgrids.BgBGrid.get(i  ,j  ,k  );
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_SE = fsgrids.BgBGrid.get(i  ,j  ,k-1);
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_NW = fsgrids.BgBGrid.get(i-1,j  ,k  );
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_NE = fsgrids.BgBGrid.get(i-1,j  ,k-1);
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_SW = fsgrids.dPerBGrid.get(i  ,j  ,k  );
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_SE = fsgrids.dPerBGrid.get(i  ,j  ,k-1);
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_NW = fsgrids.dPerBGrid.get(i-1,j  ,k  );
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_NE = fsgrids.dPerBGrid.get(i-1,j  ,k-1);
    
    // Fetch required plasma parameters:
    Real Bz_S, Bx_W, Bx_E, Bz_N, perBz_S, perBx_W, perBx_E, perBz_N;
@@ -928,17 +939,21 @@ void calculateEdgeElectricFieldY(
             ) /
         moments_SW->at(fsgrids::moments::RHOQ) /
         physicalconstants::MU_0 *
-        (dperb_SW->at(fsgrids::dperb::dPERBxdz)/technicalGrid.DZ - dperb_SW->at(fsgrids::dperb::dPERBzdx)/technicalGrid.DX);
+        (dperb_SW->at(fsgrids::dperb::dPERBxdz)/fsgrids.technicalGrid.DZ - dperb_SW->at(fsgrids::dperb::dPERBzdx)/fsgrids.technicalGrid.DX);
    }
 
    // Hall term
    if (Parameters::ohmHallTerm > 0) {
-      Ey_SW += EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_000_010);
+      Ey_SW += fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_000_010);
    }
    
    // Electron pressure gradient term
    if(Parameters::ohmGradPeTerm > 0) {
-      Ey_SW += EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EYGRADPE);
+      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         Ey_SW += fsgrids.EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EYGRADPE);
+      } else {
+         Ey_SW += fsgrids.EGradPeDt2Grid.get(i,j,k)->at(fsgrids::egradpe::EYGRADPE);
+      }
    }
    
    #ifndef FS_1ST_ORDER_SPACE
@@ -948,11 +963,7 @@ void calculateEdgeElectricFieldY(
    #endif
    
    calculateWaveSpeedXZ(
-      perBGrid,
-      momentsGrid,
-      dPerBGrid,
-      dMomentsGrid,
-      BgBGrid,
+      fsgrids,
       i, j, k,
       i, j+1, k,
       Bx_W, Bz_S, dBxdy_W, dBxdz_W, dBzdx_S, dBzdy_S, MINUS, MINUS, minRhom, maxRhom, vA, vS, vW
@@ -984,17 +995,21 @@ void calculateEdgeElectricFieldY(
             ) /
         moments_SE->at(fsgrids::moments::RHOQ) /
         physicalconstants::MU_0 *
-        (dperb_SE->at(fsgrids::dperb::dPERBxdz)/technicalGrid.DZ - dperb_SE->at(fsgrids::dperb::dPERBzdx)/technicalGrid.DX);
+        (dperb_SE->at(fsgrids::dperb::dPERBxdz)/fsgrids.technicalGrid.DZ - dperb_SE->at(fsgrids::dperb::dPERBzdx)/fsgrids.technicalGrid.DX);
    }
 
    // Hall term
    if (Parameters::ohmHallTerm > 0) {
-      Ey_SE += EHallGrid.get(i,j,k-1)->at(fsgrids::ehall::EYHALL_001_011);
+      Ey_SE += fsgrids.EHallGrid.get(i,j,k-1)->at(fsgrids::ehall::EYHALL_001_011);
    }
    
    // Electron pressure gradient term
    if(Parameters::ohmGradPeTerm > 0) {
-      Ey_SE += EGradPeGrid.get(i,j,k-1)->at(fsgrids::egradpe::EYGRADPE);
+      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         Ey_SE += fsgrids.EGradPeGrid.get(i,j,k-1)->at(fsgrids::egradpe::EYGRADPE);
+      } else {
+         Ey_SE += fsgrids.EGradPeDt2Grid.get(i,j,k-1)->at(fsgrids::egradpe::EYGRADPE);
+      }
    }
    
    #ifndef FS_1ST_ORDER_SPACE
@@ -1004,11 +1019,7 @@ void calculateEdgeElectricFieldY(
    #endif
    
    calculateWaveSpeedXZ(
-      perBGrid,
-      momentsGrid,
-      dPerBGrid,
-      dMomentsGrid,
-      BgBGrid,
+      fsgrids,
       i, j  , k-1,
       i, j+1, k-1,
       Bx_E, Bz_S, dBxdy_E, dBxdz_E, dBzdx_S, dBzdy_S, MINUS, PLUS, minRhom, maxRhom, vA, vS, vW
@@ -1040,17 +1051,21 @@ void calculateEdgeElectricFieldY(
             ) /
         moments_NW->at(fsgrids::moments::RHOQ) /
         physicalconstants::MU_0 *
-        (dperb_NW->at(fsgrids::dperb::dPERBxdz)/technicalGrid.DZ - dperb_NW->at(fsgrids::dperb::dPERBzdx)/technicalGrid.DX);
+        (dperb_NW->at(fsgrids::dperb::dPERBxdz)/fsgrids.technicalGrid.DZ - dperb_NW->at(fsgrids::dperb::dPERBzdx)/fsgrids.technicalGrid.DX);
    }
 
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ey_NW += EHallGrid.get(i-1,j,k)->at(fsgrids::ehall::EYHALL_100_110);
+      Ey_NW += fsgrids.EHallGrid.get(i-1,j,k)->at(fsgrids::ehall::EYHALL_100_110);
    }
    
    // Electron pressure gradient term
    if(Parameters::ohmGradPeTerm > 0) {
-      Ey_NW += EGradPeGrid.get(i-1,j,k)->at(fsgrids::egradpe::EYGRADPE);
+      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         Ey_NW += fsgrids.EGradPeGrid.get(i-1,j,k)->at(fsgrids::egradpe::EYGRADPE);
+      } else {
+         Ey_NW += fsgrids.EGradPeDt2Grid.get(i-1,j,k)->at(fsgrids::egradpe::EYGRADPE);
+      }
    }
    
    #ifndef FS_1ST_ORDER_SPACE
@@ -1060,11 +1075,7 @@ void calculateEdgeElectricFieldY(
    #endif
    
    calculateWaveSpeedXZ(
-      perBGrid,
-      momentsGrid,
-      dPerBGrid,
-      dMomentsGrid,
-      BgBGrid,
+      fsgrids,
       i-1,j  ,k,
       i-1,j+1,k,
       Bx_W, Bz_N, dBxdy_W, dBxdz_W, dBzdx_N, dBzdy_N, PLUS, MINUS, minRhom, maxRhom, vA, vS, vW
@@ -1096,17 +1107,21 @@ void calculateEdgeElectricFieldY(
             ) /
         moments_NE->at(fsgrids::moments::RHOQ) /
         physicalconstants::MU_0 *
-        (dperb_NE->at(fsgrids::dperb::dPERBxdz)/technicalGrid.DZ - dperb_NE->at(fsgrids::dperb::dPERBzdx)/technicalGrid.DX);
+        (dperb_NE->at(fsgrids::dperb::dPERBxdz)/fsgrids.technicalGrid.DZ - dperb_NE->at(fsgrids::dperb::dPERBzdx)/fsgrids.technicalGrid.DX);
    }
 
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ey_NE += EHallGrid.get(i-1,j,k-1)->at(fsgrids::ehall::EYHALL_101_111);
+      Ey_NE += fsgrids.EHallGrid.get(i-1,j,k-1)->at(fsgrids::ehall::EYHALL_101_111);
    }
    
    // Electron pressure gradient term
    if(Parameters::ohmGradPeTerm > 0) {
-      Ey_NE += EGradPeGrid.get(i-1,j,k-1)->at(fsgrids::egradpe::EYGRADPE);
+      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         Ey_NE += fsgrids.EGradPeGrid.get(i-1,j,k-1)->at(fsgrids::egradpe::EYGRADPE);
+      } else {
+         Ey_NE += fsgrids.EGradPeDt2Grid.get(i-1,j,k-1)->at(fsgrids::egradpe::EYGRADPE);
+      }
    }
    
    #ifndef FS_1ST_ORDER_SPACE
@@ -1116,11 +1131,7 @@ void calculateEdgeElectricFieldY(
    #endif
    
    calculateWaveSpeedXZ(
-      perBGrid,
-      momentsGrid,
-      dPerBGrid,
-      dMomentsGrid,
-      BgBGrid,
+      fsgrids,
       i-1,j  ,k-1,
       i-1,j+1,k-1,
       Bx_E, Bz_N, dBxdy_E, dBxdz_E, dBzdx_N, dBzdy_N, PLUS, PLUS, minRhom, maxRhom, vA, vS, vW
@@ -1149,10 +1160,10 @@ void calculateEdgeElectricFieldY(
    if ((RKCase == RK_ORDER1) || (RKCase == RK_ORDER2_STEP2)) {
       //compute maximum timestep for fieldsolver in this cell (CFL=1)      
       Real min_dx=std::numeric_limits<Real>::max();;
-      min_dx=min(min_dx,technicalGrid.DX);
-      min_dx=min(min_dx,technicalGrid.DZ);
+      min_dx=min(min_dx,fsgrids.technicalGrid.DX);
+      min_dx=min(min_dx,fsgrids.technicalGrid.DZ);
       //update max allowed timestep for field propagation in this cell, which is the minimum of CFL=1 timesteps
-      if (maxV!=ZERO) technicalGrid.get(i,j,k)->maxFsDt=min(technicalGrid.get(i,j,k)->maxFsDt,min_dx/maxV);
+      if (maxV!=ZERO) fsgrids.technicalGrid.get(i,j,k)->maxFsDt=min(fsgrids.technicalGrid.get(i,j,k)->maxFsDt,min_dx/maxV);
    }
 }
 
@@ -1167,15 +1178,7 @@ void calculateEdgeElectricFieldY(
  * \param RKCase Element in the enum defining the Runge-Kutta method steps
  */
 void calculateEdgeElectricFieldZ(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    cint i,
    cint j,
    cint k,
@@ -1203,28 +1206,58 @@ void calculateEdgeElectricFieldZ(
    Real c_x,c_y;                    // Characteristic speeds to xy-directions
    
    // Get read-only pointers to NE,NW,SE,SW states (SW is rw, result is written there):
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_SW = perBGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_SE = perBGrid.get(i-1,j  ,k  );
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_NE = perBGrid.get(i-1,j-1,k  );
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_NW = perBGrid.get(i  ,j-1,k  );
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_SW = BgBGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_SE = BgBGrid.get(i-1,j  ,k  );
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_NE = BgBGrid.get(i-1,j-1,k  );
-   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_NW = BgBGrid.get(i  ,j-1,k  );
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_SW = momentsGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_SE = momentsGrid.get(i-1,j  ,k  );
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_NE = momentsGrid.get(i-1,j-1,k  );
-   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_NW = momentsGrid.get(i  ,j-1,k  );
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_SW = dMomentsGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_SE = dMomentsGrid.get(i-1,j  ,k  );
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_NE = dMomentsGrid.get(i-1,j-1,k  );
-   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_NW = dMomentsGrid.get(i  ,j-1,k  );
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_SW = dPerBGrid.get(i  ,j  ,k  );
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_SE = dPerBGrid.get(i-1,j  ,k  );
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_NE = dPerBGrid.get(i-1,j-1,k  );
-   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_NW = dPerBGrid.get(i  ,j-1,k  );
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_SW;
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_SE;
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_NE;
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perb_NW;
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_SW;
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_SE;
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_NE;
+   std::array<Real, fsgrids::moments::N_MOMENTS> * moments_NW;
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_SW;
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_SE;
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_NE;
+   std::array<Real, fsgrids::dmoments::N_DMOMENTS> * dmoments_NW;
+   std::array<Real, fsgrids::efield::N_EFIELD> * efield_SW;
+   if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+      perb_SW = fsgrids.perBGrid.get(i  ,j  ,k  );
+      perb_SE = fsgrids.perBGrid.get(i-1,j  ,k  );
+      perb_NE = fsgrids.perBGrid.get(i-1,j-1,k  );
+      perb_NW = fsgrids.perBGrid.get(i  ,j-1,k  );
+      moments_SW = fsgrids.momentsGrid.get(i  ,j  ,k  );
+      moments_SE = fsgrids.momentsGrid.get(i-1,j  ,k  );
+      moments_NE = fsgrids.momentsGrid.get(i-1,j-1,k  );
+      moments_NW = fsgrids.momentsGrid.get(i  ,j-1,k  );
+      dmoments_SW = fsgrids.dMomentsGrid.get(i  ,j  ,k  );
+      dmoments_SE = fsgrids.dMomentsGrid.get(i-1,j  ,k  );
+      dmoments_NE = fsgrids.dMomentsGrid.get(i-1,j-1,k  );
+      dmoments_NW = fsgrids.dMomentsGrid.get(i  ,j-1,k  );
+      efield_SW = fsgrids.EGrid.get(i,j,k);
+   } else { // RKCase == RK_ORDER2_STEP1
+      perb_SW = fsgrids.perBDt2Grid.get(i  ,j  ,k  );
+      perb_SE = fsgrids.perBDt2Grid.get(i-1,j  ,k  );
+      perb_NE = fsgrids.perBDt2Grid.get(i-1,j-1,k  );
+      perb_NW = fsgrids.perBDt2Grid.get(i  ,j-1,k  );
+      moments_SW = fsgrids.momentsDt2Grid.get(i  ,j  ,k  );
+      moments_SE = fsgrids.momentsDt2Grid.get(i-1,j  ,k  );
+      moments_NE = fsgrids.momentsDt2Grid.get(i-1,j-1,k  );
+      moments_NW = fsgrids.momentsDt2Grid.get(i  ,j-1,k  );
+      dmoments_SW = fsgrids.dMomentsDt2Grid.get(i  ,j  ,k  );
+      dmoments_SE = fsgrids.dMomentsDt2Grid.get(i-1,j  ,k  );
+      dmoments_NE = fsgrids.dMomentsDt2Grid.get(i-1,j-1,k  );
+      dmoments_NW = fsgrids.dMomentsDt2Grid.get(i  ,j-1,k  );
+      efield_SW = fsgrids.EDt2Grid.get(i,j,k);
+   }
+
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_SW = fsgrids.BgBGrid.get(i  ,j  ,k  );
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_SE = fsgrids.BgBGrid.get(i-1,j  ,k  );
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_NE = fsgrids.BgBGrid.get(i-1,j-1,k  );
+   std::array<Real, fsgrids::bgbfield::N_BGB> * bgb_NW = fsgrids.BgBGrid.get(i  ,j-1,k  );
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_SW = fsgrids.dPerBGrid.get(i  ,j  ,k  );
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_SE = fsgrids.dPerBGrid.get(i-1,j  ,k  );
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_NE = fsgrids.dPerBGrid.get(i-1,j-1,k  );
+   std::array<Real, fsgrids::dperb::N_DPERB> * dperb_NW = fsgrids.dPerBGrid.get(i  ,j-1,k  );
    
-   std::array<Real, fsgrids::efield::N_EFIELD> * efield_SW = EGrid.get(i,j,k);
    
    // Fetch needed plasma parameters/derivatives from the four cells:
    Real Bx_S, By_W, By_E, Bx_N, perBx_S, perBy_W, perBy_E, perBx_N;
@@ -1287,17 +1320,21 @@ void calculateEdgeElectricFieldZ(
            ) /
        moments_SW->at(fsgrids::moments::RHOQ) /
        physicalconstants::MU_0 *
-       (dperb_SW->at(fsgrids::dperb::dPERBydx)/technicalGrid.DX - dperb_SW->at(fsgrids::dperb::dPERBxdy)/technicalGrid.DY);
+       (dperb_SW->at(fsgrids::dperb::dPERBydx)/fsgrids.technicalGrid.DX - dperb_SW->at(fsgrids::dperb::dPERBxdy)/fsgrids.technicalGrid.DY);
    }
    
    // Hall term
    if (Parameters::ohmHallTerm > 0) {
-      Ez_SW += EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_000_001);
+      Ez_SW += fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_000_001);
    }
    
    // Electron pressure gradient term
    if(Parameters::ohmGradPeTerm > 0) {
-      Ez_SW += EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EZGRADPE);
+      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         Ez_SW += fsgrids.EGradPeGrid.get(i,j,k)->at(fsgrids::egradpe::EZGRADPE);
+      } else {
+         Ez_SW += fsgrids.EGradPeDt2Grid.get(i,j,k)->at(fsgrids::egradpe::EZGRADPE);
+      }
    }
    
    #ifndef FS_1ST_ORDER_SPACE
@@ -1309,11 +1346,7 @@ void calculateEdgeElectricFieldZ(
    // Calculate maximum wave speed (fast magnetosonic speed) on SW cell. In order 
    // to get Alfven speed we need to calculate some reconstruction coeff. for Bz:
    calculateWaveSpeedXY(
-      perBGrid,
-      momentsGrid,
-      dPerBGrid,
-      dMomentsGrid,
-      BgBGrid,
+      fsgrids,
       i, j, k,
       i, j, k+1,
       Bx_S, By_W, dBxdy_S, dBxdz_S, dBydx_W, dBydz_W, MINUS, MINUS, minRhom, maxRhom, vA, vS, vW
@@ -1345,17 +1378,21 @@ void calculateEdgeElectricFieldZ(
             ) /
         moments_SE->at(fsgrids::moments::RHOQ) /
         physicalconstants::MU_0 *
-        (dperb_SE->at(fsgrids::dperb::dPERBydx)/technicalGrid.DX - dperb_SE->at(fsgrids::dperb::dPERBxdy)/technicalGrid.DY);
+        (dperb_SE->at(fsgrids::dperb::dPERBydx)/fsgrids.technicalGrid.DX - dperb_SE->at(fsgrids::dperb::dPERBxdy)/fsgrids.technicalGrid.DY);
    }
    
    // Hall term
    if (Parameters::ohmHallTerm > 0) {
-      Ez_SE += EHallGrid.get(i-1,j,k)->at(fsgrids::ehall::EZHALL_100_101);
+      Ez_SE += fsgrids.EHallGrid.get(i-1,j,k)->at(fsgrids::ehall::EZHALL_100_101);
    }
    
    // Electron pressure gradient term
    if(Parameters::ohmGradPeTerm > 0) {
-      Ez_SE += EGradPeGrid.get(i-1,j,k)->at(fsgrids::egradpe::EZGRADPE);
+      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         Ez_SE += fsgrids.EGradPeGrid.get(i-1,j,k)->at(fsgrids::egradpe::EZGRADPE);
+      } else {
+         Ez_SE += fsgrids.EGradPeDt2Grid.get(i-1,j,k)->at(fsgrids::egradpe::EZGRADPE);
+      }
    }
    
    #ifndef FS_1ST_ORDER_SPACE
@@ -1365,11 +1402,7 @@ void calculateEdgeElectricFieldZ(
    #endif
    
    calculateWaveSpeedXY(
-      perBGrid,
-      momentsGrid,
-      dPerBGrid,
-      dMomentsGrid,
-      BgBGrid,
+      fsgrids,
       i-1,j  ,k,
       i-1,j  ,k+1,
       Bx_S, By_E, dBxdy_S, dBxdz_S, dBydx_E, dBydz_E, PLUS, MINUS, minRhom, maxRhom, vA, vS, vW
@@ -1401,17 +1434,21 @@ void calculateEdgeElectricFieldZ(
             ) /
         moments_NW->at(fsgrids::moments::RHOQ) /
         physicalconstants::MU_0 *
-        (dperb_NW->at(fsgrids::dperb::dPERBydx)/technicalGrid.DX - dperb_NW->at(fsgrids::dperb::dPERBxdy)/technicalGrid.DY);
+        (dperb_NW->at(fsgrids::dperb::dPERBydx)/fsgrids.technicalGrid.DX - dperb_NW->at(fsgrids::dperb::dPERBxdy)/fsgrids.technicalGrid.DY);
    }
    
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ez_NW += EHallGrid.get(i,j-1,k)->at(fsgrids::ehall::EZHALL_010_011);
+      Ez_NW += fsgrids.EHallGrid.get(i,j-1,k)->at(fsgrids::ehall::EZHALL_010_011);
    }
    
    // Electron pressure gradient term
    if(Parameters::ohmGradPeTerm > 0) {
-      Ez_NW += EGradPeGrid.get(i,j-1,k)->at(fsgrids::egradpe::EZGRADPE);
+      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         Ez_NW += fsgrids.EGradPeGrid.get(i,j-1,k)->at(fsgrids::egradpe::EZGRADPE);
+      } else {
+         Ez_NW += fsgrids.EGradPeDt2Grid.get(i,j-1,k)->at(fsgrids::egradpe::EZGRADPE);
+      }
    }
    
    #ifndef FS_1ST_ORDER_SPACE
@@ -1421,11 +1458,7 @@ void calculateEdgeElectricFieldZ(
    #endif
    
    calculateWaveSpeedXY(
-      perBGrid,
-      momentsGrid,
-      dPerBGrid,
-      dMomentsGrid,
-      BgBGrid,
+      fsgrids,
       i, j-1, k,
       i, j-1, k+1,
       Bx_N, By_W, dBxdy_N, dBxdz_N, dBydx_W, dBydz_W, MINUS, PLUS, minRhom, maxRhom, vA, vS, vW
@@ -1457,17 +1490,21 @@ void calculateEdgeElectricFieldZ(
             ) /
         moments_NE->at(fsgrids::moments::RHOQ) /
         physicalconstants::MU_0 *
-        (dperb_NE->at(fsgrids::dperb::dPERBydx)/technicalGrid.DX - dperb_NE->at(fsgrids::dperb::dPERBxdy)/technicalGrid.DY);
+        (dperb_NE->at(fsgrids::dperb::dPERBydx)/fsgrids.technicalGrid.DX - dperb_NE->at(fsgrids::dperb::dPERBxdy)/fsgrids.technicalGrid.DY);
    }
    
    // Hall term
    if(Parameters::ohmHallTerm > 0) {
-      Ez_NE += EHallGrid.get(i-1,j-1,k)->at(fsgrids::ehall::EZHALL_110_111);
+      Ez_NE += fsgrids.EHallGrid.get(i-1,j-1,k)->at(fsgrids::ehall::EZHALL_110_111);
    }
    
    // Electron pressure gradient term
    if(Parameters::ohmGradPeTerm > 0) {
-      Ez_NE += EGradPeGrid.get(i-1,j-1,k)->at(fsgrids::egradpe::EZGRADPE);
+      if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
+         Ez_NE += fsgrids.EGradPeGrid.get(i-1,j-1,k)->at(fsgrids::egradpe::EZGRADPE);
+      } else {
+         Ez_NE += fsgrids.EGradPeDt2Grid.get(i-1,j-1,k)->at(fsgrids::egradpe::EZGRADPE);
+      }
    }
    
    #ifndef FS_1ST_ORDER_SPACE
@@ -1477,11 +1514,7 @@ void calculateEdgeElectricFieldZ(
    #endif
    
    calculateWaveSpeedXY(
-      perBGrid,
-      momentsGrid,
-      dPerBGrid,
-      dMomentsGrid,
-      BgBGrid,
+      fsgrids,
       i-1,j-1,k,
       i-1,j-1,k+1,
       Bx_N, By_E, dBxdy_N, dBxdz_N, dBydx_E, dBydz_E, PLUS, PLUS, minRhom, maxRhom, vA, vS, vW
@@ -1511,10 +1544,10 @@ void calculateEdgeElectricFieldZ(
    if ((RKCase == RK_ORDER1) || (RKCase == RK_ORDER2_STEP2)) {
       //compute maximum timestep for fieldsolver in this cell (CFL=1)
       Real min_dx=std::numeric_limits<Real>::max();;
-      min_dx=min(min_dx,technicalGrid.DX);
-      min_dx=min(min_dx,technicalGrid.DY);
+      min_dx=min(min_dx,fsgrids.technicalGrid.DX);
+      min_dx=min(min_dx,fsgrids.technicalGrid.DY);
       //update max allowed timestep for field propagation in this cell, which is the minimum of CFL=1 timesteps
-      if(maxV!=ZERO) technicalGrid.get(i,j,k)->maxFsDt=min(technicalGrid.get(i,j,k)->maxFsDt,min_dx/maxV);
+      if(maxV!=ZERO) fsgrids.technicalGrid.get(i,j,k)->maxFsDt=min(fsgrids.technicalGrid.get(i,j,k)->maxFsDt,min_dx/maxV);
    }
 }
 
@@ -1522,15 +1555,7 @@ void calculateEdgeElectricFieldZ(
  * 
  * Calls the general or the system boundary electric field propagation functions.
  * 
- * \param perBGrid fsGrid holding the perturbed B quantities
- * \param EGrid fsGrid holding the electric field
- * \param EHallGrid fsGrid holding the Hall contributions to the electric field
- * \param EGradPeGrid fsGrid holding the electron pressure gradient E field
- * \param momentsGrid fsGrid holding the moment quantities
- * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derviatives of moments
- * \param BgBGrid fsGrid holding the background B quantities
- * \param technicalGrid fsGrid holding technical information (such as boundary types)
+ * \param fsgrids Field solver grid container
  * \param i,j,k fsGrid cell coordinates for the current cell
  * \param sysBoundaries System boundary conditions existing
  * \param RKCase Element in the enum defining the Runge-Kutta method steps
@@ -1539,85 +1564,53 @@ void calculateEdgeElectricFieldZ(
  * 
  */
 void calculateElectricField(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    cint i,
    cint j,
    cint k,
    SysBoundary& sysBoundaries,
    cint& RKCase
 ) {
-   cuint cellSysBoundaryFlag = technicalGrid.get(i,j,k)->sysBoundaryFlag;
+   cuint cellSysBoundaryFlag = fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag;
    
    if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || cellSysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) return;
    
-   cuint bitfield = technicalGrid.get(i,j,k)->SOLVE;
+   cuint bitfield = fsgrids.technicalGrid.get(i,j,k)->SOLVE;
    
    if ((bitfield & compute::EX) == compute::EX) {
       calculateEdgeElectricFieldX(
-         perBGrid,
-         EGrid,
-         EHallGrid,
-         EGradPeGrid,
-         momentsGrid,
-         dPerBGrid,
-         dMomentsGrid,
-         BgBGrid,
-         technicalGrid,
+         fsgrids,
          i,
          j,
          k,
          RKCase
       );
    } else {
-      sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondElectricField(EGrid, i, j, k, 0);
+      sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondElectricField(fsgrids.EGrid, i, j, k, 0);
    }
    
    if ((bitfield & compute::EY) == compute::EY) {
       calculateEdgeElectricFieldY(
-         perBGrid,
-         EGrid,
-         EHallGrid,
-         EGradPeGrid,
-         momentsGrid,
-         dPerBGrid,
-         dMomentsGrid,
-         BgBGrid,
-         technicalGrid,
+         fsgrids,
          i,
          j,
          k,
          RKCase
       );
    } else {
-      sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondElectricField(EGrid, i, j, k, 1);
+      sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondElectricField(fsgrids.EGrid, i, j, k, 1);
    }
    
    if ((bitfield & compute::EZ) == compute::EZ) {
       calculateEdgeElectricFieldZ(
-         perBGrid,
-         EGrid,
-         EHallGrid,
-         EGradPeGrid,
-         momentsGrid,
-         dPerBGrid,
-         dMomentsGrid,
-         BgBGrid,
-         technicalGrid,
+         fsgrids,
          i,
          j,
          k,
          RKCase
       );
    } else {
-      sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondElectricField(EGrid, i, j, k, 2);
+      sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondElectricField(fsgrids.EGrid, i, j, k, 2);
    }
 }
 
@@ -1625,45 +1618,20 @@ void calculateElectricField(
  * 
  * Transfers the derivatives, calculates the edge electric fields and transfers the new electric fields.
  * 
- * \param perBGrid fsGrid holding the perturbed B quantities at runge-kutta t=0
- * \param perBDt2Grid fsGrid holding the perturbed B quantities at runge-kutta t=0.5
- * \param EGrid fsGrid holding the Electric field quantities at runge-kutta t=0
- * \param EDt2Grid fsGrid holding the Electric field quantities at runge-kutta t=0.5
- * \param EHallGrid fsGrid holding the Hall contributions to the electric field
- * \param EGradPeGrid fsGrid holding the electron pressure gradient E field
- * \param momentsGrid fsGrid holding the moment quantities at runge-kutta t=0
- * \param momentsDt2Grid fsGrid holding the moment quantities at runge-kutta t=0.5
- * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derivatives of moments
- * \param dMomentsDt2Grid fsGrid holding the derivatives of moments at runge-kutta t=0.5
- * \param BgBGrid fsGrid holding the background B quantities
- * \param technicalGrid fsGrid holding technical information (such as boundary types)
+ * \param fsgrids Field solver grid container
  * \param sysBoundaries System boundary conditions existing
  * \param RKCase Element in the enum defining the Runge-Kutta method steps
  * 
  * \sa calculateElectricField calculateEdgeElectricFieldX calculateEdgeElectricFieldY calculateEdgeElectricFieldZ
  */
 void calculateUpwindedElectricFieldSimple(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EDt2Grid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeDt2Grid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    cint& RKCase,
    const bool communicateEGradPeOrMomentsDerivatives
 ) {
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
-   const FsGridTools::FsIndex_t* gridDims = &technicalGrid.getLocalSize()[0];
+   const FsGridTools::FsIndex_t* gridDims = &fsgrids.technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    phiprof::Timer upwindedETimer {"Calculate upwinded electric field"};
    int computeTimerID {phiprof::initializeTimer("Electric field compute cells")};
@@ -1671,23 +1639,23 @@ void calculateUpwindedElectricFieldSimple(
    phiprof::Timer mpiTimer {"Electric field ghost updates MPI", {"MPI"}};
    // Update ghosts if necessary, unless previous terms have already updated them
    if(P::ohmHallTerm > 0) {
-      EHallGrid.updateGhostCells();
+      fsgrids.EHallGrid.updateGhostCells();
    }
    if(P::ohmGradPeTerm > 0 && communicateEGradPeOrMomentsDerivatives) {
       if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-         EGradPeGrid.updateGhostCells();
+         fsgrids.EGradPeGrid.updateGhostCells();
       } else {
-         EGradPeDt2Grid.updateGhostCells();
+         fsgrids.EGradPeDt2Grid.updateGhostCells();
       }
    }
    if(P::ohmHallTerm == 0) {
-      dPerBGrid.updateGhostCells();
+      fsgrids.dPerBGrid.updateGhostCells();
    }
    if(P::ohmHallTerm == 0 && P::ohmGradPeTerm == 0 && communicateEGradPeOrMomentsDerivatives) {
       if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-         dMomentsGrid.updateGhostCells();
+         fsgrids.dMomentsGrid.updateGhostCells();
       } else {
-         dMomentsDt2Grid.updateGhostCells();
+         fsgrids.dMomentsDt2Grid.updateGhostCells();
       }
    }
    
@@ -1703,15 +1671,7 @@ void calculateUpwindedElectricFieldSimple(
             for (FsGridTools::FsIndex_t i=0; i<gridDims[0]; i++) {
                if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
                   calculateElectricField(
-                     perBGrid,
-                     EGrid,
-                     EHallGrid,
-                     EGradPeGrid,
-                     momentsGrid,
-                     dPerBGrid,
-                     dMomentsGrid,
-                     BgBGrid,
-                     technicalGrid,
+                     fsgrids,
                      i,
                      j,
                      k,
@@ -1720,15 +1680,7 @@ void calculateUpwindedElectricFieldSimple(
                   );
                } else { // RKCase == RK_ORDER2_STEP1
                   calculateElectricField(
-                     perBDt2Grid,
-                     EDt2Grid,
-                     EHallGrid,
-                     EGradPeDt2Grid,
-                     momentsDt2Grid,
-                     dPerBGrid,
-                     dMomentsDt2Grid,
-                     BgBGrid,
-                     technicalGrid,
+                     fsgrids,
                      i,
                      j,
                      k,
@@ -1745,9 +1697,9 @@ void calculateUpwindedElectricFieldSimple(
    mpiTimer.start();
    // Exchange electric field with neighbouring processes
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-      EGrid.updateGhostCells();
+      fsgrids.EGrid.updateGhostCells();
    } else { 
-      EDt2Grid.updateGhostCells();
+      fsgrids.EDt2Grid.updateGhostCells();
    }
    mpiTimer.stop();
    

--- a/fieldsolver/ldz_electric_field.hpp
+++ b/fieldsolver/ldz_electric_field.hpp
@@ -23,20 +23,7 @@
 #include "fs_common.h"
 
 void calculateUpwindedElectricFieldSimple(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EDt2Grid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeDt2Grid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    cint& RKCase,
    const bool communicateEGradPeOrMomentsDerivatives

--- a/fieldsolver/ldz_gradpe.cpp
+++ b/fieldsolver/ldz_gradpe.cpp
@@ -22,6 +22,7 @@
 
 #include "fs_common.h"
 #include "ldz_gradpe.hpp"
+#include "../object_wrapper.h"
 
 #ifndef NDEBUG
    #define DEBUG_FSOLVER
@@ -151,27 +152,21 @@ void calculateGradPeTerm(
 }
 
 void calculateGradPeTermSimple(
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeDt2Grid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsDt2Grid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    cint& RKCase
 ) {
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
-   const FsGridTools::FsIndex_t* gridDims = &technicalGrid.getLocalSize()[0];
+   const FsGridTools::FsIndex_t* gridDims = &fsgrids.technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    phiprof::Timer gradPeTimer {"Calculate GradPe term"};
    int computeTimerId {phiprof::initializeTimer("EgradPe compute cells")};
 
    phiprof::Timer mpiTimer {"EgradPe field update ghosts MPI", {"MPI"}};
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-      dMomentsGrid.updateGhostCells();
+      fsgrids.dMomentsGrid.updateGhostCells();
    } else {
-      dMomentsDt2Grid.updateGhostCells();
+      fsgrids.dMomentsDt2Grid.updateGhostCells();
    }
    mpiTimer.stop();
 
@@ -184,9 +179,9 @@ void calculateGradPeTermSimple(
          for (FsGridTools::FsIndex_t j=0; j<gridDims[1]; j++) {
             for (FsGridTools::FsIndex_t i=0; i<gridDims[0]; i++) {
                if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-                  calculateGradPeTerm(EGradPeGrid, momentsGrid, dMomentsGrid, technicalGrid, i, j, k, sysBoundaries);
+                  calculateGradPeTerm(fsgrids.EGradPeGrid, fsgrids.momentsGrid, fsgrids.dMomentsGrid, fsgrids.technicalGrid, i, j, k, sysBoundaries);
                } else {
-                  calculateGradPeTerm(EGradPeDt2Grid, momentsDt2Grid, dMomentsDt2Grid, technicalGrid, i, j, k, sysBoundaries);
+                  calculateGradPeTerm(fsgrids.EGradPeDt2Grid, fsgrids.momentsDt2Grid, fsgrids.dMomentsDt2Grid, fsgrids.technicalGrid, i, j, k, sysBoundaries);
                }
             }
          }

--- a/fieldsolver/ldz_gradpe.hpp
+++ b/fieldsolver/ldz_gradpe.hpp
@@ -23,13 +23,7 @@
 #include "../definitions.h"
 
 void calculateGradPeTermSimple(
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeDt2Grid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsDt2Grid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    cint& RKCase
 );

--- a/fieldsolver/ldz_hall.cpp
+++ b/fieldsolver/ldz_hall.cpp
@@ -22,6 +22,7 @@
 
 #include "fs_common.h"
 #include "ldz_hall.hpp"
+#include "../object_wrapper.h"
 
 #ifndef NDEBUG
    #define DEBUG_FSOLVER
@@ -419,36 +420,40 @@ REAL JXBZ_110_111(
  *
  * Calls the lower-level inline templates and scales the components properly.
  *
- * \param perBGrid fsGrid holding the perturbed B quantities
- * \param EHallGrid fsGrid holding the Hall contributions to the electric field
- * \param momentsGrid fsGrid holding the moment quantities
- * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derivatives of moments
- * \param BgBGrid fsGrid holding the background B quantities
- * \param technicalGrid fsGrid holding technical information (such as boundary types)
+ * \param fsgrids the field solver grid container
  * \param perturbedCoefficients Reconstruction coefficients
  * \param i,j,k fsGrid cell coordinates for the current cell
+ * \param dt2 whether to solve using the full or half-timestep moments and fields
  *
  * \sa calculateHallTerm JXBX_000_100 JXBX_001_101 JXBX_010_110 JXBX_011_111
  *
  */
 void calculateEdgeHallTermXComponents(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    const std::array<Real, Rec::N_REC_COEFFICIENTS> & perturbedCoefficients,
    cint i,
    cint j,
-   cint k
+   cint k,
+   bool dt2
 ) {
    Real By = 0.0;
    Real Bz = 0.0;
    Real hallRhoq = 0.0;
    Real EXHall = 0.0;
+
+   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>* perBGrid;
+   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>* momentsGrid;
+   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>* dMomentsGrid;
+
+   if(dt2) {
+      perBGrid = &fsgrids.perBDt2Grid;
+      momentsGrid = &fsgrids.momentsDt2Grid;
+      dMomentsGrid = &fsgrids.dMomentsDt2Grid;
+   } else {
+      perBGrid = &fsgrids.perBGrid;
+      momentsGrid = &fsgrids.momentsGrid;
+      dMomentsGrid = &fsgrids.dMomentsGrid;
+   }
 
    switch (Parameters::ohmHallTerm) {
     case 0:
@@ -456,55 +461,55 @@ void calculateEdgeHallTermXComponents(
       break;
 
     case 1:
-      By = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBY)+BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY);
-      Bz = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBZ)+BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ);
+      By = perBGrid->get(i,j,k)->at(fsgrids::bfield::PERBY)+fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY);
+      Bz = perBGrid->get(i,j,k)->at(fsgrids::bfield::PERBZ)+fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ);
 
-      hallRhoq =  (momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ) <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ) ;
-      EXHall = Bz*((BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBxdz)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBxdz)) / technicalGrid.DZ -
-                  (BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBzdx)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBzdx)) / technicalGrid.DX) -
-               By*((BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBydx)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBydx)) / technicalGrid.DX -
-                  (BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBxdy)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBxdy)) / technicalGrid.DY);
+      hallRhoq =  (momentsGrid->get(i,j,k)->at(fsgrids::moments::RHOQ) <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : momentsGrid->get(i,j,k)->at(fsgrids::moments::RHOQ) ;
+      EXHall = Bz*((fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBxdz)+fsgrids.dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBxdz)) / fsgrids.technicalGrid.DZ -
+                  (fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBzdx)+fsgrids.dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBzdx)) / fsgrids.technicalGrid.DX) -
+               By*((fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBydx)+fsgrids.dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBydx)) / fsgrids.technicalGrid.DX -
+                  (fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBxdy)+fsgrids.dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBxdy)) / fsgrids.technicalGrid.DY);
       EXHall /= physicalconstants::MU_0 * hallRhoq;
 
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_000_100) =
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_010_110) =
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_001_101) =
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_011_111) = EXHall;
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_000_100) =
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_010_110) =
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_001_101) =
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_011_111) = EXHall;
 
       break;
     case 2:
       hallRhoq = FOURTH * (
-         momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j-1,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j  ,k-1)->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j-1,k-1)->at(fsgrids::moments::RHOQ)
+         momentsGrid->get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j-1,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j  ,k-1)->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j-1,k-1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_000_100) = JXBX_000_100(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_000_100) = JXBX_000_100(perturbedCoefficients, fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), fsgrids.technicalGrid.DX, fsgrids.technicalGrid.DY, fsgrids.technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
-         momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j+1,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j  ,k-1)->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j+1,k-1)->at(fsgrids::moments::RHOQ)
+         momentsGrid->get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j+1,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j  ,k-1)->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j+1,k-1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_010_110) = JXBX_010_110(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_010_110) = JXBX_010_110(perturbedCoefficients, fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), fsgrids.technicalGrid.DX, fsgrids.technicalGrid.DY, fsgrids.technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
-         momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j-1,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j  ,k+1)->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j-1,k+1)->at(fsgrids::moments::RHOQ)
+         momentsGrid->get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j-1,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j  ,k+1)->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j-1,k+1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_001_101) = JXBX_001_101(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_001_101) = JXBX_001_101(perturbedCoefficients, fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), fsgrids.technicalGrid.DX, fsgrids.technicalGrid.DY, fsgrids.technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
-         momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j+1,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j  ,k+1)->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j+1,k+1)->at(fsgrids::moments::RHOQ)
+         momentsGrid->get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j+1,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j  ,k+1)->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j+1,k+1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_011_111) = JXBX_011_111(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EXHALL_011_111) = JXBX_011_111(perturbedCoefficients, fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), fsgrids.technicalGrid.DX, fsgrids.technicalGrid.DY, fsgrids.technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
       break;
 
     default:
@@ -517,36 +522,40 @@ void calculateEdgeHallTermXComponents(
  *
  * Calls the lower-level inline templates and scales the components properly.
  *
- * \param perBGrid fsGrid holding the perturbed B quantities
- * \param EHallGrid fsGrid holding the Hall contributions to the electric field
- * \param momentsGrid fsGrid holding the moment quantities
- * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derivatives of moments
- * \param BgBGrid fsGrid holding the background B quantities
- * \param technicalGrid fsGrid holding technical information (such as boundary types)
+ * \param fsgrids the field solver grid container
  * \param perturbedCoefficients Reconstruction coefficients
  * \param i,j,k fsGrid cell coordinates for the current cell
+ * \param dt2 whether to solve using the full or half-timestep moments and fields
  *
  * \sa calculateHallTerm JXBY_000_010 JXBY_001_011 JXBY_100_110 JXBY_101_111
  *
  */
 void calculateEdgeHallTermYComponents(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    const std::array<Real, Rec::N_REC_COEFFICIENTS> & perturbedCoefficients,
    cint i,
    cint j,
-   cint k
+   cint k,
+   bool dt2
 ) {
    Real Bx = 0.0;
    Real Bz = 0.0;
    Real hallRhoq = 0.0;
    Real EYHall = 0.0;
+
+   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>* perBGrid;
+   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>* momentsGrid;
+   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>* dMomentsGrid;
+
+   if(dt2) {
+      perBGrid = &fsgrids.perBDt2Grid;
+      momentsGrid = &fsgrids.momentsDt2Grid;
+      dMomentsGrid = &fsgrids.dMomentsDt2Grid;
+   } else {
+      perBGrid = &fsgrids.perBGrid;
+      momentsGrid = &fsgrids.momentsGrid;
+      dMomentsGrid = &fsgrids.dMomentsGrid;
+   }
 
    switch (Parameters::ohmHallTerm) {
     case 0:
@@ -554,55 +563,55 @@ void calculateEdgeHallTermYComponents(
       break;
 
     case 1:
-      Bx = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBX)+BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX);
-      Bz = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBZ)+BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ);
+      Bx = perBGrid->get(i,j,k)->at(fsgrids::bfield::PERBX)+fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX);
+      Bz = perBGrid->get(i,j,k)->at(fsgrids::bfield::PERBZ)+fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ);
 
-      hallRhoq =  (momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ) <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ) ;
-      EYHall = Bx*((BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBydx)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBydx)) / technicalGrid.DX -
-                  (BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBxdy)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBxdy)) / technicalGrid.DY) -
-               Bz*((BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBzdy)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBzdy)) / technicalGrid.DY -
-                  (BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBydz)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBydz)) / technicalGrid.DZ);
+      hallRhoq =  (momentsGrid->get(i,j,k)->at(fsgrids::moments::RHOQ) <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : momentsGrid->get(i,j,k)->at(fsgrids::moments::RHOQ) ;
+      EYHall = Bx*((fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBydx)+fsgrids.dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBydx)) / fsgrids.technicalGrid.DX -
+                  (fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBxdy)+fsgrids.dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBxdy)) / fsgrids.technicalGrid.DY) -
+               Bz*((fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBzdy)+fsgrids.dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBzdy)) / fsgrids.technicalGrid.DY -
+                  (fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBydz)+fsgrids.dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBydz)) / fsgrids.technicalGrid.DZ);
       EYHall /= physicalconstants::MU_0 * hallRhoq;
 
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_000_010) =
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_100_110) =
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_101_111) =
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_001_011) = EYHall;
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_000_010) =
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_100_110) =
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_101_111) =
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_001_011) = EYHall;
       break;
 
     case 2:
       hallRhoq = FOURTH * (
-         momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i-1,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j  ,k-1)->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i-1,j  ,k-1)->at(fsgrids::moments::RHOQ)
+         momentsGrid->get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i-1,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j  ,k-1)->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i-1,j  ,k-1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_000_010) = JXBY_000_010(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_000_010) = JXBY_000_010(perturbedCoefficients, fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), fsgrids.technicalGrid.DX, fsgrids.technicalGrid.DY, fsgrids.technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
-         momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i+1,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j  ,k-1)->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i+1,j  ,k-1)->at(fsgrids::moments::RHOQ)
+         momentsGrid->get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i+1,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j  ,k-1)->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i+1,j  ,k-1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_100_110) = JXBY_100_110(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_100_110) = JXBY_100_110(perturbedCoefficients, fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), fsgrids.technicalGrid.DX, fsgrids.technicalGrid.DY, fsgrids.technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
-         momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i-1,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j  ,k+1)->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i-1,j  ,k+1)->at(fsgrids::moments::RHOQ)
+         momentsGrid->get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i-1,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j  ,k+1)->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i-1,j  ,k+1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_001_011) = JXBY_001_011(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_001_011) = JXBY_001_011(perturbedCoefficients, fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), fsgrids.technicalGrid.DX, fsgrids.technicalGrid.DY, fsgrids.technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
-         momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i+1,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j  ,k+1)->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i+1,j  ,k+1)->at(fsgrids::moments::RHOQ)
+         momentsGrid->get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i+1,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j  ,k+1)->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i+1,j  ,k+1)->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_101_111) = JXBY_101_111(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EYHALL_101_111) = JXBY_101_111(perturbedCoefficients, fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBZ), fsgrids.technicalGrid.DX, fsgrids.technicalGrid.DY, fsgrids.technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
       break;
 
     default:
@@ -615,36 +624,40 @@ void calculateEdgeHallTermYComponents(
  *
  * Calls the lower-level inline templates and scales the components properly.
  *
- * \param perBGrid fsGrid holding the perturbed B quantities
- * \param EHallGrid fsGrid holding the Hall contributions to the electric field
- * \param momentsGrid fsGrid holding the moment quantities
- * \param dPerBGrid fsGrid holding the derivatives of perturbed B
- * \param dMomentsGrid fsGrid holding the derivatives of moments
- * \param BgBGrid fsGrid holding the background B quantities
- * \param technicalGrid fsGrid holding technical information (such as boundary types)
+ * \param fsgrids the field solver grid container
  * \param perturbedCoefficients Reconstruction coefficients
  * \param i,j,k fsGrid cell coordinates for the current cell
+ * \param dt2 whether to solve using the full or half-timestep moments and fields
  *
  * \sa calculateHallTerm JXBZ_000_001 JXBZ_010_011 JXBZ_100_101 JXBZ_110_111
  *
  */
 void calculateEdgeHallTermZComponents(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    const std::array<Real, Rec::N_REC_COEFFICIENTS> & perturbedCoefficients,
    cint i,
    cint j,
-   cint k
+   cint k,
+   bool dt2
 ) {
    Real Bx = 0.0;
    Real By = 0.0;
    Real hallRhoq = 0.0;
    Real EZHall = 0.0;
+
+   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>* perBGrid;
+   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH>* momentsGrid;
+   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH>* dMomentsGrid;
+
+   if(dt2) {
+      perBGrid = &fsgrids.perBDt2Grid;
+      momentsGrid = &fsgrids.momentsDt2Grid;
+      dMomentsGrid = &fsgrids.dMomentsDt2Grid;
+   } else {
+      perBGrid = &fsgrids.perBGrid;
+      momentsGrid = &fsgrids.momentsGrid;
+      dMomentsGrid = &fsgrids.dMomentsGrid;
+   }
 
    switch (Parameters::ohmHallTerm) {
    case 0:
@@ -652,55 +665,55 @@ void calculateEdgeHallTermZComponents(
      break;
 
    case 1:
-     Bx = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBX)+BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX);
-     By = perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBY)+BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY);
+     Bx = perBGrid->get(i,j,k)->at(fsgrids::bfield::PERBX)+fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX);
+     By = perBGrid->get(i,j,k)->at(fsgrids::bfield::PERBY)+fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY);
 
-     hallRhoq =  (momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ) <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : momentsGrid.get(i,j,k)->at(fsgrids::moments::RHOQ) ;
-     EZHall = By*((BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBzdy)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBzdy)) / technicalGrid.DY -
-                 (BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBydz)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBydz)) / technicalGrid.DZ) -
-              Bx*((BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBxdz)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBxdz)) / technicalGrid.DZ -
-                 (BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBzdx)+dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBzdx)) / technicalGrid.DX);
+     hallRhoq =  (momentsGrid->get(i,j,k)->at(fsgrids::moments::RHOQ) <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : momentsGrid->get(i,j,k)->at(fsgrids::moments::RHOQ) ;
+     EZHall = By*((fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBzdy)+fsgrids.dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBzdy)) / fsgrids.technicalGrid.DY -
+                 (fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBydz)+fsgrids.dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBydz)) / fsgrids.technicalGrid.DZ) -
+              Bx*((fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBxdz)+fsgrids.dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBxdz)) / fsgrids.technicalGrid.DZ -
+                 (fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::dBGBzdx)+fsgrids.dPerBGrid.get(i,j,k)->at(fsgrids::dperb::dPERBzdx)) / fsgrids.technicalGrid.DX);
      EZHall /= physicalconstants::MU_0 * hallRhoq;
 
-     EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_000_001) =
-     EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_100_101) =
-     EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_110_111) =
-     EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_010_011) = EZHall;
+     fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_000_001) =
+     fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_100_101) =
+     fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_110_111) =
+     fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_010_011) = EZHall;
      break;
 
    case 2:
       hallRhoq = FOURTH * (
-         momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i-1,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j-1,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i-1,j-1,k  )->at(fsgrids::moments::RHOQ)
+         momentsGrid->get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i-1,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j-1,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i-1,j-1,k  )->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_000_001) = JXBZ_000_001(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_000_001) = JXBZ_000_001(perturbedCoefficients, fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), fsgrids.technicalGrid.DX, fsgrids.technicalGrid.DY, fsgrids.technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
-         momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i+1,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j-1,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i+1,j-1,k  )->at(fsgrids::moments::RHOQ)
+         momentsGrid->get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i+1,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j-1,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i+1,j-1,k  )->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_100_101) = JXBZ_100_101(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_100_101) = JXBZ_100_101(perturbedCoefficients, fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), fsgrids.technicalGrid.DX, fsgrids.technicalGrid.DY, fsgrids.technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
-         momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i-1,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j+1,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i-1,j+1,k  )->at(fsgrids::moments::RHOQ)
+         momentsGrid->get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i-1,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j+1,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i-1,j+1,k  )->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_010_011) = JXBZ_010_011(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_010_011) = JXBZ_010_011(perturbedCoefficients, fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), fsgrids.technicalGrid.DX, fsgrids.technicalGrid.DY, fsgrids.technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
       hallRhoq = FOURTH * (
-         momentsGrid.get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i+1,j  ,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i  ,j+1,k  )->at(fsgrids::moments::RHOQ) +
-         momentsGrid.get(i+1,j+1,k  )->at(fsgrids::moments::RHOQ)
+         momentsGrid->get(i  ,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i+1,j  ,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i  ,j+1,k  )->at(fsgrids::moments::RHOQ) +
+         momentsGrid->get(i+1,j+1,k  )->at(fsgrids::moments::RHOQ)
       );
       hallRhoq =  (hallRhoq <= Parameters::hallMinimumRhoq ) ? Parameters::hallMinimumRhoq : hallRhoq ;
-      EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_110_111) = JXBZ_110_111(perturbedCoefficients, BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), technicalGrid.DX, technicalGrid.DY, technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
+      fsgrids.EHallGrid.get(i,j,k)->at(fsgrids::ehall::EZHALL_110_111) = JXBZ_110_111(perturbedCoefficients, fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBX), fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBY), fsgrids.technicalGrid.DX, fsgrids.technicalGrid.DY, fsgrids.technicalGrid.DZ) / (physicalconstants::MU_0 * hallRhoq);
       break;
 
     default:
@@ -724,17 +737,12 @@ void calculateEdgeHallTermZComponents(
  * \sa calculateHallTermSimple calculateEdgeHallTermXComponents calculateEdgeHallTermYComponents calculateEdgeHallTermZComponents
  */
 void calculateHallTerm(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    cint i,
    cint j,
-   cint k
+   cint k,
+   bool dt2
 ) {
 
    #ifdef DEBUG_FSOLVER
@@ -744,17 +752,17 @@ void calculateHallTerm(
    }
    #endif
 
-   cuint cellSysBoundaryFlag = technicalGrid.get(i,j,k)->sysBoundaryFlag;
+   cuint cellSysBoundaryFlag = fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag;
 
    if (cellSysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || cellSysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) return;
 
-   cuint cellSysBoundaryLayer = technicalGrid.get(i,j,k)->sysBoundaryLayer;
+   cuint cellSysBoundaryLayer = fsgrids.technicalGrid.get(i,j,k)->sysBoundaryLayer;
 
    std::array<Real, Rec::N_REC_COEFFICIENTS> perturbedCoefficients;
 
    reconstructionCoefficients(
-      perBGrid,
-      dPerBGrid,
+      fsgrids.perBGrid,
+      fsgrids.dPerBGrid,
       perturbedCoefficients,
       i,
       j,
@@ -763,13 +771,13 @@ void calculateHallTerm(
    );
 
    if ((cellSysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY) && (cellSysBoundaryLayer != 1)) {
-      sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondHallElectricField(EHallGrid, i, j, k, 0);
-      sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondHallElectricField(EHallGrid, i, j, k, 1);
-      sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondHallElectricField(EHallGrid, i, j, k, 2);
+      sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondHallElectricField(fsgrids.EHallGrid, i, j, k, 0);
+      sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondHallElectricField(fsgrids.EHallGrid, i, j, k, 1);
+      sysBoundaries.getSysBoundary(cellSysBoundaryFlag)->fieldSolverBoundaryCondHallElectricField(fsgrids.EHallGrid, i, j, k, 2);
    } else {
-      calculateEdgeHallTermXComponents(perBGrid, EHallGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, technicalGrid, perturbedCoefficients, i, j, k);
-      calculateEdgeHallTermYComponents(perBGrid, EHallGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, technicalGrid, perturbedCoefficients, i, j, k);
-      calculateEdgeHallTermZComponents(perBGrid, EHallGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, technicalGrid, perturbedCoefficients, i, j, k);
+      calculateEdgeHallTermXComponents(fsgrids, perturbedCoefficients, i, j, k, dt2);
+      calculateEdgeHallTermYComponents(fsgrids, perturbedCoefficients, i, j, k, dt2);
+      calculateEdgeHallTermZComponents(fsgrids, perturbedCoefficients, i, j, k, dt2);
    }
 
 }
@@ -795,33 +803,24 @@ void calculateHallTerm(
  * \sa calculateHallTerm
  */
 void calculateHallTermSimple(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    cint& RKCase,
    const bool communicateMomentsDerivatives
 ) {
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
-   const FsGridTools::FsIndex_t* gridDims = &technicalGrid.getLocalSize()[0];
+   const FsGridTools::FsIndex_t* gridDims = &fsgrids.technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
 
    phiprof::Timer hallTimer {"Calculate Hall term"};
    phiprof::Timer mpiTimer {"EHall ghost updates MPI", {"MPI"}};
    int computeTimerId {phiprof::initializeTimer("EHall compute cells")};
-   dPerBGrid.updateGhostCells();
+   fsgrids.dPerBGrid.updateGhostCells();
    if(P::ohmGradPeTerm == 0 && communicateMomentsDerivatives) {
       if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-         dMomentsGrid.updateGhostCells();
+         fsgrids.dMomentsGrid.updateGhostCells();
       } else {
-         dMomentsDt2Grid.updateGhostCells();
+         fsgrids.dMomentsDt2Grid.updateGhostCells();
       }
    }
    mpiTimer.stop();
@@ -834,9 +833,9 @@ void calculateHallTermSimple(
          for (FsGridTools::FsIndex_t j=0; j<gridDims[1]; j++) {
             for (FsGridTools::FsIndex_t i=0; i<gridDims[0]; i++) {
                if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-                  calculateHallTerm(perBGrid, EHallGrid, momentsGrid, dPerBGrid, dMomentsGrid, BgBGrid, technicalGrid,sysBoundaries, i, j, k);
+                  calculateHallTerm(fsgrids, sysBoundaries, i, j, k, false);
                } else {
-                  calculateHallTerm(perBDt2Grid, EHallGrid, momentsDt2Grid, dPerBGrid, dMomentsDt2Grid, BgBGrid, technicalGrid,sysBoundaries, i, j, k);
+                  calculateHallTerm(fsgrids, sysBoundaries, i, j, k, true);
                }
             }
          }

--- a/fieldsolver/ldz_hall.hpp
+++ b/fieldsolver/ldz_hall.hpp
@@ -23,16 +23,7 @@
 #include "../definitions.h"
 
 void calculateHallTermSimple(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    cint& RKCase,
    const bool communicateMomentsDerivatives

--- a/fieldsolver/ldz_magnetic_field.cpp
+++ b/fieldsolver/ldz_magnetic_field.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "ldz_magnetic_field.hpp"
+#include "../object_wrapper.h"
 
 /*! \brief Low-level magnetic field propagation function.
  *
@@ -47,10 +48,7 @@
  * \param doZ If true, compute the z component (default true).
  */
 void propagateMagneticField(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EDt2Grid,
+   FsGridWrapper& fsgrids,
    cint i,
    cint j,
    cint k,
@@ -60,11 +58,11 @@ void propagateMagneticField(
    const bool doY, //=true (default)
    const bool doZ  //=true (default)
 ) {
-   creal dx = perBGrid.DX;
-   creal dy = perBGrid.DY;
-   creal dz = perBGrid.DZ;
+   creal dx = fsgrids.perBGrid.DX;
+   creal dy = fsgrids.perBGrid.DY;
+   creal dz = fsgrids.perBGrid.DZ;
 
-   std::array<Real, fsgrids::bfield::N_BFIELD> * perBGrid0 = perBGrid.get(i,j,k);
+   std::array<Real, fsgrids::bfield::N_BFIELD> * perBGrid0 = fsgrids.perBGrid.get(i,j,k);
    std::array<Real, fsgrids::efield::N_EFIELD> * EGrid0;
    std::array<Real, fsgrids::efield::N_EFIELD> * EGrid1;
    std::array<Real, fsgrids::efield::N_EFIELD> * EGrid2;
@@ -73,24 +71,24 @@ void propagateMagneticField(
    if (doX == true) {
       switch (RKCase) {
          case RK_ORDER1:
-            EGrid0 = EGrid.get(i,j,k);
-            EGrid1 = EGrid.get(i,j+1,k);
-            EGrid2 = EGrid.get(i,j,k+1);
+            EGrid0 = fsgrids.EGrid.get(i,j,k);
+            EGrid1 = fsgrids.EGrid.get(i,j+1,k);
+            EGrid2 = fsgrids.EGrid.get(i,j,k+1);
             perBGrid0->at(fsgrids::bfield::PERBX) += dt/dz*(EGrid2->at(fsgrids::efield::EY) - EGrid0->at(fsgrids::efield::EY)) + dt/dy*(EGrid0->at(fsgrids::efield::EZ) - EGrid1->at(fsgrids::efield::EZ));
             break;
 
          case RK_ORDER2_STEP1:
-            perBDt2Grid0 = perBDt2Grid.get(i,j,k);
-            EGrid0 = EGrid.get(i,j,k);
-            EGrid1 = EGrid.get(i,j+1,k);
-            EGrid2 = EGrid.get(i,j,k+1);
+            perBDt2Grid0 = fsgrids.perBDt2Grid.get(i,j,k);
+            EGrid0 = fsgrids.EGrid.get(i,j,k);
+            EGrid1 = fsgrids.EGrid.get(i,j+1,k);
+            EGrid2 = fsgrids.EGrid.get(i,j,k+1);
             perBDt2Grid0->at(fsgrids::bfield::PERBX) = perBGrid0->at(fsgrids::bfield::PERBX) + 0.5*dt*(1.0/dz*(EGrid2->at(fsgrids::efield::EY) - EGrid0->at(fsgrids::efield::EY)) + 1.0/dy*(EGrid0->at(fsgrids::efield::EZ) - EGrid1->at(fsgrids::efield::EZ)));
             break;
 
          case RK_ORDER2_STEP2:
-            EGrid0 = EDt2Grid.get(i,j,k);
-            EGrid1 = EDt2Grid.get(i,j+1,k);
-            EGrid2 = EDt2Grid.get(i,j,k+1);
+            EGrid0 = fsgrids.EDt2Grid.get(i,j,k);
+            EGrid1 = fsgrids.EDt2Grid.get(i,j+1,k);
+            EGrid2 = fsgrids.EDt2Grid.get(i,j,k+1);
             perBGrid0->at(fsgrids::bfield::PERBX) += dt * (1.0/dz*(EGrid2->at(fsgrids::efield::EY) - EGrid0->at(fsgrids::efield::EY)) + 1.0/dy*(EGrid0->at(fsgrids::efield::EZ) - EGrid1->at(fsgrids::efield::EZ)));
             break;
 
@@ -103,22 +101,22 @@ void propagateMagneticField(
    if (doY == true) {
       switch (RKCase) {
          case RK_ORDER1:
-            EGrid0 = EGrid.get(i,j,k);
-            EGrid1 = EGrid.get(i,j,k+1);
-            EGrid2 = EGrid.get(i+1,j,k);
+            EGrid0 = fsgrids.EGrid.get(i,j,k);
+            EGrid1 = fsgrids.EGrid.get(i,j,k+1);
+            EGrid2 = fsgrids.EGrid.get(i+1,j,k);
             perBGrid0->at(fsgrids::bfield::PERBY) += dt/dx*(EGrid2->at(fsgrids::efield::EZ) - EGrid0->at(fsgrids::efield::EZ)) + dt/dz*(EGrid0->at(fsgrids::efield::EX) - EGrid1->at(fsgrids::efield::EX));
             break;
          case RK_ORDER2_STEP1:
-            perBDt2Grid0 = perBDt2Grid.get(i,j,k);
-            EGrid0 = EGrid.get(i,j,k);
-            EGrid1 = EGrid.get(i,j,k+1);
-            EGrid2 = EGrid.get(i+1,j,k);
+            perBDt2Grid0 = fsgrids.perBDt2Grid.get(i,j,k);
+            EGrid0 = fsgrids.EGrid.get(i,j,k);
+            EGrid1 = fsgrids.EGrid.get(i,j,k+1);
+            EGrid2 = fsgrids.EGrid.get(i+1,j,k);
             perBDt2Grid0->at(fsgrids::bfield::PERBY) = perBGrid0->at(fsgrids::bfield::PERBY) + 0.5*dt*(1.0/dx*(EGrid2->at(fsgrids::efield::EZ) - EGrid0->at(fsgrids::efield::EZ)) + 1.0/dz*(EGrid0->at(fsgrids::efield::EX) - EGrid1->at(fsgrids::efield::EX)));
             break;
          case RK_ORDER2_STEP2:
-            EGrid0 = EDt2Grid.get(i,j,k);
-            EGrid1 = EDt2Grid.get(i,j,k+1);
-            EGrid2 = EDt2Grid.get(i+1,j,k);
+            EGrid0 = fsgrids.EDt2Grid.get(i,j,k);
+            EGrid1 = fsgrids.EDt2Grid.get(i,j,k+1);
+            EGrid2 = fsgrids.EDt2Grid.get(i+1,j,k);
             perBGrid0->at(fsgrids::bfield::PERBY) += dt * (1.0/dx*(EGrid2->at(fsgrids::efield::EZ) - EGrid0->at(fsgrids::efield::EZ)) + 1.0/dz*(EGrid0->at(fsgrids::efield::EX) - EGrid1->at(fsgrids::efield::EX)));
             break;
          default:
@@ -130,22 +128,22 @@ void propagateMagneticField(
    if (doZ == true) {
       switch (RKCase) {
          case RK_ORDER1:
-            EGrid0 = EGrid.get(i,j,k);
-            EGrid1 = EGrid.get(i+1,j,k);
-            EGrid2 = EGrid.get(i,j+1,k);
+            EGrid0 = fsgrids.EGrid.get(i,j,k);
+            EGrid1 = fsgrids.EGrid.get(i+1,j,k);
+            EGrid2 = fsgrids.EGrid.get(i,j+1,k);
             perBGrid0->at(fsgrids::bfield::PERBZ) += dt/dy*(EGrid2->at(fsgrids::efield::EX) - EGrid0->at(fsgrids::efield::EX)) + dt/dx*(EGrid0->at(fsgrids::efield::EY) - EGrid1->at(fsgrids::efield::EY));
             break;
          case RK_ORDER2_STEP1:
-            perBDt2Grid0 = perBDt2Grid.get(i,j,k);
-            EGrid0 = EGrid.get(i,j,k);
-            EGrid1 = EGrid.get(i+1,j,k);
-            EGrid2 = EGrid.get(i,j+1,k);
+            perBDt2Grid0 = fsgrids.perBDt2Grid.get(i,j,k);
+            EGrid0 = fsgrids.EGrid.get(i,j,k);
+            EGrid1 = fsgrids.EGrid.get(i+1,j,k);
+            EGrid2 = fsgrids.EGrid.get(i,j+1,k);
             perBDt2Grid0->at(fsgrids::bfield::PERBZ) = perBGrid0->at(fsgrids::bfield::PERBZ) + 0.5*dt*(1.0/dy*(EGrid2->at(fsgrids::efield::EX) - EGrid0->at(fsgrids::efield::EX)) + 1.0/dx*(EGrid0->at(fsgrids::efield::EY) - EGrid1->at(fsgrids::efield::EY)));
             break;
          case RK_ORDER2_STEP2:
-            EGrid0 = EDt2Grid.get(i,j,k);
-            EGrid1 = EDt2Grid.get(i+1,j,k);
-            EGrid2 = EDt2Grid.get(i,j+1,k);
+            EGrid0 = fsgrids.EDt2Grid.get(i,j,k);
+            EGrid1 = fsgrids.EDt2Grid.get(i+1,j,k);
+            EGrid2 = fsgrids.EDt2Grid.get(i,j+1,k);
             perBGrid0->at(fsgrids::bfield::PERBZ) += dt  * (1.0/dy*(EGrid2->at(fsgrids::efield::EX) - EGrid0->at(fsgrids::efield::EX)) + 1.0/dx*(EGrid0->at(fsgrids::efield::EY) - EGrid1->at(fsgrids::efield::EY)));
             break;
          default:
@@ -173,12 +171,7 @@ void propagateMagneticField(
  * \sa propagateMagneticFieldSimple propagateMagneticField
  */
 void propagateSysBoundaryMagneticField(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EDt2Grid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    cint i,
    cint j,
    cint k,
@@ -188,9 +181,9 @@ void propagateSysBoundaryMagneticField(
    cuint component
 ) {
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
-      perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBX + component) = sysBoundaries.getSysBoundary(technicalGrid.get(i,j,k)->sysBoundaryFlag)->fieldSolverBoundaryCondMagneticField(perBGrid, bgbGrid, technicalGrid, i, j, k, dt, component);
+      fsgrids.perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBX + component) = sysBoundaries.getSysBoundary(fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag)->fieldSolverBoundaryCondMagneticField(fsgrids, i, j, k, dt, component);
    } else {
-      perBDt2Grid.get(i,j,k)->at(fsgrids::bfield::PERBX + component) = sysBoundaries.getSysBoundary(technicalGrid.get(i,j,k)->sysBoundaryFlag)->fieldSolverBoundaryCondMagneticField(perBDt2Grid, bgbGrid, technicalGrid, i, j, k, dt, component);
+      fsgrids.perBDt2Grid.get(i,j,k)->at(fsgrids::bfield::PERBX + component) = sysBoundaries.getSysBoundary(fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag)->fieldSolverBoundaryCondMagneticField(fsgrids, i, j, k, dt, component);
    }
 }
 
@@ -210,18 +203,13 @@ void propagateSysBoundaryMagneticField(
  * \sa propagateMagneticField propagateSysBoundaryMagneticField
  */
 void propagateMagneticFieldSimple(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EDt2Grid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    creal& dt,
    cint& RKCase
 ) {
-   //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
-   const FsGridTools::FsIndex_t* gridDims = &technicalGrid.getLocalSize()[0];
+   //const std::array<int, 3> gridDims = fsgrids.technicalGrid.getLocalSize();
+   const FsGridTools::FsIndex_t* gridDims = &fsgrids.technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
    phiprof::Timer propagateBTimer {"Propagate magnetic field"};
 
@@ -234,8 +222,8 @@ void propagateMagneticFieldSimple(
       for (FsGridTools::FsIndex_t k=0; k<gridDims[2]; k++) {
          for (FsGridTools::FsIndex_t j=0; j<gridDims[1]; j++) {
             for (FsGridTools::FsIndex_t i=0; i<gridDims[0]; i++) {
-               cuint bitfield = technicalGrid.get(i,j,k)->SOLVE;
-               propagateMagneticField(perBGrid, perBDt2Grid, EGrid, EDt2Grid, i, j, k, dt, RKCase, ((bitfield & compute::BX) == compute::BX), ((bitfield & compute::BY) == compute::BY), ((bitfield & compute::BZ) == compute::BZ));
+               cuint bitfield = fsgrids.technicalGrid.get(i,j,k)->SOLVE;
+               propagateMagneticField(fsgrids, i, j, k, dt, RKCase, ((bitfield & compute::BX) == compute::BX), ((bitfield & compute::BY) == compute::BY), ((bitfield & compute::BZ) == compute::BZ));
             }
          }
       }
@@ -247,10 +235,10 @@ void propagateMagneticFieldSimple(
    phiprof::Timer mpiTimer {"MPI", {"MPI"}};
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
       // Exchange PERBX,PERBY,PERBZ with neighbours
-      perBGrid.updateGhostCells();
+      fsgrids.perBGrid.updateGhostCells();
    } else { // RKCase == RK_ORDER2_STEP1
       // Exchange PERBX_DT2,PERBY_DT2,PERBZ_DT2 with neighbours
-      perBDt2Grid.updateGhostCells();
+      fsgrids.perBDt2Grid.updateGhostCells();
    }
    mpiTimer.stop();
 
@@ -263,17 +251,17 @@ void propagateMagneticFieldSimple(
       for (int k=0; k<gridDims[2]; k++) {
          for (int j=0; j<gridDims[1]; j++) {
             for (int i=0; i<gridDims[0]; i++) {
-               cuint bitfield = technicalGrid.get(i,j,k)->SOLVE;
+               cuint bitfield = fsgrids.technicalGrid.get(i,j,k)->SOLVE;
                // L1 pass
-               if (technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) {
+               if (fsgrids.technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) {
                   if ((bitfield & compute::BX) != compute::BX) {
-                     propagateSysBoundaryMagneticField(perBGrid, perBDt2Grid, bgbGrid, EGrid, EDt2Grid, technicalGrid, i, j, k, sysBoundaries, dt, RKCase, 0);
+                     propagateSysBoundaryMagneticField(fsgrids, i, j, k, sysBoundaries, dt, RKCase, 0);
                   }
                   if ((bitfield & compute::BY) != compute::BY) {
-                     propagateSysBoundaryMagneticField(perBGrid, perBDt2Grid, bgbGrid, EGrid, EDt2Grid, technicalGrid, i, j, k, sysBoundaries, dt, RKCase, 1);
+                     propagateSysBoundaryMagneticField(fsgrids, i, j, k, sysBoundaries, dt, RKCase, 1);
                   }
                   if ((bitfield & compute::BZ) != compute::BZ) {
-                     propagateSysBoundaryMagneticField(perBGrid, perBDt2Grid, bgbGrid, EGrid, EDt2Grid, technicalGrid, i, j, k, sysBoundaries, dt, RKCase, 2);
+                     propagateSysBoundaryMagneticField(fsgrids, i, j, k, sysBoundaries, dt, RKCase, 2);
                   }
                }
             }
@@ -284,10 +272,10 @@ void propagateMagneticFieldSimple(
    mpiTimer.start();
    if (RKCase == RK_ORDER1 || RKCase == RK_ORDER2_STEP2) {
       // Exchange PERBX,PERBY,PERBZ with neighbours
-      perBGrid.updateGhostCells();
+      fsgrids.perBGrid.updateGhostCells();
    } else { // RKCase == RK_ORDER2_STEP1
       // Exchange PERBX_DT2,PERBY_DT2,PERBZ_DT2 with neighbours
-      perBDt2Grid.updateGhostCells();
+      fsgrids.perBDt2Grid.updateGhostCells();
    }
    mpiTimer.stop();
 
@@ -299,11 +287,11 @@ void propagateMagneticFieldSimple(
       for (int k=0; k<gridDims[2]; k++) {
          for (int j=0; j<gridDims[1]; j++) {
             for (int i=0; i<gridDims[0]; i++) {
-               if(technicalGrid.get(i,j,k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY &&
-                  technicalGrid.get(i,j,k)->sysBoundaryLayer == 2
+               if(fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY &&
+                  fsgrids.technicalGrid.get(i,j,k)->sysBoundaryLayer == 2
                   ) {
                   for (uint component = 0; component < 3; component++) {
-                     propagateSysBoundaryMagneticField(perBGrid, perBDt2Grid, bgbGrid, EGrid, EDt2Grid, technicalGrid, i, j, k, sysBoundaries, dt, RKCase, component);
+                     propagateSysBoundaryMagneticField(fsgrids, i, j, k, sysBoundaries, dt, RKCase, component);
                   }
                }
             }

--- a/fieldsolver/ldz_magnetic_field.hpp
+++ b/fieldsolver/ldz_magnetic_field.hpp
@@ -29,10 +29,7 @@
 #include "fs_common.h"
 
 void propagateMagneticField(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EDt2Grid,
+   FsGridWrapper& fsgrids,
    cint i,
    cint j,
    cint k,
@@ -44,12 +41,7 @@ void propagateMagneticField(
 );
 
 void propagateMagneticFieldSimple(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EDt2Grid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    creal& dt,
    cint& RKCase

--- a/fieldsolver/ldz_main.cpp
+++ b/fieldsolver/ldz_main.cpp
@@ -69,21 +69,7 @@
  * 
  */
 bool propagateFields(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBDt2Grid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EDt2Grid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeDt2Grid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    creal& dt,
    cuint subcycles
@@ -94,13 +80,13 @@ bool propagateFields(
       exit(1);
    }
    
-   const FsGridTools::FsIndex_t* gridDims = &technicalGrid.getLocalSize()[0];
+   const FsGridTools::FsIndex_t* gridDims = &fsgrids.technicalGrid.getLocalSize()[0];
    
    #pragma omp parallel for collapse(2)
    for (FsGridTools::FsIndex_t k=0; k<gridDims[2]; k++) {
       for (FsGridTools::FsIndex_t j=0; j<gridDims[1]; j++) {
          for (FsGridTools::FsIndex_t i=0; i<gridDims[0]; i++) {
-            technicalGrid.get(i,j,k)->maxFsDt=std::numeric_limits<Real>::max();
+            fsgrids.technicalGrid.get(i,j,k)->maxFsDt=std::numeric_limits<Real>::max();
          }
       }
    }
@@ -108,127 +94,61 @@ bool propagateFields(
    
    if (subcycles == 1) {
       #ifdef FS_1ST_ORDER_TIME
-      propagateMagneticFieldSimple(perBGrid, perBDt2Grid, BgBGrid, EGrid, EDt2Grid, technicalGrid, sysBoundaries, dt, RK_ORDER1);
-      calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, dMomentsDt2Grid, technicalGrid, sysBoundaries, RK_ORDER1, true/*doMoments*/);
+      propagateMagneticFieldSimple(fsgrids, sysBoundaries, dt, RK_ORDER1);
+      calculateDerivativesSimple(fsgrids, sysBoundaries, RK_ORDER1, true/*doMoments*/);
       if(P::ohmGradPeTerm > 0){
-         calculateGradPeTermSimple(EGradPeGrid, EGradPeDt2Grid, momentsGrid, momentsDt2Grid, dMomentsGrid, dMomentsDt2Grid, technicalGrid, sysBoundaries, RK_ORDER1);
+         calculateGradPeTermSimple(fsgrids, sysBoundaries, RK_ORDER1);
       }
       if(P::ohmHallTerm > 0) {
          calculateHallTermSimple(
-            perBGrid,
-            perBDt2Grid,
-            EHallGrid,
-            momentsGrid,
-            momentsDt2Grid,
-            dPerBGrid,
-            dMomentsGrid,
-            dMomentsDt2Grid,
-            BgBGrid,
-            technicalGrid,
+            fsgrids
             sysBoundaries,
             RK_ORDER1,
             true // communicateMomentsDerivatives
          );
       }
       calculateUpwindedElectricFieldSimple(
-         perBGrid,
-         perBDt2Grid,
-         EGrid,
-         EDt2Grid,
-         EHallGrid,
-         EGradPeGrid,
-         EGradPeDt2Grid,
-         momentsGrid,
-         momentsDt2Grid,
-         dPerBGrid,
-         dMomentsGrid,
-         dMomentsDt2Grid,
-         BgBGrid,
-         technicalGrid,
+         fsgrids,
          sysBoundaries,
          RK_ORDER1,
          true // communicateEGradPeOrMomentsDerivatives
       );
       #else
-      propagateMagneticFieldSimple(perBGrid, perBDt2Grid, BgBGrid, EGrid, EDt2Grid, technicalGrid, sysBoundaries, dt, RK_ORDER2_STEP1);
-      calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, dMomentsDt2Grid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1, true/*doMoments*/);
+      propagateMagneticFieldSimple(fsgrids, sysBoundaries, dt, RK_ORDER2_STEP1);
+      calculateDerivativesSimple(fsgrids, sysBoundaries, RK_ORDER2_STEP1, true/*doMoments*/);
       if(P::ohmGradPeTerm > 0) {
-         calculateGradPeTermSimple(EGradPeGrid, EGradPeDt2Grid, momentsGrid, momentsDt2Grid, dMomentsGrid, dMomentsDt2Grid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1);
+         calculateGradPeTermSimple(fsgrids, sysBoundaries, RK_ORDER2_STEP1);
       }
       if(P::ohmHallTerm > 0) {
          calculateHallTermSimple(
-            perBGrid,
-            perBDt2Grid,
-            EHallGrid,
-            momentsGrid,
-            momentsDt2Grid,
-            dPerBGrid,
-            dMomentsGrid,
-            dMomentsDt2Grid,
-            BgBGrid,
-            technicalGrid,
+            fsgrids,
             sysBoundaries,
             RK_ORDER2_STEP1,
             true // communicateMomentsDerivatives
          );
       }
       calculateUpwindedElectricFieldSimple(
-         perBGrid,
-         perBDt2Grid,
-         EGrid,
-         EDt2Grid,
-         EHallGrid,
-         EGradPeGrid,
-         EGradPeDt2Grid,
-         momentsGrid,
-         momentsDt2Grid,
-         dPerBGrid,
-         dMomentsGrid,
-         dMomentsDt2Grid,
-         BgBGrid,
-         technicalGrid,
+         fsgrids,
          sysBoundaries,
          RK_ORDER2_STEP1,
          true // communicateEGradPeOrMomentsDerivatives
       );
       
-      propagateMagneticFieldSimple(perBGrid, perBDt2Grid, BgBGrid, EGrid, EDt2Grid, technicalGrid, sysBoundaries, dt, RK_ORDER2_STEP2);
-      calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, dMomentsDt2Grid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2, true/*doMoments*/);
+      propagateMagneticFieldSimple(fsgrids, sysBoundaries, dt, RK_ORDER2_STEP2);
+      calculateDerivativesSimple(fsgrids, sysBoundaries, RK_ORDER2_STEP2, true/*doMoments*/);
       if(P::ohmGradPeTerm > 0) {
-         calculateGradPeTermSimple(EGradPeGrid, EGradPeDt2Grid, momentsGrid, momentsDt2Grid, dMomentsGrid, dMomentsDt2Grid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2);
+         calculateGradPeTermSimple(fsgrids, sysBoundaries, RK_ORDER2_STEP2);
       }
       if(P::ohmHallTerm > 0) {
          calculateHallTermSimple(
-            perBGrid,
-            perBDt2Grid,
-            EHallGrid,
-            momentsGrid,
-            momentsDt2Grid,
-            dPerBGrid,
-            dMomentsGrid,
-            dMomentsDt2Grid,
-            BgBGrid,
-            technicalGrid,
+            fsgrids,
             sysBoundaries,
             RK_ORDER2_STEP2,
             true // communicateMomentsDerivatives
          );
       }
       calculateUpwindedElectricFieldSimple(
-         perBGrid,
-         perBDt2Grid,
-         EGrid,
-         EDt2Grid,
-         EHallGrid,
-         EGradPeGrid,
-         EGradPeDt2Grid,
-         momentsGrid,
-         momentsDt2Grid,
-         dPerBGrid,
-         dMomentsGrid,
-         dMomentsDt2Grid,
-         BgBGrid,
-         technicalGrid,
+         fsgrids,
          sysBoundaries,
          RK_ORDER2_STEP2,
          true // communicateEGradPeOrMomentsDerivatives
@@ -240,96 +160,52 @@ bool propagateFields(
       creal targetT = P::t + dt;
       uint subcycleCount = 0;
       uint maxSubcycleCount = std::numeric_limits<uint>::max();
-      int myRank = perBGrid.getRank();
+      int myRank = fsgrids.perBGrid.getRank();
 
       while (subcycleCount < maxSubcycleCount ) {
          // In case of subcycling, we decided to go for a blunt Runge-Kutta subcycling even though e.g. moments are not going along.
          // Result of the Summer of Debugging 2016, the behaviour in wave dispersion was much improved with this.
-         propagateMagneticFieldSimple(perBGrid, perBDt2Grid, BgBGrid, EGrid, EDt2Grid, technicalGrid, sysBoundaries, subcycleDt, RK_ORDER2_STEP1);
+         propagateMagneticFieldSimple(fsgrids, sysBoundaries, subcycleDt, RK_ORDER2_STEP1);
 
          // We need to calculate derivatives of the moments at every substep, but the moments only
          // need to be communicated in the first one.
-         calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, dMomentsDt2Grid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1, (subcycleCount==0)/*doMoments*/);
+         calculateDerivativesSimple(fsgrids, sysBoundaries, RK_ORDER2_STEP1, (subcycleCount==0)/*doMoments*/);
          if(P::ohmGradPeTerm > 0 && subcycleCount==0) {
-            calculateGradPeTermSimple(EGradPeGrid, EGradPeDt2Grid, momentsGrid, momentsDt2Grid, dMomentsGrid, dMomentsDt2Grid, technicalGrid, sysBoundaries, RK_ORDER2_STEP1);
+            calculateGradPeTermSimple(fsgrids, sysBoundaries, RK_ORDER2_STEP1);
          }
          if(P::ohmHallTerm > 0) {
             calculateHallTermSimple(
-               perBGrid,
-               perBDt2Grid,
-               EHallGrid,
-               momentsGrid,
-               momentsDt2Grid,
-               dPerBGrid,
-               dMomentsGrid,
-               dMomentsDt2Grid,
-               BgBGrid,
-               technicalGrid,
+               fsgrids,
                sysBoundaries,
                RK_ORDER2_STEP1,
                subcycleCount==0 // communicateMomentsDerivatives
             );
          }
          calculateUpwindedElectricFieldSimple(
-            perBGrid,
-            perBDt2Grid,
-            EGrid,
-            EDt2Grid,
-            EHallGrid,
-            EGradPeGrid,
-            EGradPeDt2Grid,
-            momentsGrid,
-            momentsDt2Grid,
-            dPerBGrid,
-            dMomentsGrid,
-            dMomentsDt2Grid,
-            BgBGrid,
-            technicalGrid,
+            fsgrids,
             sysBoundaries,
             RK_ORDER2_STEP1,
             subcycleCount==0 // communicateEGradPeOrMomentsDerivatives
          );
          
-         propagateMagneticFieldSimple(perBGrid, perBDt2Grid, BgBGrid, EGrid, EDt2Grid, technicalGrid, sysBoundaries, subcycleDt, RK_ORDER2_STEP2);
+         propagateMagneticFieldSimple(fsgrids, sysBoundaries, subcycleDt, RK_ORDER2_STEP2);
          
          // We need to calculate derivatives of the moments at every substep, but the moments only
          // need to be communicated in the first one.
-         calculateDerivativesSimple(perBGrid, perBDt2Grid, momentsGrid, momentsDt2Grid, dPerBGrid, dMomentsGrid, dMomentsDt2Grid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2, (subcycleCount==0)/*doMoments*/);
+         calculateDerivativesSimple(fsgrids, sysBoundaries, RK_ORDER2_STEP2, (subcycleCount==0)/*doMoments*/);
          if(P::ohmGradPeTerm > 0 && subcycleCount==0) {
-            calculateGradPeTermSimple(EGradPeGrid, EGradPeDt2Grid, momentsGrid, momentsDt2Grid, dMomentsGrid, dMomentsDt2Grid, technicalGrid, sysBoundaries, RK_ORDER2_STEP2);
+            calculateGradPeTermSimple(fsgrids, sysBoundaries, RK_ORDER2_STEP2);
          }
          if(P::ohmHallTerm > 0) {
             calculateHallTermSimple(
-               perBGrid,
-               perBDt2Grid,
-               EHallGrid,
-               momentsGrid,
-               momentsDt2Grid,
-               dPerBGrid,
-               dMomentsGrid,
-               dMomentsDt2Grid,
-               BgBGrid,
-               technicalGrid,
+               fsgrids,
                sysBoundaries,
                RK_ORDER2_STEP2,
                subcycleCount==0 // communicateMomentsDerivatives
             );
          }
          calculateUpwindedElectricFieldSimple(
-            perBGrid,
-            perBDt2Grid,
-            EGrid,
-            EDt2Grid,
-            EHallGrid,
-            EGradPeGrid,
-            EGradPeDt2Grid,
-            momentsGrid,
-            momentsDt2Grid,
-            dPerBGrid,
-            dMomentsGrid,
-            dMomentsDt2Grid,
-            BgBGrid,
-            technicalGrid,
+            fsgrids,
             sysBoundaries,
             RK_ORDER2_STEP2,
             subcycleCount==0 // communicateEGradPeOrMomentsDerivatives
@@ -355,11 +231,11 @@ bool propagateFields(
          Real dtMaxGlobal;
          dtMaxLocal=std::numeric_limits<Real>::max();
 
-         std::array<FsGridTools::FsIndex_t, 3>& localSize = technicalGrid.getLocalSize();
+         std::array<FsGridTools::FsIndex_t, 3>& localSize = fsgrids.technicalGrid.getLocalSize();
          for(FsGridTools::FsIndex_t z=0; z<localSize[2]; z++) {
             for(FsGridTools::FsIndex_t y=0; y<localSize[1]; y++) {
                for(FsGridTools::FsIndex_t x=0; x<localSize[0]; x++) {
-                  fsgrids::technical* cell = technicalGrid.get(x,y,z);
+                  fsgrids::technical* cell = fsgrids.technicalGrid.get(x,y,z);
                   if ( cell->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ||
                         (cell->sysBoundaryLayer == 1 && cell->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY )) {
                      dtMaxLocal=min(dtMaxLocal, cell->maxFsDt);
@@ -369,7 +245,7 @@ bool propagateFields(
          }
 
          phiprof::Timer allreduceTimer {"MPI_Allreduce"};
-         technicalGrid.Allreduce(&(dtMaxLocal), &(dtMaxGlobal), 1, MPI_Type<Real>(), MPI_MIN);
+         fsgrids.technicalGrid.Allreduce(&(dtMaxLocal), &(dtMaxGlobal), 1, MPI_Type<Real>(), MPI_MIN);
          allreduceTimer.stop();
          
          //reduce dt if it is too high
@@ -402,11 +278,11 @@ bool propagateFields(
       }
    }
    
-   calculateVolumeAveragedFields(perBGrid,EGrid,dPerBGrid,volGrid,technicalGrid);
-   calculateBVOLDerivativesSimple(volGrid, technicalGrid, sysBoundaries);
+   calculateVolumeAveragedFields(fsgrids);
+   calculateBVOLDerivativesSimple(fsgrids, sysBoundaries);
    if(FieldTracing::fieldTracingParameters.doTraceFullBox || Parameters::computeCurvature) {
-      volGrid.updateGhostCells();
-      calculateCurvatureSimple(volGrid, BgBGrid, technicalGrid, sysBoundaries);
+      fsgrids.volGrid.updateGhostCells();
+      calculateCurvatureSimple(fsgrids, sysBoundaries);
    }
    return true;
 }

--- a/fieldsolver/ldz_volume.cpp
+++ b/fieldsolver/ldz_volume.cpp
@@ -24,6 +24,7 @@
 
 #include "fs_common.h"
 #include "ldz_volume.hpp"
+#include "../object_wrapper.h"
 
 #ifndef NDEBUG
    #define DEBUG_FSOLVER
@@ -32,14 +33,10 @@
 using namespace std;
 
 void calculateVolumeAveragedFields(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
+   FsGridWrapper& fsgrids
 ) {
    //const std::array<int, 3> gridDims = technicalGrid.getLocalSize();
-   const FsGridTools::FsIndex_t* gridDims = &technicalGrid.getLocalSize()[0];
+   const FsGridTools::FsIndex_t* gridDims = &fsgrids.technicalGrid.getLocalSize()[0];
    const size_t N_cells = gridDims[0]*gridDims[1]*gridDims[2];
 
    phiprof::Timer timer {"Calculate volume averaged fields"};
@@ -52,13 +49,13 @@ void calculateVolumeAveragedFields(
          for (FsGridTools::FsIndex_t j=0; j<gridDims[1]; j++) {
             for (FsGridTools::FsIndex_t i=0; i<gridDims[0]; i++) {
                std::array<Real, Rec::N_REC_COEFFICIENTS> perturbedCoefficients;
-               std::array<Real, fsgrids::volfields::N_VOL> * volGrid0 = volGrid.get(i,j,k);
+               std::array<Real, fsgrids::volfields::N_VOL> * volGrid0 = fsgrids.volGrid.get(i,j,k);
 
                // Calculate reconstruction coefficients for this cell:
                // This handles domain edges so no need to skip DO_NOT_COMPUTE or OUTER_BOUNDARY_PADDING cells.
                reconstructionCoefficients(
-                  perBGrid,
-                  dPerBGrid,
+                  fsgrids.perBGrid,
+                  fsgrids.dPerBGrid,
                   perturbedCoefficients,
                   i,
                   j,
@@ -72,17 +69,17 @@ void calculateVolumeAveragedFields(
                volGrid0->at(fsgrids::volfields::PERBZVOL) = perturbedCoefficients[Rec::c_0];
 
                // This avoids out of domain accesses below.
-               if(technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) continue;
+               if(fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::DO_NOT_COMPUTE || fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::OUTER_BOUNDARY_PADDING) continue;
                // Calculate volume average of E (FIXME NEEDS IMPROVEMENT):
-               std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i1j1k1 = EGrid.get(i,j,k);
-               if ( technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ||
-                    (technicalGrid.get(i,j,k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY && technicalGrid.get(i,j,k)->sysBoundaryLayer == 1)
+               std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i1j1k1 = fsgrids.EGrid.get(i,j,k);
+               if ( fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ||
+                    (fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY && fsgrids.technicalGrid.get(i,j,k)->sysBoundaryLayer == 1)
                   ) {
                   #ifdef DEBUG_FSOLVER
                   bool ok = true;
-                  if (technicalGrid.get(i  ,j+1,k  ) == NULL) ok = false;
-                  if (technicalGrid.get(i  ,j  ,k+1) == NULL) ok = false;
-                  if (technicalGrid.get(i  ,j+1,k+1) == NULL) ok = false;
+                  if (fsgrids.technicalGrid.get(i  ,j+1,k  ) == NULL) ok = false;
+                  if (fsgrids.technicalGrid.get(i  ,j  ,k+1) == NULL) ok = false;
+                  if (fsgrids.technicalGrid.get(i  ,j+1,k+1) == NULL) ok = false;
                   if (ok == false) {
                      stringstream ss;
                      ss << "ERROR, got NULL neighbor in " << __FILE__ << ":" << __LINE__ << endl;
@@ -90,9 +87,9 @@ void calculateVolumeAveragedFields(
                   }
                   #endif
 
-                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i1j2k1 = EGrid.get(i  ,j+1,k  );
-                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i1j1k2 = EGrid.get(i  ,j  ,k+1);
-                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i1j2k2 = EGrid.get(i  ,j+1,k+1);
+                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i1j2k1 = fsgrids.EGrid.get(i  ,j+1,k  );
+                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i1j1k2 = fsgrids.EGrid.get(i  ,j  ,k+1);
+                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i1j2k2 = fsgrids.EGrid.get(i  ,j+1,k+1);
 
                   CHECK_FLOAT(EGrid_i1j1k1->at(fsgrids::efield::EX));
                   CHECK_FLOAT(EGrid_i1j2k1->at(fsgrids::efield::EX));
@@ -104,14 +101,14 @@ void calculateVolumeAveragedFields(
                   volGrid0->at(fsgrids::volfields::EXVOL) = 0.0;
                }
 
-               if ( technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ||
-                    (technicalGrid.get(i,j,k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY && technicalGrid.get(i,j,k)->sysBoundaryLayer == 1)
+               if ( fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ||
+                    (fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY && fsgrids.technicalGrid.get(i,j,k)->sysBoundaryLayer == 1)
                   ) {
                   #ifdef DEBUG_FSOLVER
                   bool ok = true;
-                  if (technicalGrid.get(i+1,j  ,k  ) == NULL) ok = false;
-                  if (technicalGrid.get(i  ,j  ,k+1) == NULL) ok = false;
-                  if (technicalGrid.get(i+1,j  ,k+1) == NULL) ok = false;
+                  if (fsgrids.technicalGrid.get(i+1,j  ,k  ) == NULL) ok = false;
+                  if (fsgrids.technicalGrid.get(i  ,j  ,k+1) == NULL) ok = false;
+                  if (fsgrids.technicalGrid.get(i+1,j  ,k+1) == NULL) ok = false;
                   if (ok == false) {
                      stringstream ss;
                      ss << "ERROR, got NULL neighbor in " << __FILE__ << ":" << __LINE__ << endl;
@@ -119,9 +116,9 @@ void calculateVolumeAveragedFields(
                   }
                   #endif
 
-                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i2j1k1 = EGrid.get(i+1,j  ,k  );
-                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i1j1k2 = EGrid.get(i  ,j  ,k+1);
-                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i2j1k2 = EGrid.get(i+1,j  ,k+1);
+                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i2j1k1 = fsgrids.EGrid.get(i+1,j  ,k  );
+                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i1j1k2 = fsgrids.EGrid.get(i  ,j  ,k+1);
+                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i2j1k2 = fsgrids.EGrid.get(i+1,j  ,k+1);
 
                   CHECK_FLOAT(EGrid_i1j1k1->at(fsgrids::efield::EY));
                   CHECK_FLOAT(EGrid_i2j1k1->at(fsgrids::efield::EY));
@@ -133,14 +130,14 @@ void calculateVolumeAveragedFields(
                   volGrid0->at(fsgrids::volfields::EYVOL) = 0.0;
                }
 
-               if ( technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ||
-                    (technicalGrid.get(i,j,k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY && technicalGrid.get(i,j,k)->sysBoundaryLayer == 1)
+               if ( fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ||
+                    (fsgrids.technicalGrid.get(i,j,k)->sysBoundaryFlag != sysboundarytype::NOT_SYSBOUNDARY && fsgrids.technicalGrid.get(i,j,k)->sysBoundaryLayer == 1)
                   ) {
                   #ifdef DEBUG_FSOLVER
                   bool ok = true;
-                  if (technicalGrid.get(i+1,j  ,k  ) == NULL) ok = false;
-                  if (technicalGrid.get(i  ,j+1,k  ) == NULL) ok = false;
-                  if (technicalGrid.get(i+1,j+1,k  ) == NULL) ok = false;
+                  if (fsgrids.technicalGrid.get(i+1,j  ,k  ) == NULL) ok = false;
+                  if (fsgrids.technicalGrid.get(i  ,j+1,k  ) == NULL) ok = false;
+                  if (fsgrids.technicalGrid.get(i+1,j+1,k  ) == NULL) ok = false;
                   if (ok == false) {
                      stringstream ss;
                      ss << "ERROR, got NULL neighbor in " << __FILE__ << ":" << __LINE__ << endl;
@@ -148,9 +145,9 @@ void calculateVolumeAveragedFields(
                   }
                   #endif
 
-                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i2j1k1 = EGrid.get(i+1,j  ,k  );
-                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i1j2k1 = EGrid.get(i  ,j+1,k  );
-                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i2j2k1 = EGrid.get(i+1,j+1,k  );
+                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i2j1k1 = fsgrids.EGrid.get(i+1,j  ,k  );
+                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i1j2k1 = fsgrids.EGrid.get(i  ,j+1,k  );
+                  std::array<Real, fsgrids::efield::N_EFIELD> * EGrid_i2j2k1 = fsgrids.EGrid.get(i+1,j+1,k  );
 
                   CHECK_FLOAT(EGrid_i1j1k1->at(fsgrids::efield::EZ));
                   CHECK_FLOAT(EGrid_i2j1k1->at(fsgrids::efield::EZ));

--- a/fieldsolver/ldz_volume.hpp
+++ b/fieldsolver/ldz_volume.hpp
@@ -32,11 +32,7 @@
  * \sa reconstructionCoefficients
  */
 void calculateVolumeAveragedFields(
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
+      FsGridWrapper& fsgrids
 );
 
 #endif

--- a/fieldtracing/fieldtracing.cpp
+++ b/fieldtracing/fieldtracing.cpp
@@ -41,17 +41,15 @@ namespace FieldTracing {
    /* Call the heavier operations for DROs to be called only if needed, before an IO.
     */
    void reduceData(
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
+      FsGridWrapper& fsgrids,
       dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry> & mpiGrid,
       std::vector<SBC::SphericalTriGrid::Node> & nodes
    ) {
       if(fieldTracingParameters.doTraceOpenClosed) {
-         traceOpenClosedConnection(technicalGrid, perBGrid, dPerBGrid, nodes);
+         traceOpenClosedConnection(fsgrids, nodes);
       }
       if(fieldTracingParameters.doTraceFullBox) {
-         traceFullBoxConnectionAndFluxRopes(technicalGrid, perBGrid, dPerBGrid, mpiGrid);
+         traceFullBoxConnectionAndFluxRopes(fsgrids, mpiGrid);
       }
    }
    
@@ -61,9 +59,7 @@ namespace FieldTracing {
    * coupling values are recorded in the grid nodes.
    */
    void calculateIonosphereFsgridCoupling(
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
+      FsGridWrapper& fsgrids,
       std::vector<SBC::SphericalTriGrid::Node> & nodes,
       creal couplingRadius
    ) {
@@ -75,7 +71,7 @@ namespace FieldTracing {
       
       phiprof::Timer timer {"fieldtracing-ionosphere-fsgridCoupling"};
       // Pick an initial stepsize
-      creal stepSize = min(100e3, technicalGrid.DX / 2.);
+      creal stepSize = min(100e3, fsgrids.technicalGrid.DX / 2.);
       std::vector<Real> nodeTracingStepSize(nodes.size(), stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
       std::vector<Real> reducedNodeTracingStepSize(nodes.size());
       
@@ -92,8 +88,8 @@ namespace FieldTracing {
       }
       bool anyNodeNeedsTracing;
       
-      TracingFieldFunction<Real> tracingFullField = [&perBGrid, &dPerBGrid, &technicalGrid](std::array<Real,3>& r, const bool alongB, std::array<Real,3>& b)->bool{
-         return traceFullFieldFunction(perBGrid, dPerBGrid, technicalGrid, r, alongB, b);
+      TracingFieldFunction<Real> tracingFullField = [&fsgrids](std::array<Real,3>& r, const bool alongB, std::array<Real,3>& b)->bool{
+         return traceFullFieldFunction(fsgrids, r, alongB, b);
       };
       
       int itCount = 0;
@@ -119,7 +115,7 @@ namespace FieldTracing {
                while( true ) {
                   
                   // Check if the current coordinates (pre-step) are in our own domain.
-                  std::array<FsGridTools::FsIndex_t, 3> fsgridCell = getLocalFsGridCellIndexForCoord(technicalGrid,x);
+                  std::array<FsGridTools::FsIndex_t, 3> fsgridCell = getLocalFsGridCellIndexForCoord(fsgrids.technicalGrid,x);
                   // If it is not in our domain, somebody else takes care of it.
                   if(fsgridCell[0] == -1) {
                      nodeNeedsContinuedTracing[n] = 0;
@@ -129,7 +125,7 @@ namespace FieldTracing {
                   }
                   
                   // Make one step along the fieldline
-                  stepFieldLine(x,v, nodeTracingStepSize[n],fieldTracingParameters.min_tracer_dx_full_box,technicalGrid.DX/2,fieldTracingParameters.tracingMethod,tracingFullField,(no.x[2] < 0));
+                  stepFieldLine(x,v, nodeTracingStepSize[n],fieldTracingParameters.min_tracer_dx_full_box,fsgrids.technicalGrid.DX/2,fieldTracingParameters.tracingMethod,tracingFullField,(no.x[2] < 0));
                   
                   // If we map back into the ionosphere, we obviously don't couple out to SBC::Ionosphere::downmapRadius.
                   if(x.at(0)*x.at(0) + x.at(1)*x.at(1) + x.at(2)*x.at(2) < SBC::Ionosphere::innerRadius*SBC::Ionosphere::innerRadius) {
@@ -143,7 +139,7 @@ namespace FieldTracing {
                      const std::array<Real, 3> x_out = x;
 
                      // Take a step back and find the downmapRadius crossing point
-                     stepFieldLine(x,v, nodeTracingStepSize[n],fieldTracingParameters.min_tracer_dx_full_box,technicalGrid.DX/2,fieldTracingParameters.tracingMethod,tracingFullField,!(no.x[2] < 0));
+                     stepFieldLine(x,v, nodeTracingStepSize[n],fieldTracingParameters.min_tracer_dx_full_box,fsgrids.technicalGrid.DX/2,fieldTracingParameters.tracingMethod,tracingFullField,!(no.x[2] < 0));
                      Real r_out = sqrt(x_out[0]*x_out[0] + x_out[1]*x_out[1] + x_out[2]*x_out[2]);
                      Real r_in = sqrt(x[0]*x[0] + x[1]*x[1] + x[2]*x[2]);
                      Real alpha = (SBC::Ionosphere::downmapRadius-r_out)/(r_in - r_out);
@@ -159,13 +155,11 @@ namespace FieldTracing {
                      no.xMapped[2] = x_out[2] + zi*alpha;
 
                      // Look up the fsgrid cell belonging to these coordinates, including ghost IDs as we might have stepped back across the domain edge
-                     fsgridCell = getLocalFsGridCellIndexWithGhostsForCoord(technicalGrid,x);
+                     fsgridCell = getLocalFsGridCellIndexWithGhostsForCoord(fsgrids.technicalGrid,x);
 
                      // Interpolate and record upmapped B at final xMapped ccordinates
                      const std::array<Real, 3> perB = interpolatePerturbedB(
-                        perBGrid,
-                        dPerBGrid,
-                        technicalGrid,
+                        fsgrids,
                         fieldTracingParameters.reconstructionCoefficientsCache,
                         fsgridCell[0], fsgridCell[1], fsgridCell[2],
                         no.xMapped
@@ -182,7 +176,7 @@ namespace FieldTracing {
                   }
 
                   // Look up the fsgrid cell belonging to these coordinates, again only local (no ghosts)
-                  fsgridCell = getLocalFsGridCellIndexForCoord(technicalGrid,x);
+                  fsgridCell = getLocalFsGridCellIndexForCoord(fsgrids.technicalGrid,x);
                   // Now, after stepping, if it is no longer in our domain, another MPI rank will pick up later.
                   if(fsgridCell[0] == -1) {
                      nodeNeedsContinuedTracing[n] = 1;
@@ -473,9 +467,7 @@ namespace FieldTracing {
    /*! Trace magnetic field lines out from ionospheric nodes to record whether they are on an open or closed field line.
    */
    void traceOpenClosedConnection(
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
+      FsGridWrapper& fsgrids,
       std::vector<SBC::SphericalTriGrid::Node> & nodes
    ) {
       
@@ -486,11 +478,11 @@ namespace FieldTracing {
 
       phiprof::Timer tracingTimer {"fieldtracing-ionosphere-openclosedTracing"};
       // Pick an initial stepsize
-      const TReal stepSize = min(1000e3, technicalGrid.DX / 2.);
+      const TReal stepSize = min(1000e3, fsgrids.technicalGrid.DX / 2.);
       std::vector<TReal> nodeTracingStepSize(nodes.size(), stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
       std::vector<TReal> reducedNodeTracingStepSize(nodes.size());
-      std::array<FsGridTools::FsSize_t, 3> gridSize = technicalGrid.getGlobalSize();
-      uint64_t maxTracingSteps = 8 * (gridSize[0] * technicalGrid.DX + gridSize[1] * technicalGrid.DY + gridSize[2] * technicalGrid.DZ) / stepSize;
+      std::array<FsGridTools::FsSize_t, 3> gridSize = fsgrids.technicalGrid.getGlobalSize();
+      uint64_t maxTracingSteps = 8 * (gridSize[0] * fsgrids.technicalGrid.DX + gridSize[1] * fsgrids.technicalGrid.DY + gridSize[2] * fsgrids.technicalGrid.DZ) / stepSize;
       
       std::vector<int> nodeMapping(nodes.size(), TracingLineEndType::UNPROCESSED);                                 /*!< For reduction of node coupling */
       std::vector<uint64_t> nodeStepCounter(nodes.size());                                 /*!< Count number of field line tracing steps */
@@ -507,8 +499,8 @@ namespace FieldTracing {
       }
       bool anyNodeNeedsTracing;
       
-      TracingFieldFunction<TReal> tracingFullField = [&perBGrid, &dPerBGrid, &technicalGrid](std::array<TReal,3>& r, const bool alongB, std::array<TReal,3>& b)->bool{
-         return traceFullFieldFunction(perBGrid, dPerBGrid, technicalGrid, r, alongB, b);
+      TracingFieldFunction<TReal> tracingFullField = [&fsgrids](std::array<TReal,3>& r, const bool alongB, std::array<TReal,3>& b)->bool{
+         return traceFullFieldFunction(fsgrids, r, alongB, b);
       };
       
       int itCount=0;
@@ -536,7 +528,7 @@ namespace FieldTracing {
                   nodeStepCounter[n]++;
                   
                   // Check if the current coordinates (pre-step) are in our own domain.
-                  std::array<FsGridTools::FsIndex_t, 3> fsgridCell = getLocalFsGridCellIndexForCoord(technicalGrid,{(TReal)x[0], (TReal)x[1], (TReal)x[2]});
+                  std::array<FsGridTools::FsIndex_t, 3> fsgridCell = getLocalFsGridCellIndexForCoord(fsgrids.technicalGrid,{(TReal)x[0], (TReal)x[1], (TReal)x[2]});
                   // If it is not in our domain, somebody else takes care of it.
                   if(fsgridCell[0] == -1) {
                      nodeNeedsContinuedTracing[n] = 0;
@@ -557,11 +549,11 @@ namespace FieldTracing {
                   
                   // Make one step along the fieldline
                   // If the node is in the North, trace along -B (false for last argument), in the South, trace along B
-                  stepFieldLine(x,v, nodeTracingStepSize[n],(TReal)fieldTracingParameters.min_tracer_dx_full_box,(TReal)technicalGrid.DX/2,fieldTracingParameters.tracingMethod,tracingFullField,(no.x[2] < 0));
+                  stepFieldLine(x,v, nodeTracingStepSize[n],(TReal)fieldTracingParameters.min_tracer_dx_full_box,(TReal)fsgrids.technicalGrid.DX/2,fieldTracingParameters.tracingMethod,tracingFullField,(no.x[2] < 0));
                   nodeTracingStepCount[n]++;
                   
                   // Look up the fsgrid cell belonging to these coordinates
-                  fsgridCell = getLocalFsGridCellIndexForCoord(technicalGrid,{(TReal)x[0], (TReal)x[1], (TReal)x[2]});
+                  fsgridCell = getLocalFsGridCellIndexForCoord(fsgrids.technicalGrid,{(TReal)x[0], (TReal)x[1], (TReal)x[2]});
                   
                   // If we map into the ionosphere, this node is on a closed field line.
                   if(x.at(0)*x.at(0) + x.at(1)*x.at(1) + x.at(2)*x.at(2) < SBC::Ionosphere::innerRadius*SBC::Ionosphere::innerRadius) {
@@ -831,9 +823,7 @@ namespace FieldTracing {
     * \sa stepCellAcrossTaskDomain
     */
    void traceFullBoxConnectionAndFluxRopes(
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
+      FsGridWrapper& fsgrids,
       dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid
    ) {
       phiprof::Timer fluxTracingTimer {"fieldtracing-fullAndFluxTracing"};
@@ -854,13 +844,13 @@ namespace FieldTracing {
       MPI_Allgatherv(localDccrgCells.data(), localDccrgSize, MPI_UINT64_T, allDccrgCells.data(), amounts.data(), displacements.data(), MPI_UINT64_T, MPI_COMM_WORLD);
       
       // Pick an initial stepsize
-      const TReal stepSize = min(1000e3, technicalGrid.DX / 2.);
+      const TReal stepSize = min(1000e3, fsgrids.technicalGrid.DX / 2.);
       std::vector<TReal> cellFWTracingStepSize(globalDccrgSize, stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
       std::vector<TReal> cellBWTracingStepSize(globalDccrgSize, stepSize); // In-flight storage of step size, needed when crossing into next MPI domain
       
-      std::array<FsGridTools::FsSize_t, 3> gridSize = technicalGrid.getGlobalSize();
+      std::array<FsGridTools::FsSize_t, 3> gridSize = fsgrids.technicalGrid.getGlobalSize();
       // If fullbox_and_fluxrope_max_distance is unset, use this heuristic considering how far an IMF+dipole combo can sensibly stretch in the box before we're safe to assume it's rolled up more or less pathologically.
-      const TReal maxTracingDistance = fieldTracingParameters.fullbox_and_fluxrope_max_distance > 0 ? fieldTracingParameters.fullbox_and_fluxrope_max_distance : gridSize[0] * technicalGrid.DX + gridSize[1] * technicalGrid.DY + gridSize[2] * technicalGrid.DZ;
+      const TReal maxTracingDistance = fieldTracingParameters.fullbox_and_fluxrope_max_distance > 0 ? fieldTracingParameters.fullbox_and_fluxrope_max_distance : gridSize[0] * fsgrids.technicalGrid.DX + gridSize[1] * fsgrids.technicalGrid.DY + gridSize[2] * fsgrids.technicalGrid.DZ;
       
       std::vector<TReal> cellCurvatureRadius(globalDccrgSize);
       std::vector<TReal> reducedCellCurvatureRadius(globalDccrgSize);
@@ -939,8 +929,8 @@ namespace FieldTracing {
       cellBWTracingStepSize.swap(reducedCellBWTracingStepSize);
       cellCurvatureRadius.swap(reducedCellCurvatureRadius);
       
-      TracingFieldFunction<TReal> tracingFullField = [&perBGrid, &dPerBGrid, &technicalGrid](std::array<TReal,3>& r, const bool alongB, std::array<TReal,3>& b)->bool {
-         return traceFullFieldFunction(perBGrid, dPerBGrid, technicalGrid, r, alongB, b);
+      TracingFieldFunction<TReal> tracingFullField = [&fsgrids](std::array<TReal,3>& r, const bool alongB, std::array<TReal,3>& b)->bool {
+         return traceFullFieldFunction(fsgrids, r, alongB, b);
       };
       int itCount = 0;
       bool warnMaxDistanceExceeded = false;
@@ -974,7 +964,7 @@ namespace FieldTracing {
                if(cellFWConnection[n] % TracingLineEndType::N_TYPES == TracingLineEndType::UNPROCESSED) {
                   stepCellAcrossTaskDomain(
                      n,
-                     technicalGrid,
+                     fsgrids.technicalGrid,
                      tracingFullField,
                      cellInitialCoordinates,
                      cellCurvatureRadius,
@@ -991,7 +981,7 @@ namespace FieldTracing {
                if(cellBWConnection[n] % TracingLineEndType::N_TYPES == TracingLineEndType::UNPROCESSED) {
                   stepCellAcrossTaskDomain(
                      n,
-                     technicalGrid,
+                     fsgrids.technicalGrid,
                      tracingFullField,
                      cellInitialCoordinates,
                      cellCurvatureRadius,

--- a/fieldtracing/fieldtracing.h
+++ b/fieldtracing/fieldtracing.h
@@ -30,6 +30,7 @@
 #include "../fieldsolver/fs_common.h"
 #include "../fieldsolver/derivatives.hpp"
 #include "../sysboundary/ionosphere.h"
+#include "../object_wrapper.h"
 
 // Used in full box + flux rope tracing, the others used in coupling should use Real as double probably.
 typedef float TReal;
@@ -154,9 +155,7 @@ namespace FieldTracing {
    template<typename REAL> using TracingFieldFunction = std::function<bool(std::array<REAL,3>&, const bool, std::array<REAL, 3>&)>;
    
    template<typename REAL> bool traceFullFieldFunction(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+      FsGridWrapper& fsgrids,
       std::array<REAL,3>& r,
       const bool alongB,
       std::array<REAL,3>& b
@@ -177,10 +176,10 @@ namespace FieldTracing {
       b[1] = SBC::ionosphereGrid.dipoleField(r[0],r[1],r[2],Y,0,Y) + SBC::ionosphereGrid.BGB[1];
       b[2] = SBC::ionosphereGrid.dipoleField(r[0],r[1],r[2],Z,0,Z) + SBC::ionosphereGrid.BGB[2];
       
-      std::array<FsGridTools::FsSize_t, 3> fsgridCellu = getGlobalFsGridCellIndexForCoord(technicalGrid,{(TReal)r[0], (TReal)r[1], (TReal)r[2]});
+      std::array<FsGridTools::FsSize_t, 3> fsgridCellu = getGlobalFsGridCellIndexForCoord(fsgrids.technicalGrid,{(TReal)r[0], (TReal)r[1], (TReal)r[2]});
       std::array<FsGridTools::FsIndex_t,3> fsgridCell = {(FsGridTools::FsIndex_t)fsgridCellu[0],(FsGridTools::FsIndex_t)fsgridCellu[1],(FsGridTools::FsIndex_t)fsgridCellu[2]};
-      const std::array<FsGridTools::FsIndex_t, 3> localStart = technicalGrid.getLocalStart();
-      const std::array<FsGridTools::FsIndex_t, 3> localSize = technicalGrid.getLocalSize();
+      const std::array<FsGridTools::FsIndex_t, 3> localStart = fsgrids.technicalGrid.getLocalStart();
+      const std::array<FsGridTools::FsIndex_t, 3> localSize = fsgrids.technicalGrid.getLocalSize();
       // Make the global index a local one, bypass the fsgrid function that yields (-1,-1,-1) also for ghost cells.
       fsgridCell[0] -= localStart[0];
       fsgridCell[1] -= localStart[1];
@@ -195,11 +194,9 @@ namespace FieldTracing {
          abort();
          return false;
       } else {
-         if(technicalGrid.get(fsgridCell[0],fsgridCell[1],fsgridCell[2])->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) {
+         if(fsgrids.technicalGrid.get(fsgridCell[0],fsgridCell[1],fsgridCell[2])->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) {
             const std::array<Real, 3> perB = interpolatePerturbedB(
-               perBGrid,
-               dPerBGrid,
-               technicalGrid,
+               fsgrids,
                fieldTracingParameters.reconstructionCoefficientsCache,
                fsgridCell[0],fsgridCell[1],fsgridCell[2],
                {(Real)r[0], (Real)r[1], (Real)r[2]}
@@ -626,9 +623,7 @@ namespace FieldTracing {
    
    /*! Link each ionospheric node to fsgrid cells for coupling */
    void calculateIonosphereFsgridCoupling(
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
+      FsGridWrapper& fsgrids,
       std::vector<SBC::SphericalTriGrid::Node> & nodes,
       creal radius
    );
@@ -642,24 +637,18 @@ namespace FieldTracing {
 
    /*! Compute whether a node is connected to the ionosphere or the IMF. */
    void traceOpenClosedConnection(
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
+      FsGridWrapper& fsgrids,
       std::vector<SBC::SphericalTriGrid::Node> & nodes
    );
 
    /*! Trace magnetic field lines forward and backward from each DCCRG cell to record the connectivity and detect flux ropes. */
    void traceFullBoxConnectionAndFluxRopes(
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
+      FsGridWrapper& fsgrids,
       dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid
    );
 
    void reduceData(
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
+      FsGridWrapper& fsgrids,
       dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry> & mpiGrid,
       std::vector<SBC::SphericalTriGrid::Node> & nodes
    );

--- a/grid.cpp
+++ b/grid.cpp
@@ -89,15 +89,7 @@ void initializeGrids(
    int argn,
    char **argc,
    dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    Project& project
 ) {
@@ -147,7 +139,7 @@ void initializeGrids(
       if (P::amrMaxSpatialRefLevel > 0 && project.refineSpatialCells(mpiGrid)) {
          mpiGrid.balance_load();
          recalculateLocalCellsCache(mpiGrid);
-         mapRefinement(mpiGrid, technicalGrid);
+         mapRefinement(mpiGrid, fsgrids.technicalGrid);
       }
    } else {
       if (myRank == MASTER_RANK) logFile << "(INIT): Reading grid structure from " << P::restartFileName << endl << writeVerbose;
@@ -156,7 +148,7 @@ void initializeGrids(
       if (restartSuccess) {
          mpiGrid.balance_load();
          recalculateLocalCellsCache(mpiGrid);
-         mapRefinement(mpiGrid, technicalGrid);
+         mapRefinement(mpiGrid, fsgrids.technicalGrid);
       }
    }
    refineTimer.stop();
@@ -199,17 +191,17 @@ void initializeGrids(
    SpatialCell::set_mpi_transfer_type(Transfer::CELL_DIMENSIONS);
    mpiGrid.update_copies_of_remote_neighbors(SYSBOUNDARIES_NEIGHBORHOOD_ID);
 
-   computeCoupling(mpiGrid, cells, technicalGrid);
+   computeCoupling(mpiGrid, cells, fsgrids.technicalGrid);
 
    // We want this before restart refinement
    phiprof::Timer classifyTimer {"Classify cells (sys boundary conditions)"};
-   sysBoundaries.classifyCells(mpiGrid,technicalGrid);
+   sysBoundaries.classifyCells(mpiGrid,fsgrids.technicalGrid);
    classifyTimer.stop();
 
    if (P::isRestart) {
       logFile << "Restart from "<< P::restartFileName << std::endl << writeVerbose;
       phiprof::Timer restartReadTimer {"Read restart"};
-      if (readGrid(mpiGrid,perBGrid,EGrid,technicalGrid,P::restartFileName) == false) {
+      if (readGrid(mpiGrid,fsgrids,P::restartFileName) == false) {
          logFile << "(MAIN) ERROR: restarting failed" << endl;
          exit(1);
       }
@@ -220,19 +212,19 @@ void initializeGrids(
          phiprof::Timer timer {"Restart refinement"};
          for (int i = 0; i < P::amrMaxSpatialRefLevel; ++i) {
             // (un)Refinement is done one level at a time so we don't blow up memory
-            if (!adaptRefinement(mpiGrid, technicalGrid, sysBoundaries, project, i)) {
+            if (!adaptRefinement(mpiGrid, fsgrids.technicalGrid, sysBoundaries, project, i)) {
                cerr << "(MAIN) ERROR: Forcing refinement takes too much memory" << endl;
                exit(1);
             }
-            balanceLoad(mpiGrid, sysBoundaries, technicalGrid);
+            balanceLoad(mpiGrid, sysBoundaries, fsgrids.technicalGrid);
          }
       } else if (P::refineOnRestart) {
          // Considered deprecated
          phiprof::Timer timer {"Restart refinement"};
          // Get good load balancing for refinement
-         balanceLoad(mpiGrid, sysBoundaries, technicalGrid);
-         adaptRefinement(mpiGrid, technicalGrid, sysBoundaries, project);
-         balanceLoad(mpiGrid, sysBoundaries, technicalGrid);
+         balanceLoad(mpiGrid, sysBoundaries, fsgrids.technicalGrid);
+         adaptRefinement(mpiGrid, fsgrids.technicalGrid, sysBoundaries, project);
+         balanceLoad(mpiGrid, sysBoundaries, fsgrids.technicalGrid);
       }
    }
 
@@ -244,11 +236,11 @@ void initializeGrids(
    if (P::isRestart) {
       //initial state for sys-boundary cells, will skip those not set to be reapplied at restart
       phiprof::Timer timer {"Apply system boundary conditions state"};
-      sysBoundaries.applyInitialState(mpiGrid, technicalGrid, perBGrid, BgBGrid, project);
+      sysBoundaries.applyInitialState(mpiGrid, fsgrids, project);
    }
 
    // Update technicalGrid (e.g. sysboundary flags)
-   technicalGrid.updateGhostCells();
+   fsgrids.technicalGrid.updateGhostCells();
 
    if (!P::isRestart && !P::writeFullBGB) {
       // If we are starting a new regular simulation, we need to prepare all cells with their initial state.
@@ -278,7 +270,7 @@ void initializeGrids(
       // Initial state for sys-boundary cells
       applyInitialTimer.stop();
       phiprof::Timer applyBCTimer {"Apply system boundary conditions state"};
-      sysBoundaries.applyInitialState(mpiGrid, technicalGrid, perBGrid, BgBGrid, project);
+      sysBoundaries.applyInitialState(mpiGrid, fsgrids, project);
       applyBCTimer.stop();
 
       #pragma omp parallel for schedule(static)
@@ -328,7 +320,7 @@ void initializeGrids(
 
 
    // Balance load before we transfer all data below
-   balanceLoad(mpiGrid, sysBoundaries, technicalGrid, false);
+   balanceLoad(mpiGrid, sysBoundaries, fsgrids.technicalGrid, false);
    // Function includes re-calculation of local cells cache, but
    // setting third parameter to false skips preparation of
    // translation cell lists and building of pencils.
@@ -340,18 +332,18 @@ void initializeGrids(
    fetchNeighbourTimer.stop();
 
    phiprof::Timer setBTimer {"project.setProjectBField"};
-   project.setProjectBField(perBGrid, BgBGrid, technicalGrid);
+   project.setProjectBField(fsgrids);
    setBTimer.stop();
    phiprof::Timer fsGridGhostTimer {"fsgrid-ghost-updates"};
-   perBGrid.updateGhostCells();
-   BgBGrid.updateGhostCells();
-   EGrid.updateGhostCells();
+   fsgrids.perBGrid.updateGhostCells();
+   fsgrids.BgBGrid.updateGhostCells();
+   fsgrids.EGrid.updateGhostCells();
 
    // This will only have the BGB set up properly at this stage but we need the BGBvol for the Vlasov boundaries below.
-   volGrid.updateGhostCells();
+   fsgrids.volGrid.updateGhostCells();
    fsGridGhostTimer.stop();
    phiprof::Timer getFieldsTimer {"getFieldsFromFsGrid"};
-   getFieldsFromFsGrid(volGrid, BgBGrid, EGradPeGrid, dMomentsGrid, technicalGrid, mpiGrid, cells);
+   getFieldsFromFsGrid(fsgrids, mpiGrid, cells);
    getFieldsTimer.stop();
 
    setBTimer.stop();
@@ -377,15 +369,15 @@ void initializeGrids(
 
 
    phiprof::Timer finishFSGridTimer {"Finish fsgrid setup"};
-   feedMomentsIntoFsGrid(mpiGrid, cells, momentsGrid, technicalGrid, false);
+   feedMomentsIntoFsGrid(mpiGrid, cells, fsgrids, false);
    if(!P::isRestart) {
       // WARNING this means moments and dt2 moments are the same here at t=0, which is a feature so far.
-      feedMomentsIntoFsGrid(mpiGrid, cells, momentsDt2Grid, technicalGrid, false);
+      feedMomentsIntoFsGrid(mpiGrid, cells, fsgrids, false);
    } else {
-      feedMomentsIntoFsGrid(mpiGrid, cells, momentsDt2Grid, technicalGrid, true);
+      feedMomentsIntoFsGrid(mpiGrid, cells, fsgrids, true);
    }
-   momentsGrid.updateGhostCells();
-   momentsDt2Grid.updateGhostCells();
+   fsgrids.momentsGrid.updateGhostCells();
+   fsgrids.momentsDt2Grid.updateGhostCells();
    finishFSGridTimer.stop();
 
    // Set this so CFL doesn't break

--- a/grid.h
+++ b/grid.h
@@ -22,13 +22,14 @@
 #ifndef GRID_H
 #define GRID_H
 
-#include "definitions.h"
-#include "spatial_cell_wrapper.hpp"
 #include <dccrg.hpp>
 #include <dccrg_cartesian_geometry.hpp>
+#include "definitions.h"
+#include "spatial_cell_wrapper.hpp"
 #include "sysboundary/sysboundary.h"
 #include "projects/project.h"
 #include <string>
+#include "object_wrapper.h"
 
 /*!
   \brief Initialize DCCRG and fsgrids
@@ -37,15 +38,7 @@ void initializeGrids(
    int argn,
    char **argc,
    dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsDt2Grid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    SysBoundary& sysBoundaries,
    Project& project
 );

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -1093,10 +1093,7 @@ bool readIonosphereNodeVariable(
  \sa readGrid
  */
 bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-                   const std::string& name) {
+      FsGridWrapper& fsgrids, const std::string& name) {
    vector<CellID> fileCells; /*< CellIds for all cells in file*/
    vector<size_t> nBlocks;/*< Number of blocks for all cells in file*/
    bool success=true;
@@ -1325,8 +1322,8 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    }
    tReadScalarParameter.stop();
 
-   if (success) { success = readFsGridVariable(file, "fg_PERB", fsgridInputRanks, perBGrid); }
-   if (success) { success = readFsGridVariable(file, "fg_E", fsgridInputRanks, EGrid); }
+   if (success) { success = readFsGridVariable(file, "fg_PERB", fsgridInputRanks, fsgrids.perBGrid); }
+   if (success) { success = readFsGridVariable(file, "fg_E", fsgridInputRanks, fsgrids.EGrid); }
    exitOnError(success,"(RESTART) Failure reading fsgrid restart variables",MPI_COMM_WORLD);
    readfsTimer.stop();
    
@@ -1376,12 +1373,9 @@ bool exec_readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
 \param name Name of the restart file e.g. "restart.00052.vlsv"
 */
 bool readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-              const std::string& name){
+      FsGridWrapper& fsgrids, const std::string& name){
    //Check the vlsv version from the file:
-   return exec_readGrid(mpiGrid,perBGrid,EGrid,technicalGrid,name);
+   return exec_readGrid(mpiGrid,fsgrids,name);
 }
 
 /*!

--- a/ioread.h
+++ b/ioread.h
@@ -30,6 +30,7 @@
 #include "definitions.h"
 #include "spatial_cell_wrapper.hpp"
 #include "datareduction/datareducer.h"
+#include "object_wrapper.h"
 
 
 /*!
@@ -39,10 +40,7 @@
 \param name Name of the restart file e.g. "restart.00052.vlsv"
 */
 bool readGrid(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-              const std::string& name);
+      FsGridWrapper& fsgrids, const std::string& name);
 
 /*!
 

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -307,16 +307,7 @@ bool writeVelocityDistributionData(const uint popID,Writer& vlsvWriter,
  */
 bool writeDataReducer(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                       const std::vector<CellID>& cells,
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+                      FsGridWrapper& fsgrids,
                       const bool writeAsFloat,
                       const bool writeFsGrid,
                       DataReducer& dataReducer,
@@ -384,7 +375,7 @@ bool writeDataReducer(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
   if( dataReducer.getName(dataReducerIndex).find("fg_", 0) == 0 ) {
       // Write fsgrid data
       phiprof::Timer writeFsTimer {"writeFsGrid"};
-      success = dataReducer.writeFsGridData(perBGrid,EGrid,EHallGrid,EGradPeGrid,momentsGrid,dPerBGrid,dMomentsGrid,BgBGrid,volGrid, technicalGrid, "fsgrid", dataReducerIndex, vlsvWriter, writeAsFloat);
+      success = dataReducer.writeFsGridData(fsgrids, "fsgrid", dataReducerIndex, vlsvWriter, writeAsFloat);
       writeFsTimer.stop();
 
    } else if( dataReducer.getName(dataReducerIndex).find("ig_", 0) == 0 ) {
@@ -1297,16 +1288,7 @@ bool checkForSameMembers(const vector<uint64_t>& local_cells, const vector<uint6
 */
 bool writeGrid(
    dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    const std::string& versionInfo,
    const std::string& configInfo,
    DataReducer* dataReducer,
@@ -1431,7 +1413,7 @@ bool writeGrid(
    }
 
    //Write FSGrid metadata
-   if( writeFsGridMetadata( technicalGrid, vlsvWriter, P::systemWriteFsGrid.at(outputFileTypeIndex) ) == false ) {
+   if( writeFsGridMetadata( fsgrids.technicalGrid, vlsvWriter, P::systemWriteFsGrid.at(outputFileTypeIndex) ) == false ) {
       return false;
    }
    
@@ -1462,9 +1444,7 @@ bool writeGrid(
    //Determines whether we write in floats or doubles
    phiprof::Timer writeDataTimer {"writeDataReducer"};
    if (dataReducer != NULL) for( uint i = 0; i < dataReducer->size(); ++i ) {
-      if( writeDataReducer( mpiGrid, local_cells,
-            perBGrid, EGrid, EHallGrid, EGradPeGrid, momentsGrid, dPerBGrid, dMomentsGrid,
-            BgBGrid, volGrid, technicalGrid,
+      if( writeDataReducer( mpiGrid, local_cells, fsgrids,
             (P::writeAsFloat==1), P::systemWriteFsGrid.at(outputFileTypeIndex), *dataReducer, i, vlsvWriter ) == false
       ) {
          return false;
@@ -1513,16 +1493,7 @@ bool writeGrid(
 */
 bool writeRestart(
    dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids, 
    const std::string& versionInfo,
    const std::string& configInfo,
    DataReducer& dataReducer,
@@ -1632,7 +1603,7 @@ bool writeRestart(
    if( writeDomainSizes( vlsvWriter, meshName, local_cells.size(), ghost_cells.size() ) == false ) return false;
 
    //Write FSGrid metadata
-   if( writeFsGridMetadata( technicalGrid, vlsvWriter, true ) == false ) return false;
+   if( writeFsGridMetadata( fsgrids.technicalGrid, vlsvWriter, true ) == false ) return false;
    
    //Write Version Info 
    if( writeVersionInfo(versionInfo,vlsvWriter,MPI_COMM_WORLD) == false ) return false;
@@ -1671,23 +1642,14 @@ bool writeRestart(
 
    // Fsgrid Reducers
    restartReducer.addOperator(new DRO::DataReductionOperatorFsGrid("fg_E",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<Real> {
-            std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+                      FsGridWrapper& fsgrids)->std::vector<Real> {
+            std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
             std::vector<Real> retval(gridSize[0]*gridSize[1]*gridSize[2]*fsgrids::efield::N_EFIELD);
             int index=0;
             for(FsGridTools::FsIndex_t z=0; z<gridSize[2]; z++) {
                for(FsGridTools::FsIndex_t y=0; y<gridSize[1]; y++) {
                   for(FsGridTools::FsIndex_t x=0; x<gridSize[0]; x++) {
-                     std::memcpy(&retval[index], EGrid.get(x,y,z), sizeof(Real)*fsgrids::efield::N_EFIELD);
+                     std::memcpy(&retval[index], fsgrids.EGrid.get(x,y,z), sizeof(Real)*fsgrids::efield::N_EFIELD);
                      index += fsgrids::efield::N_EFIELD;
                   }
                }
@@ -1697,23 +1659,14 @@ bool writeRestart(
    ));
    
    restartReducer.addOperator(new DRO::DataReductionOperatorFsGrid("fg_PERB",[](
-                      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-                      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-                      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-                      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-                      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-                      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-                      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-                      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)->std::vector<Real> {
-            std::array<FsGridTools::FsIndex_t,3>& gridSize = technicalGrid.getLocalSize();
+                      FsGridWrapper& fsgrids)->std::vector<Real> {
+            std::array<FsGridTools::FsIndex_t,3>& gridSize = fsgrids.technicalGrid.getLocalSize();
             std::vector<Real> retval(gridSize[0]*gridSize[1]*gridSize[2]*fsgrids::bfield::N_BFIELD);
             int index=0;
             for(FsGridTools::FsIndex_t z=0; z<gridSize[2]; z++) {
                for(FsGridTools::FsIndex_t y=0; y<gridSize[1]; y++) {
                   for(FsGridTools::FsIndex_t x=0; x<gridSize[0]; x++) {
-                     std::memcpy(&retval[index], perBGrid.get(x,y,z), sizeof(Real)*fsgrids::bfield::N_BFIELD);
+                     std::memcpy(&retval[index], fsgrids.perBGrid.get(x,y,z), sizeof(Real)*fsgrids::bfield::N_BFIELD);
                      index += fsgrids::bfield::N_BFIELD;
                   }
                }
@@ -1815,9 +1768,7 @@ bool writeRestart(
    //Write necessary variables:
    const bool writeAsFloat = P::writeRestartAsFloat;
    for (uint i=0; i<restartReducer.size(); ++i) {
-      writeDataReducer(mpiGrid, local_cells,
-            perBGrid, EGrid, EHallGrid, EGradPeGrid, momentsGrid, dPerBGrid, dMomentsGrid,
-            BgBGrid, volGrid, technicalGrid,
+      writeDataReducer(mpiGrid, local_cells, fsgrids,
             writeAsFloat, true, restartReducer, i, vlsvWriter);
    }
    reducedTimer.stop();

--- a/iowrite.h
+++ b/iowrite.h
@@ -31,6 +31,7 @@
 #include "definitions.h"
 #include "spatial_cell_wrapper.hpp"
 #include "datareduction/datareducer.h"
+#include "object_wrapper.h"
 
 /*!
 
@@ -43,16 +44,7 @@
 */
 bool writeGrid(
    dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    const std::string& versionInfo,
    const std::string& configInfo,
    DataReducer* dataReducer,
@@ -72,16 +64,7 @@ bool writeGrid(
 */
 bool writeRestart(
    dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> & EGrid,
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> & EHallGrid,
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> & EGradPeGrid,
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> & dMomentsGrid,
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+   FsGridWrapper& fsgrids,
    const std::string& versionInfo,
    const std::string& configInfo,
    DataReducer& dataReducer,

--- a/object_wrapper.h
+++ b/object_wrapper.h
@@ -24,6 +24,7 @@
 #define OBJECT_WRAPPER_H
 
 #include <vector>
+#include <fsgrid.hpp>
 
 #include "definitions.h"
 #include "item_storage.h"
@@ -32,7 +33,10 @@
 #include "particle_species.h"
 #include "projects/project.h"
 #include "velocity_mesh_parameters.h"
+#include "sysboundary/sysboundarycondition.h"
 #include "sysboundary/sysboundary.h"
+#include "common.h"
+
 
 struct ObjectWrapper {
    ObjectWrapper() { }
@@ -54,5 +58,68 @@ struct ObjectWrapper {
 
 // Currently defined in vlasiator.cpp
 ObjectWrapper& getObjectWrapper();
+
+// All fsgrids together in a crunchy wrapper
+struct FsGridWrapper {
+
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> perBGrid;
+      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> perBDt2Grid;
+      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> EGrid;
+      FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> EDt2Grid;
+      FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> EHallGrid;
+      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> EGradPeGrid;
+      FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> EGradPeDt2Grid;
+      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> momentsGrid;
+      FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> momentsDt2Grid;
+      FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> dPerBGrid;
+      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> dMomentsGrid;
+      FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> dMomentsDt2Grid;
+      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> BgBGrid;
+      FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> volGrid;
+      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> technicalGrid;
+
+      FsGridWrapper(std::array<FsGridTools::FsSize_t,3> fsGridDimensions, 
+            MPI_Comm communicator, std::array<bool, 3> periodicity,
+            std::array<Real, 3> DX, std::array<Real, 3> xmin) :
+      perBGrid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      perBDt2Grid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      EGrid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      EDt2Grid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      EHallGrid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      EGradPeGrid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      EGradPeDt2Grid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      momentsGrid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      momentsDt2Grid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      dPerBGrid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      dMomentsGrid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      dMomentsDt2Grid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      BgBGrid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      volGrid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition),
+      technicalGrid(fsGridDimensions, communicator, periodicity,P::manualFsGridDecomposition) {
+
+         // Set DX, DY and DZ
+         // TODO: This is currently just taking the values from cell 1, and assuming them to be
+         // constant throughout the simulation.
+         perBGrid.DX = perBDt2Grid.DX = EGrid.DX = EDt2Grid.DX = EHallGrid.DX = EGradPeGrid.DX = EGradPeDt2Grid.DX = momentsGrid.DX
+            = momentsDt2Grid.DX = dPerBGrid.DX = dMomentsGrid.DX = dMomentsDt2Grid.DX = BgBGrid.DX = volGrid.DX = technicalGrid.DX
+            = DX[0];
+
+         perBGrid.DY = perBDt2Grid.DY = EGrid.DY = EDt2Grid.DY = EHallGrid.DY = EGradPeGrid.DY = EGradPeDt2Grid.DY = momentsGrid.DY
+            = momentsDt2Grid.DY = dPerBGrid.DY = dMomentsGrid.DY = dMomentsDt2Grid.DY = BgBGrid.DY = volGrid.DY = technicalGrid.DY
+            = DX[1];
+
+         perBGrid.DZ = perBDt2Grid.DZ = EGrid.DZ = EDt2Grid.DZ = EHallGrid.DZ = EGradPeGrid.DZ = EGradPeDt2Grid.DZ = momentsGrid.DZ
+            = momentsDt2Grid.DZ = dPerBGrid.DZ = dMomentsGrid.DZ = dMomentsDt2Grid.DZ = BgBGrid.DZ = volGrid.DZ = technicalGrid.DZ
+            = DX[2];
+
+         // Set the physical start (lower left corner) X, Y, Z
+         perBGrid.physicalGlobalStart = perBDt2Grid.physicalGlobalStart = EGrid.physicalGlobalStart = EDt2Grid.physicalGlobalStart
+            = EHallGrid.physicalGlobalStart = EGradPeGrid.physicalGlobalStart = EGradPeDt2Grid.physicalGlobalStart = momentsGrid.physicalGlobalStart
+            = momentsDt2Grid.physicalGlobalStart = dPerBGrid.physicalGlobalStart = dMomentsGrid.physicalGlobalStart = dMomentsDt2Grid.physicalGlobalStart
+            = BgBGrid.physicalGlobalStart = volGrid.physicalGlobalStart = technicalGrid.physicalGlobalStart
+            = xmin;
+
+      }
+};
 
 #endif

--- a/projects/Dispersion/Dispersion.cpp
+++ b/projects/Dispersion/Dispersion.cpp
@@ -98,7 +98,7 @@ namespace projects {
    void Dispersion::hook(
       cuint& stage,
       const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid
+      FsGridWrapper& fsgrids
    ) const {
       if(hook::END_OF_TIME_STEP == stage) {
          int myRank;
@@ -123,12 +123,12 @@ namespace projects {
          vector<Real> outputPerBy(P::xcells_ini, 0.0);
          vector<Real> outputPerBz(P::xcells_ini, 0.0);
          
-         const std::array<FsGridTools::FsIndex_t, 3> localSize = perBGrid.getLocalSize();
-         const std::array<FsGridTools::FsIndex_t, 3> localStart = perBGrid.getLocalStart();
+         const std::array<FsGridTools::FsIndex_t, 3> localSize = fsgrids.perBGrid.getLocalSize();
+         const std::array<FsGridTools::FsIndex_t, 3> localStart = fsgrids.perBGrid.getLocalStart();
          for (FsGridTools::FsIndex_t x = 0; x < localSize[0]; ++x) {
-            localPerBx[x + localStart[0]] = perBGrid.get(x, 0, 0)->at(fsgrids::bfield::PERBX);
-            localPerBy[x + localStart[0]] = perBGrid.get(x, 0, 0)->at(fsgrids::bfield::PERBY);
-            localPerBz[x + localStart[0]] = perBGrid.get(x, 0, 0)->at(fsgrids::bfield::PERBZ);
+            localPerBx[x + localStart[0]] = fsgrids.perBGrid.get(x, 0, 0)->at(fsgrids::bfield::PERBX);
+            localPerBy[x + localStart[0]] = fsgrids.perBGrid.get(x, 0, 0)->at(fsgrids::bfield::PERBY);
+            localPerBz[x + localStart[0]] = fsgrids.perBGrid.get(x, 0, 0)->at(fsgrids::bfield::PERBZ);
          }
          
          MPI_Reduce(&(localPerBx[0]), &(outputPerBx[0]), P::xcells_ini, MPI_DOUBLE, MPI_SUM, MASTER_RANK, MPI_COMM_WORLD);

--- a/projects/Dispersion/Dispersion.h
+++ b/projects/Dispersion/Dispersion.h
@@ -57,7 +57,7 @@ namespace projects {
       virtual void hook(
          cuint& stage,
          const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid
+         FsGridWrapper& fsgrids
       ) const;
     protected:
       Real getDistribValue(creal& vx, creal& vy, creal& vz, const uint popID) const;

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -175,9 +175,7 @@ namespace projects {
 
    /*! Print a warning message to stderr and abort, one should not use the base class functions. */
    void Project::setProjectBField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
+      FsGridWrapper& fsgrids
    ) {
       int rank;
       MPI_Comm_rank(MPI_COMM_WORLD,&rank);
@@ -190,7 +188,7 @@ namespace projects {
    void Project::hook(
       cuint& stage,
       const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid
+      FsGridWrapper& fsgrids
    ) const { }
 
    void Project::setupBeforeSetCell(const std::vector<CellID>& cells) {

--- a/projects/project.h
+++ b/projects/project.h
@@ -24,10 +24,13 @@
 #define PROJECT_H
 
 #include <random>
-#include "../spatial_cell_wrapper.hpp"
 #include <dccrg.hpp>
 #include <dccrg_cartesian_geometry.hpp>
+#include "../spatial_cell_wrapper.hpp"
 #include "fsgrid.hpp"
+
+// Forward definition
+struct FsGridWrapper;
 
 namespace projects {
    class Project {
@@ -50,7 +53,7 @@ namespace projects {
       virtual void hook(
          cuint& stage,
          const dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid
+         FsGridWrapper& fsgrids
       ) const;
       
       bool initialized();
@@ -63,9 +66,7 @@ namespace projects {
        * \sa setBackgroundField, setBackgroundFieldToZero
        */
       virtual void setProjectBField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & BgBGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
+         FsGridWrapper& fsgrids
       );
       
       /*! Setup data structures for subsequent setCell calls.

--- a/sysboundary/copysphere.cpp
+++ b/sysboundary/copysphere.cpp
@@ -185,9 +185,7 @@ namespace SBC {
 
    void Copysphere::applyInitialState(
       dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+      FsGridWrapper& fsgrids,
       Project &project
    ) {
       const vector<CellID>& cells = getLocalCells();
@@ -476,9 +474,7 @@ namespace SBC {
     * -- Retain only the normal components of perturbed face B
     */
    Real Copysphere::fieldSolverBoundaryCondMagneticField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+      FsGridWrapper& fsgrids,
       cint i,
       cint j,
       cint k,
@@ -486,44 +482,44 @@ namespace SBC {
       cuint component
    ) {
       if(this->zeroPerB == true){
-         return bGrid.get(i,j,k)->at(fsgrids::bfield::PERBX+component);
+         return fsgrids.perBGrid.get(i,j,k)->at(fsgrids::bfield::PERBX+component);
       } else {
-         if (technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) {
+         if (fsgrids.technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) {
             switch(component) {
                case 0:
-                  if (  ((technicalGrid.get(i-1,j,k)->SOLVE & compute::BX) == compute::BX)
-                     && ((technicalGrid.get(i+1,j,k)->SOLVE & compute::BX) == compute::BX)
+                  if (  ((fsgrids.technicalGrid.get(i-1,j,k)->SOLVE & compute::BX) == compute::BX)
+                     && ((fsgrids.technicalGrid.get(i+1,j,k)->SOLVE & compute::BX) == compute::BX)
                   ) {
-                     return 0.5 * (bGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBX) + bGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBX));
-                  } else if ((technicalGrid.get(i-1,j,k)->SOLVE & compute::BX) == compute::BX) {
-                     return bGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBX);
-                  } else if ((technicalGrid.get(i+1,j,k)->SOLVE & compute::BX) == compute::BX) {
-                     return bGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBX);
+                     return 0.5 * (fsgrids.perBGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBX) + fsgrids.perBGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBX));
+                  } else if ((fsgrids.technicalGrid.get(i-1,j,k)->SOLVE & compute::BX) == compute::BX) {
+                     return fsgrids.perBGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBX);
+                  } else if ((fsgrids.technicalGrid.get(i+1,j,k)->SOLVE & compute::BX) == compute::BX) {
+                     return fsgrids.perBGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBX);
                   } else {
                      Real retval = 0.0;
                      uint nCells = 0;
-                     if ((technicalGrid.get(i,j-1,k)->SOLVE & compute::BX) == compute::BX) {
-                        retval += bGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBX);
+                     if ((fsgrids.technicalGrid.get(i,j-1,k)->SOLVE & compute::BX) == compute::BX) {
+                        retval += fsgrids.perBGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBX);
                         nCells++;
                      }
-                     if ((technicalGrid.get(i,j+1,k)->SOLVE & compute::BX) == compute::BX) {
-                        retval += bGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBX);
+                     if ((fsgrids.technicalGrid.get(i,j+1,k)->SOLVE & compute::BX) == compute::BX) {
+                        retval += fsgrids.perBGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBX);
                         nCells++;
                      }
-                     if ((technicalGrid.get(i,j,k-1)->SOLVE & compute::BX) == compute::BX) {
-                        retval += bGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBX);
+                     if ((fsgrids.technicalGrid.get(i,j,k-1)->SOLVE & compute::BX) == compute::BX) {
+                        retval += fsgrids.perBGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBX);
                         nCells++;
                      }
-                     if ((technicalGrid.get(i,j,k+1)->SOLVE & compute::BX) == compute::BX) {
-                        retval += bGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBX);
+                     if ((fsgrids.technicalGrid.get(i,j,k+1)->SOLVE & compute::BX) == compute::BX) {
+                        retval += fsgrids.perBGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBX);
                         nCells++;
                      }
                      if (nCells == 0) {
                         for (int a=i-1; a<i+2; a++) {
                            for (int b=j-1; b<j+2; b++) {
                               for (int c=k-1; c<k+2; c++) {
-                                 if ((technicalGrid.get(a,b,c)->SOLVE & compute::BX) == compute::BX) {
-                                    retval += bGrid.get(a,b,c)->at(fsgrids::bfield::PERBX);
+                                 if ((fsgrids.technicalGrid.get(a,b,c)->SOLVE & compute::BX) == compute::BX) {
+                                    retval += fsgrids.perBGrid.get(a,b,c)->at(fsgrids::bfield::PERBX);
                                     nCells++;
                                  }
                               }
@@ -537,39 +533,39 @@ namespace SBC {
                      return retval / nCells;
                   }
                case 1:
-                  if (  (technicalGrid.get(i,j-1,k)->SOLVE & compute::BY) == compute::BY
-                     && (technicalGrid.get(i,j+1,k)->SOLVE & compute::BY) == compute::BY
+                  if (  (fsgrids.technicalGrid.get(i,j-1,k)->SOLVE & compute::BY) == compute::BY
+                     && (fsgrids.technicalGrid.get(i,j+1,k)->SOLVE & compute::BY) == compute::BY
                   ) {
-                     return 0.5 * (bGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBY) + bGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBY));
-                  } else if ((technicalGrid.get(i,j-1,k)->SOLVE & compute::BY) == compute::BY) {
-                     return bGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBY);
-                  } else if ((technicalGrid.get(i,j+1,k)->SOLVE & compute::BY) == compute::BY) {
-                     return bGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBY);
+                     return 0.5 * (fsgrids.perBGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBY) + fsgrids.perBGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBY));
+                  } else if ((fsgrids.technicalGrid.get(i,j-1,k)->SOLVE & compute::BY) == compute::BY) {
+                     return fsgrids.perBGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBY);
+                  } else if ((fsgrids.technicalGrid.get(i,j+1,k)->SOLVE & compute::BY) == compute::BY) {
+                     return fsgrids.perBGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBY);
                   } else {
                      Real retval = 0.0;
                      uint nCells = 0;
-                     if ((technicalGrid.get(i-1,j,k)->SOLVE & compute::BY) == compute::BY) {
-                        retval += bGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBY);
+                     if ((fsgrids.technicalGrid.get(i-1,j,k)->SOLVE & compute::BY) == compute::BY) {
+                        retval += fsgrids.perBGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBY);
                         nCells++;
                      }
-                     if ((technicalGrid.get(i+1,j,k)->SOLVE & compute::BY) == compute::BY) {
-                        retval += bGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBY);
+                     if ((fsgrids.technicalGrid.get(i+1,j,k)->SOLVE & compute::BY) == compute::BY) {
+                        retval += fsgrids.perBGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBY);
                         nCells++;
                      }
-                     if ((technicalGrid.get(i,j,k-1)->SOLVE & compute::BY) == compute::BY) {
-                        retval += bGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBY);
+                     if ((fsgrids.technicalGrid.get(i,j,k-1)->SOLVE & compute::BY) == compute::BY) {
+                        retval += fsgrids.perBGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBY);
                         nCells++;
                      }
-                     if ((technicalGrid.get(i,j,k+1)->SOLVE & compute::BY) == compute::BY) {
-                        retval += bGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBY);
+                     if ((fsgrids.technicalGrid.get(i,j,k+1)->SOLVE & compute::BY) == compute::BY) {
+                        retval += fsgrids.perBGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBY);
                         nCells++;
                      }
                      if (nCells == 0) {
                         for (int a=i-1; a<i+2; a++) {
                            for (int b=j-1; b<j+2; b++) {
                               for (int c=k-1; c<k+2; c++) {
-                                 if ((technicalGrid.get(a,b,c)->SOLVE & compute::BY) == compute::BY) {
-                                    retval += bGrid.get(a,b,c)->at(fsgrids::bfield::PERBY);
+                                 if ((fsgrids.technicalGrid.get(a,b,c)->SOLVE & compute::BY) == compute::BY) {
+                                    retval += fsgrids.perBGrid.get(a,b,c)->at(fsgrids::bfield::PERBY);
                                     nCells++;
                                  }
                               }
@@ -583,39 +579,39 @@ namespace SBC {
                      return retval / nCells;
                   }
                case 2:
-                  if (  (technicalGrid.get(i,j,k-1)->SOLVE & compute::BZ) == compute::BZ
-                     && (technicalGrid.get(i,j,k+1)->SOLVE & compute::BZ) == compute::BZ
+                  if (  (fsgrids.technicalGrid.get(i,j,k-1)->SOLVE & compute::BZ) == compute::BZ
+                     && (fsgrids.technicalGrid.get(i,j,k+1)->SOLVE & compute::BZ) == compute::BZ
                   ) {
-                     return 0.5 * (bGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBZ) + bGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBZ));
-                  } else if ((technicalGrid.get(i,j,k-1)->SOLVE & compute::BZ) == compute::BZ) {
-                     return bGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBZ);
-                  } else if ((technicalGrid.get(i,j,k+1)->SOLVE & compute::BZ) == compute::BZ) {
-                     return bGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBZ);
+                     return 0.5 * (fsgrids.perBGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBZ) + fsgrids.perBGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBZ));
+                  } else if ((fsgrids.technicalGrid.get(i,j,k-1)->SOLVE & compute::BZ) == compute::BZ) {
+                     return fsgrids.perBGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBZ);
+                  } else if ((fsgrids.technicalGrid.get(i,j,k+1)->SOLVE & compute::BZ) == compute::BZ) {
+                     return fsgrids.perBGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBZ);
                   } else {
                      Real retval = 0.0;
                      uint nCells = 0;
-                     if ((technicalGrid.get(i-1,j,k)->SOLVE & compute::BZ) == compute::BZ) {
-                        retval += bGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBZ);
+                     if ((fsgrids.technicalGrid.get(i-1,j,k)->SOLVE & compute::BZ) == compute::BZ) {
+                        retval += fsgrids.perBGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBZ);
                         nCells++;
                      }
-                     if ((technicalGrid.get(i+1,j,k)->SOLVE & compute::BZ) == compute::BZ) {
-                        retval += bGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBZ);
+                     if ((fsgrids.technicalGrid.get(i+1,j,k)->SOLVE & compute::BZ) == compute::BZ) {
+                        retval += fsgrids.perBGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBZ);
                         nCells++;
                      }
-                     if ((technicalGrid.get(i,j-1,k)->SOLVE & compute::BZ) == compute::BZ) {
-                        retval += bGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBZ);
+                     if ((fsgrids.technicalGrid.get(i,j-1,k)->SOLVE & compute::BZ) == compute::BZ) {
+                        retval += fsgrids.perBGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBZ);
                         nCells++;
                      }
-                     if ((technicalGrid.get(i,j+1,k)->SOLVE & compute::BZ) == compute::BZ) {
-                        retval += bGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBZ);
+                     if ((fsgrids.technicalGrid.get(i,j+1,k)->SOLVE & compute::BZ) == compute::BZ) {
+                        retval += fsgrids.perBGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBZ);
                         nCells++;
                      }
                      if (nCells == 0) {
                         for (int a=i-1; a<i+2; a++) {
                            for (int b=j-1; b<j+2; b++) {
                               for (int c=k-1; c<k+2; c++) {
-                                 if ((technicalGrid.get(a,b,c)->SOLVE & compute::BZ) == compute::BZ) {
-                                    retval += bGrid.get(a,b,c)->at(fsgrids::bfield::PERBZ);
+                                 if ((fsgrids.technicalGrid.get(a,b,c)->SOLVE & compute::BZ) == compute::BZ) {
+                                    retval += fsgrids.perBGrid.get(a,b,c)->at(fsgrids::bfield::PERBZ);
                                     nCells++;
                                  }
                               }
@@ -638,8 +634,8 @@ namespace SBC {
             for (int a=i-1; a<i+2; a++) {
                for (int b=j-1; b<j+2; b++) {
                   for (int c=k-1; c<k+2; c++) {
-                     if (technicalGrid.get(a,b,c)->sysBoundaryLayer == 1) {
-                        retval += bGrid.get(a,b,c)->at(fsgrids::bfield::PERBX + component);
+                     if (fsgrids.technicalGrid.get(a,b,c)->sysBoundaryLayer == 1) {
+                        retval += fsgrids.perBGrid.get(a,b,c)->at(fsgrids::bfield::PERBX + component);
                         nCells++;
                      }
                   }
@@ -893,8 +889,7 @@ namespace SBC {
    void Copysphere::getFaces(bool *faces) {}
    
    void Copysphere::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-                                FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-                                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                FsGridWrapper& fsgrids,
                                 creal t) {}
 
    uint Copysphere::getIndex() const {return sysboundarytype::COPYSPHERE;}

--- a/sysboundary/copysphere.h
+++ b/sysboundary/copysphere.h
@@ -68,21 +68,16 @@ namespace SBC {
                                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid);
       virtual void applyInitialState(
          dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+         FsGridWrapper& fsgrids,
          Project &project
       );
       virtual void updateState(
          dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry> &mpiGrid,
-         FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> &perBGrid,
-         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> &BgBGrid,
+         FsGridWrapper& fsgrids,
          creal t
       );
       virtual Real fieldSolverBoundaryCondMagneticField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+         FsGridWrapper& fsgrids,
          cint i,
          cint j,
          cint k,

--- a/sysboundary/donotcompute.cpp
+++ b/sysboundary/donotcompute.cpp
@@ -54,9 +54,7 @@ namespace SBC {
    
    void DoNotCompute::applyInitialState(
       dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      FsGrid< array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+      FsGridWrapper& fsgrids,
       Project&
    ) {
      const vector<CellID>& cells = getLocalCells();
@@ -80,8 +78,7 @@ namespace SBC {
    }
    
    void DoNotCompute::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry> &mpiGrid,
-                                  FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> &perBGrid,
-                                  FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                  FsGridWrapper& fsgrids,
                                   creal t) {}
 
    void DoNotCompute::getFaces(bool *faces) {}

--- a/sysboundary/donotcompute.h
+++ b/sysboundary/donotcompute.h
@@ -52,15 +52,12 @@ namespace SBC {
                                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid);
       virtual void applyInitialState(
          dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+         FsGridWrapper& fsgrids,
          Project &project
       );
       virtual void updateState(
          dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry> &mpiGrid,
-         FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> &perBGrid,
-         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+         FsGridWrapper& fsgrids,
          creal t
       );
       void getFaces(bool *faces) override;
@@ -69,9 +66,7 @@ namespace SBC {
 
       // Explicit warning functions to inform the user if a doNotCompute cell gets computed
       virtual Real fieldSolverBoundaryCondMagneticField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+         FsGridWrapper& fsgrids,
          cint i,
          cint j,
          cint k,

--- a/sysboundary/inflow.cpp
+++ b/sysboundary/inflow.cpp
@@ -148,19 +148,16 @@ void Inflow::assignSysBoundary(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geomet
 }
 
 void Inflow::applyInitialState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-                               FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-                               FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-                               FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                               FsGridWrapper& fsgrids,
                                Project& project) {
    for (uint popID = 0; popID < getObjectWrapper().particleSpecies.size(); ++popID) {
       setCellsFromTemplate(mpiGrid, popID);
    }
-   setBFromTemplate(mpiGrid, perBGrid, BgBGrid);
+   setBFromTemplate(mpiGrid, fsgrids.perBGrid, fsgrids.BgBGrid);
 }
 
 void Inflow::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-                         FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-                         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                         FsGridWrapper& fsgrids,
                          creal t) {
    if (t - tLastApply < tInterval) {
       return;
@@ -176,7 +173,7 @@ void Inflow::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& m
       setCellsFromTemplate(mpiGrid, popID);
    }
 
-   setBFromTemplate(mpiGrid, perBGrid, BgBGrid);
+   setBFromTemplate(mpiGrid, fsgrids.perBGrid, fsgrids.BgBGrid);
 
    // Ensure up-to-date velocity block counts for all neighbours
    phiprof::Timer ghostTimer {"transfer-ghost-blocks", {"MPI"}};
@@ -187,17 +184,15 @@ void Inflow::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& m
 }
 
 Real Inflow::fieldSolverBoundaryCondMagneticField(
-   FsGrid<array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& bGrid,
-   FsGrid<array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& bgbGrid,
-   FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid, cint i, cint j, cint k, creal dt, cuint component) {
+   FsGridWrapper& fsgrids, cint i, cint j, cint k, creal dt, cuint component) {
    Real result = 0.0;
    creal dx = Parameters::dx_ini;
    creal dy = Parameters::dy_ini;
    creal dz = Parameters::dz_ini;
-   const array<FsGridTools::FsIndex_t, 3> globalIndices = technicalGrid.getGlobalIndices(i, j, k);
-   creal x = (convert<Real>(globalIndices[0]) + 0.5) * technicalGrid.DX + Parameters::xmin;
-   creal y = (convert<Real>(globalIndices[1]) + 0.5) * technicalGrid.DY + Parameters::ymin;
-   creal z = (convert<Real>(globalIndices[2]) + 0.5) * technicalGrid.DZ + Parameters::zmin;
+   const array<FsGridTools::FsIndex_t, 3> globalIndices = fsgrids.technicalGrid.getGlobalIndices(i, j, k);
+   creal x = (convert<Real>(globalIndices[0]) + 0.5) * fsgrids.technicalGrid.DX + Parameters::xmin;
+   creal y = (convert<Real>(globalIndices[1]) + 0.5) * fsgrids.technicalGrid.DY + Parameters::ymin;
+   creal z = (convert<Real>(globalIndices[2]) + 0.5) * fsgrids.technicalGrid.DZ + Parameters::zmin;
 
    bool isThisCellOnAFace[6];
    determineFace(&isThisCellOnAFace[0], x, y, z, dx, dy, dz, true);
@@ -212,7 +207,7 @@ Real Inflow::fieldSolverBoundaryCondMagneticField(
    // There are projects that have non-uniform and non-zero perturbed B, e.g. Magnetosphere with dipole type 4.
    // We cannot jsut take the value from the templateCell, we also need a copy of the value from initialization.
    // This value is stored in the BgBGrid at fsgrids::bgbfield::BGBXVDCORR,BGBYVDCORR,BGBZVDCORR
-   result += bgbGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBXVDCORR + component);
+   result += fsgrids.BgBGrid.get(i,j,k)->at(fsgrids::bgbfield::BGBXVDCORR + component);
    return result;
 }
 

--- a/sysboundary/inflow.h
+++ b/sysboundary/inflow.h
@@ -63,18 +63,13 @@ public:
    virtual void assignSysBoundary(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
                                FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid);
    virtual void applyInitialState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-                                  FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-                                  FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-                                  FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                  FsGridWrapper& fsgrids,
                                   Project& project);
    virtual void updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-                            FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-                            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                            FsGridWrapper& fsgrids,
                             creal t);
    virtual Real
-   fieldSolverBoundaryCondMagneticField(FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& bGrid,
-                                        FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& bgbGrid,
-                                        FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>& technicalGrid, cint i, cint j,
+   fieldSolverBoundaryCondMagneticField(FsGridWrapper& fsgrids, cint i, cint j,
                                         cint k, creal dt, cuint component);
    virtual void
    fieldSolverBoundaryCondElectricField(FsGrid<std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH>& EGrid,

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -1115,12 +1115,7 @@ namespace SBC {
    }
 
    // Transport field-aligned currents down from the simulation cells to the ionosphere
-   void SphericalTriGrid::mapDownBoundaryData(
-       FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-       FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-       FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-         FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-       FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid) {
+   void SphericalTriGrid::mapDownBoundaryData(FsGridWrapper& fsgrids) {
 
       if(!isCouplingInwards && !isCouplingOutwards) {
          return;
@@ -1148,7 +1143,7 @@ namespace SBC {
             }
 
             // Local cell
-            std::array<FsGridTools::FsIndex_t,3> lfsc = getLocalFsGridCellIndexForCoord(technicalGrid,nodes[n].xMapped);
+            std::array<FsGridTools::FsIndex_t,3> lfsc = getLocalFsGridCellIndexForCoord(fsgrids.technicalGrid,nodes[n].xMapped);
             if(lfsc[0] == -1 || lfsc[1] == -1 || lfsc[2] == -1) {
                continue;
             }
@@ -1166,10 +1161,7 @@ namespace SBC {
             nodeAreaGeometric /= 3.;
 
             // Calc curlB, note division by DX one line down
-            const std::array<Real, 3> curlB = interpolateCurlB(
-               perBGrid,
-               dPerBGrid,
-               technicalGrid,
+            const std::array<Real, 3> curlB = interpolateCurlB(fsgrids,
                FieldTracing::fieldTracingParameters.reconstructionCoefficientsCache,
                lfsc[0],lfsc[1],lfsc[2],
                nodes[n].xMapped
@@ -1184,7 +1176,7 @@ namespace SBC {
                / ((nodes[n].parameters[ionosphereParameters::UPMAPPED_BX]*nodes[n].parameters[ionosphereParameters::UPMAPPED_BX]
                   + nodes[n].parameters[ionosphereParameters::UPMAPPED_BY]*nodes[n].parameters[ionosphereParameters::UPMAPPED_BY]
                   + nodes[n].parameters[ionosphereParameters::UPMAPPED_BZ]*nodes[n].parameters[ionosphereParameters::UPMAPPED_BZ])
-               * physicalconstants::MU_0 * technicalGrid.DX
+               * physicalconstants::MU_0 * fsgrids.technicalGrid.DX
             );
 
             // By definition, a downwards current into the ionosphere has a positive FAC value,
@@ -1194,7 +1186,7 @@ namespace SBC {
                FACinput[n] *= -1;
             }
 
-            std::array<Real,3> frac = getFractionalFsGridCellForCoord(technicalGrid,nodes[n].xMapped);
+            std::array<Real,3> frac = getFractionalFsGridCellForCoord(fsgrids.technicalGrid,nodes[n].xMapped);
             for(int c=0; c<3; c++) {
                // Shift by half a cell, as we are sampling volume quantities that are logically located at cell centres.
                if(frac[c] < 0.5) {
@@ -1218,7 +1210,7 @@ namespace SBC {
                      }
 
                      // Only couple to actual simulation cells
-                     if(technicalGrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) {
+                     if(fsgrids.technicalGrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY) {
                         couplingSum += coupling;
                      } else {
                         continue;
@@ -1226,12 +1218,12 @@ namespace SBC {
 
 
                      // Map density, temperature down
-                     Real thisCellRho = momentsGrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::RHOQ) / physicalconstants::CHARGE;
+                     Real thisCellRho = fsgrids.momentsGrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::RHOQ) / physicalconstants::CHARGE;
                      rhoInput[n] += coupling * thisCellRho;
                      temperatureInput[n] += coupling * 1./3. * (
-                        momentsGrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::P_11) +
-                        momentsGrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::P_22) +
-                        momentsGrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::P_33)) / (thisCellRho * physicalconstants::K_B * ion_electron_T_ratio);
+                        fsgrids.momentsGrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::P_11) +
+                        fsgrids.momentsGrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::P_22) +
+                        fsgrids.momentsGrid.get(lfsc[0]+xoffset,lfsc[1]+yoffset,lfsc[2]+zoffset)->at(fsgrids::P_33)) / (thisCellRho * physicalconstants::K_B * ion_electron_T_ratio);
                   }
                }
             }
@@ -2497,9 +2489,7 @@ namespace SBC {
 
    void Ionosphere::applyInitialState(
       dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+      FsGridWrapper& fsgrids,
       Project &project
    ) {
       const vector<CellID>& cells = getLocalCells();
@@ -2792,51 +2782,49 @@ namespace SBC {
     * -- Retain only the normal components of perturbed face B
     */
    Real Ionosphere::fieldSolverBoundaryCondMagneticField(
-      FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+      FsGridWrapper& fsgrids,
       cint i,
       cint j,
       cint k,
       creal dt,
       cuint component
    ) {
-      if (technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) {
+      if (fsgrids.technicalGrid.get(i,j,k)->sysBoundaryLayer == 1) {
          switch(component) {
             case 0:
-               if (  ((technicalGrid.get(i-1,j,k)->SOLVE & compute::BX) == compute::BX)
-                  && ((technicalGrid.get(i+1,j,k)->SOLVE & compute::BX) == compute::BX)
+               if (  ((fsgrids.technicalGrid.get(i-1,j,k)->SOLVE & compute::BX) == compute::BX)
+                  && ((fsgrids.technicalGrid.get(i+1,j,k)->SOLVE & compute::BX) == compute::BX)
                ) {
-                  return 0.5 * (bGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBX) + bGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBX));
-               } else if ((technicalGrid.get(i-1,j,k)->SOLVE & compute::BX) == compute::BX) {
-                  return bGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBX);
-               } else if ((technicalGrid.get(i+1,j,k)->SOLVE & compute::BX) == compute::BX) {
-                  return bGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBX);
+                  return 0.5 * (fsgrids.perBGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBX) + fsgrids.perBGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBX));
+               } else if ((fsgrids.technicalGrid.get(i-1,j,k)->SOLVE & compute::BX) == compute::BX) {
+                  return fsgrids.perBGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBX);
+               } else if ((fsgrids.technicalGrid.get(i+1,j,k)->SOLVE & compute::BX) == compute::BX) {
+                  return fsgrids.perBGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBX);
                } else {
                   Real retval = 0.0;
                   uint nCells = 0;
-                  if ((technicalGrid.get(i,j-1,k)->SOLVE & compute::BX) == compute::BX) {
-                     retval += bGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBX);
+                  if ((fsgrids.technicalGrid.get(i,j-1,k)->SOLVE & compute::BX) == compute::BX) {
+                     retval += fsgrids.perBGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBX);
                      nCells++;
                   }
-                  if ((technicalGrid.get(i,j+1,k)->SOLVE & compute::BX) == compute::BX) {
-                     retval += bGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBX);
+                  if ((fsgrids.technicalGrid.get(i,j+1,k)->SOLVE & compute::BX) == compute::BX) {
+                     retval += fsgrids.perBGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBX);
                      nCells++;
                   }
-                  if ((technicalGrid.get(i,j,k-1)->SOLVE & compute::BX) == compute::BX) {
-                     retval += bGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBX);
+                  if ((fsgrids.technicalGrid.get(i,j,k-1)->SOLVE & compute::BX) == compute::BX) {
+                     retval += fsgrids.perBGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBX);
                      nCells++;
                   }
-                  if ((technicalGrid.get(i,j,k+1)->SOLVE & compute::BX) == compute::BX) {
-                     retval += bGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBX);
+                  if ((fsgrids.technicalGrid.get(i,j,k+1)->SOLVE & compute::BX) == compute::BX) {
+                     retval += fsgrids.perBGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBX);
                      nCells++;
                   }
                   if (nCells == 0) {
                      for (int a=i-1; a<i+2; a++) {
                         for (int b=j-1; b<j+2; b++) {
                            for (int c=k-1; c<k+2; c++) {
-                              if ((technicalGrid.get(a,b,c)->SOLVE & compute::BX) == compute::BX) {
-                                 retval += bGrid.get(a,b,c)->at(fsgrids::bfield::PERBX);
+                              if ((fsgrids.technicalGrid.get(a,b,c)->SOLVE & compute::BX) == compute::BX) {
+                                 retval += fsgrids.perBGrid.get(a,b,c)->at(fsgrids::bfield::PERBX);
                                  nCells++;
                               }
                            }
@@ -2850,39 +2838,39 @@ namespace SBC {
                   return retval / nCells;
                }
             case 1:
-               if (  (technicalGrid.get(i,j-1,k)->SOLVE & compute::BY) == compute::BY
-                  && (technicalGrid.get(i,j+1,k)->SOLVE & compute::BY) == compute::BY
+               if (  (fsgrids.technicalGrid.get(i,j-1,k)->SOLVE & compute::BY) == compute::BY
+                  && (fsgrids.technicalGrid.get(i,j+1,k)->SOLVE & compute::BY) == compute::BY
                ) {
-                  return 0.5 * (bGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBY) + bGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBY));
-               } else if ((technicalGrid.get(i,j-1,k)->SOLVE & compute::BY) == compute::BY) {
-                  return bGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBY);
-               } else if ((technicalGrid.get(i,j+1,k)->SOLVE & compute::BY) == compute::BY) {
-                  return bGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBY);
+                  return 0.5 * (fsgrids.perBGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBY) + fsgrids.perBGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBY));
+               } else if ((fsgrids.technicalGrid.get(i,j-1,k)->SOLVE & compute::BY) == compute::BY) {
+                  return fsgrids.perBGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBY);
+               } else if ((fsgrids.technicalGrid.get(i,j+1,k)->SOLVE & compute::BY) == compute::BY) {
+                  return fsgrids.perBGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBY);
                } else {
                   Real retval = 0.0;
                   uint nCells = 0;
-                  if ((technicalGrid.get(i-1,j,k)->SOLVE & compute::BY) == compute::BY) {
-                     retval += bGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBY);
+                  if ((fsgrids.technicalGrid.get(i-1,j,k)->SOLVE & compute::BY) == compute::BY) {
+                     retval += fsgrids.perBGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBY);
                      nCells++;
                   }
-                  if ((technicalGrid.get(i+1,j,k)->SOLVE & compute::BY) == compute::BY) {
-                     retval += bGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBY);
+                  if ((fsgrids.technicalGrid.get(i+1,j,k)->SOLVE & compute::BY) == compute::BY) {
+                     retval += fsgrids.perBGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBY);
                      nCells++;
                   }
-                  if ((technicalGrid.get(i,j,k-1)->SOLVE & compute::BY) == compute::BY) {
-                     retval += bGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBY);
+                  if ((fsgrids.technicalGrid.get(i,j,k-1)->SOLVE & compute::BY) == compute::BY) {
+                     retval += fsgrids.perBGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBY);
                      nCells++;
                   }
-                  if ((technicalGrid.get(i,j,k+1)->SOLVE & compute::BY) == compute::BY) {
-                     retval += bGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBY);
+                  if ((fsgrids.technicalGrid.get(i,j,k+1)->SOLVE & compute::BY) == compute::BY) {
+                     retval += fsgrids.perBGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBY);
                      nCells++;
                   }
                   if (nCells == 0) {
                      for (int a=i-1; a<i+2; a++) {
                         for (int b=j-1; b<j+2; b++) {
                            for (int c=k-1; c<k+2; c++) {
-                              if ((technicalGrid.get(a,b,c)->SOLVE & compute::BY) == compute::BY) {
-                                 retval += bGrid.get(a,b,c)->at(fsgrids::bfield::PERBY);
+                              if ((fsgrids.technicalGrid.get(a,b,c)->SOLVE & compute::BY) == compute::BY) {
+                                 retval += fsgrids.perBGrid.get(a,b,c)->at(fsgrids::bfield::PERBY);
                                  nCells++;
                               }
                            }
@@ -2896,39 +2884,39 @@ namespace SBC {
                   return retval / nCells;
                }
             case 2:
-               if (  (technicalGrid.get(i,j,k-1)->SOLVE & compute::BZ) == compute::BZ
-                  && (technicalGrid.get(i,j,k+1)->SOLVE & compute::BZ) == compute::BZ
+               if (  (fsgrids.technicalGrid.get(i,j,k-1)->SOLVE & compute::BZ) == compute::BZ
+                  && (fsgrids.technicalGrid.get(i,j,k+1)->SOLVE & compute::BZ) == compute::BZ
                ) {
-                  return 0.5 * (bGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBZ) + bGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBZ));
-               } else if ((technicalGrid.get(i,j,k-1)->SOLVE & compute::BZ) == compute::BZ) {
-                  return bGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBZ);
-               } else if ((technicalGrid.get(i,j,k+1)->SOLVE & compute::BZ) == compute::BZ) {
-                  return bGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBZ);
+                  return 0.5 * (fsgrids.perBGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBZ) + fsgrids.perBGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBZ));
+               } else if ((fsgrids.technicalGrid.get(i,j,k-1)->SOLVE & compute::BZ) == compute::BZ) {
+                  return fsgrids.perBGrid.get(i,j,k-1)->at(fsgrids::bfield::PERBZ);
+               } else if ((fsgrids.technicalGrid.get(i,j,k+1)->SOLVE & compute::BZ) == compute::BZ) {
+                  return fsgrids.perBGrid.get(i,j,k+1)->at(fsgrids::bfield::PERBZ);
                } else {
                   Real retval = 0.0;
                   uint nCells = 0;
-                  if ((technicalGrid.get(i-1,j,k)->SOLVE & compute::BZ) == compute::BZ) {
-                     retval += bGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBZ);
+                  if ((fsgrids.technicalGrid.get(i-1,j,k)->SOLVE & compute::BZ) == compute::BZ) {
+                     retval += fsgrids.perBGrid.get(i-1,j,k)->at(fsgrids::bfield::PERBZ);
                      nCells++;
                   }
-                  if ((technicalGrid.get(i+1,j,k)->SOLVE & compute::BZ) == compute::BZ) {
-                     retval += bGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBZ);
+                  if ((fsgrids.technicalGrid.get(i+1,j,k)->SOLVE & compute::BZ) == compute::BZ) {
+                     retval += fsgrids.perBGrid.get(i+1,j,k)->at(fsgrids::bfield::PERBZ);
                      nCells++;
                   }
-                  if ((technicalGrid.get(i,j-1,k)->SOLVE & compute::BZ) == compute::BZ) {
-                     retval += bGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBZ);
+                  if ((fsgrids.technicalGrid.get(i,j-1,k)->SOLVE & compute::BZ) == compute::BZ) {
+                     retval += fsgrids.perBGrid.get(i,j-1,k)->at(fsgrids::bfield::PERBZ);
                      nCells++;
                   }
-                  if ((technicalGrid.get(i,j+1,k)->SOLVE & compute::BZ) == compute::BZ) {
-                     retval += bGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBZ);
+                  if ((fsgrids.technicalGrid.get(i,j+1,k)->SOLVE & compute::BZ) == compute::BZ) {
+                     retval += fsgrids.perBGrid.get(i,j+1,k)->at(fsgrids::bfield::PERBZ);
                      nCells++;
                   }
                   if (nCells == 0) {
                      for (int a=i-1; a<i+2; a++) {
                         for (int b=j-1; b<j+2; b++) {
                            for (int c=k-1; c<k+2; c++) {
-                              if ((technicalGrid.get(a,b,c)->SOLVE & compute::BZ) == compute::BZ) {
-                                 retval += bGrid.get(a,b,c)->at(fsgrids::bfield::PERBZ);
+                              if ((fsgrids.technicalGrid.get(a,b,c)->SOLVE & compute::BZ) == compute::BZ) {
+                                 retval += fsgrids.perBGrid.get(a,b,c)->at(fsgrids::bfield::PERBZ);
                                  nCells++;
                               }
                            }
@@ -2951,8 +2939,8 @@ namespace SBC {
          for (int a=i-1; a<i+2; a++) {
             for (int b=j-1; b<j+2; b++) {
                for (int c=k-1; c<k+2; c++) {
-                  if (technicalGrid.get(a,b,c)->sysBoundaryLayer == 1) {
-                     retval += bGrid.get(a,b,c)->at(fsgrids::bfield::PERBX + component);
+                  if (fsgrids.technicalGrid.get(a,b,c)->sysBoundaryLayer == 1) {
+                     retval += fsgrids.perBGrid.get(a,b,c)->at(fsgrids::bfield::PERBX + component);
                      nCells++;
                   }
                }
@@ -3470,8 +3458,7 @@ namespace SBC {
    void Ionosphere::getFaces(bool *faces) {}
 
    void Ionosphere::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-                                FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-                                FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                FsGridWrapper& fsgrids,
                                 creal t) {}
 
    uint Ionosphere::getIndex() const {return sysboundarytype::IONOSPHERE;}

--- a/sysboundary/ionosphere.h
+++ b/sysboundary/ionosphere.h
@@ -225,13 +225,7 @@ namespace SBC {
 
       // Map field-aligned currents, density and temperature
       // down from the simulation boundary onto this grid
-      void mapDownBoundaryData(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,                                                                                                                                                                                                                                
-         FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> & dPerBGrid,
-         FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> & momentsGrid,
-         FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> & volGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid
-      );
+      void mapDownBoundaryData(FsGridWrapper& fsgrids);
       
       // Returns the surface area of one element on the sphere
       Real elementArea(uint32_t elementIndex) {
@@ -331,15 +325,11 @@ namespace SBC {
                                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid);
       virtual void applyInitialState(
          dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+         FsGridWrapper& fsgrids,
          Project &project
       );
       virtual Real fieldSolverBoundaryCondMagneticField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+         FsGridWrapper& fsgrids,
          cint i,
          cint j,
          cint k,
@@ -395,8 +385,7 @@ namespace SBC {
       );
       virtual void updateState(
          dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-         FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+         FsGridWrapper& fsgrids,
          creal t
       );
       

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -243,9 +243,7 @@ namespace SBC {
    
    void Outflow::applyInitialState(
       dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-      FsGrid< array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-      FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+      FsGridWrapper& fsgrids,
       Project &project
    ) {
       const vector<CellID>& cells = getLocalCells();
@@ -285,14 +283,11 @@ namespace SBC {
    }
 
    void Outflow::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-                             FsGrid<array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                             FsGridWrapper& fsgrids,
                              creal t) {}
 
    Real Outflow::fieldSolverBoundaryCondMagneticField(
-      FsGrid< array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-      FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+      FsGridWrapper& fsgrids,
       cint i,
       cint j,
       cint k,
@@ -301,13 +296,13 @@ namespace SBC {
    ) {
       switch(component) {
       case 0:
-         return fieldBoundaryCopyFromSolvingNbrMagneticField(bGrid, technicalGrid, i, j, k, component, compute::BX);
+         return fieldBoundaryCopyFromSolvingNbrMagneticField(fsgrids.perBGrid, fsgrids.technicalGrid, i, j, k, component, compute::BX);
          break;
       case 1:
-         return fieldBoundaryCopyFromSolvingNbrMagneticField(bGrid, technicalGrid, i, j, k, component, compute::BY);
+         return fieldBoundaryCopyFromSolvingNbrMagneticField(fsgrids.perBGrid, fsgrids.technicalGrid, i, j, k, component, compute::BY);
          break;
       case 2:
-         return fieldBoundaryCopyFromSolvingNbrMagneticField(bGrid, technicalGrid, i, j, k, component, compute::BZ);
+         return fieldBoundaryCopyFromSolvingNbrMagneticField(fsgrids.perBGrid, fsgrids.technicalGrid, i, j, k, component, compute::BZ);
          break;
       default:
          return 0.0;

--- a/sysboundary/outflow.h
+++ b/sysboundary/outflow.h
@@ -67,21 +67,16 @@ namespace SBC {
                                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid);
       virtual void applyInitialState(
          dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+         FsGridWrapper& fsgrids,
          Project &project
       );
       virtual void updateState(
          dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-         FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+         FsGridWrapper& fsgrids,
          creal t
       );
       virtual Real fieldSolverBoundaryCondMagneticField(
-         FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-         FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+         FsGridWrapper& fsgrids,
          cint i,
          cint j,
          cint k,

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -610,9 +610,7 @@ void SysBoundary::classifyCells(dccrg::Dccrg<spatial_cell::SpatialCell, dccrg::C
  * \retval success If true, the application of all system boundary states succeeded.
  */
 void SysBoundary::applyInitialState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-                                    FsGrid<fsgrids::technical, FS_STENCIL_WIDTH>&technicalGrid,
-                                    FsGrid<array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-                                    FsGrid<array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                                    FsGridWrapper& fsgrids,
                                     Project& project) {
 
    list<SBC::SysBoundaryCondition*>::iterator it;
@@ -623,18 +621,17 @@ void SysBoundary::applyInitialState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_G
       ) {
          continue;
       }
-      (*it)->applyInitialState(mpiGrid, technicalGrid, perBGrid, BgBGrid, project);
+      (*it)->applyInitialState(mpiGrid, fsgrids, project);
    }
 }
 
 void SysBoundary::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-                              FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-                              FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                              FsGridWrapper& fsgrids,
                               creal t) {
    if (isAnyDynamic()) {
       for(auto& b : sysBoundaries) {
          if (b->isDynamic()) {
-            b->updateState(mpiGrid, perBGrid, BgBGrid, t);
+            b->updateState(mpiGrid, fsgrids, t);
          }
       }
    }

--- a/sysboundary/sysboundary.h
+++ b/sysboundary/sysboundary.h
@@ -74,14 +74,11 @@ class SysBoundary {
                      FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid);
    void applyInitialState(
                           dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-                          FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-                          FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-                          FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                          FsGridWrapper& fsgrids,
                           Project& project
                          );
    void updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry> &mpiGrid,
-                    FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> &perBGrid,
-                    FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                    FsGridWrapper& fsgrids,
                     creal t);
    void applySysBoundaryVlasovConditions(dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, creal& t, const bool calculate_V_moments);
    unsigned int size() const;

--- a/sysboundary/sysboundarycondition.h
+++ b/sysboundary/sysboundarycondition.h
@@ -70,21 +70,16 @@ namespace SBC {
                                         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid)=0;
          virtual void applyInitialState(
             dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & perBGrid,
-            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+            FsGridWrapper& fsgrids,
             Project &project
          )=0;
          virtual void updateState(
             dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry> &mpiGrid,
-            FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> &perBGrid,
-            FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+            FsGridWrapper& fsgrids,
             creal t
          )=0;
          virtual Real fieldSolverBoundaryCondMagneticField(
-            FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> & bGrid,
-            FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> & bgbGrid,
-            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
+            FsGridWrapper& fsgrids,
             cint i,
             cint j,
             cint k,

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -409,46 +409,17 @@ int simulate(int argn,char* args[]) {
                                   sysBoundaryContainer.isPeriodic(1),
                                   sysBoundaryContainer.isPeriodic(2)};
 
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> perBGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> perBDt2Grid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> EGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, FS_STENCIL_WIDTH> EDt2Grid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::ehall::N_EHALL>, FS_STENCIL_WIDTH> EHallGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> EGradPeGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::egradpe::N_EGRADPE>, FS_STENCIL_WIDTH> EGradPeDt2Grid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> momentsGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::moments::N_MOMENTS>, FS_STENCIL_WIDTH> momentsDt2Grid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::dperb::N_DPERB>, FS_STENCIL_WIDTH> dPerBGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> dMomentsGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::dmoments::N_DMOMENTS>, FS_STENCIL_WIDTH> dMomentsDt2Grid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> BgBGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< std::array<Real, fsgrids::volfields::N_VOL>, FS_STENCIL_WIDTH> volGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-   FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> technicalGrid(fsGridDimensions, MPI_COMM_WORLD, periodicity,P::manualFsGridDecomposition);
-
-   // Set DX, DY and DZ
-   // TODO: This is currently just taking the values from cell 1, and assuming them to be
-   // constant throughout the simulation.
-   perBGrid.DX = perBDt2Grid.DX = EGrid.DX = EDt2Grid.DX = EHallGrid.DX = EGradPeGrid.DX = EGradPeDt2Grid.DX = momentsGrid.DX
-      = momentsDt2Grid.DX = dPerBGrid.DX = dMomentsGrid.DX = dMomentsDt2Grid.DX = BgBGrid.DX = volGrid.DX = technicalGrid.DX
-      = P::dx_ini / pow(2, P::amrMaxSpatialRefLevel);
-   perBGrid.DY = perBDt2Grid.DY = EGrid.DY = EDt2Grid.DY = EHallGrid.DY = EGradPeGrid.DY = EGradPeDt2Grid.DY = momentsGrid.DY
-      = momentsDt2Grid.DY = dPerBGrid.DY = dMomentsGrid.DY = dMomentsDt2Grid.DY = BgBGrid.DY = volGrid.DY = technicalGrid.DY
-      = P::dy_ini / pow(2, P::amrMaxSpatialRefLevel);
-   perBGrid.DZ = perBDt2Grid.DZ = EGrid.DZ = EDt2Grid.DZ = EHallGrid.DZ = EGradPeGrid.DZ = EGradPeDt2Grid.DZ = momentsGrid.DZ
-      = momentsDt2Grid.DZ = dPerBGrid.DZ = dMomentsGrid.DZ = dMomentsDt2Grid.DZ = BgBGrid.DZ = volGrid.DZ = technicalGrid.DZ
-      = P::dz_ini / pow(2, P::amrMaxSpatialRefLevel);
-   // Set the physical start (lower left corner) X, Y, Z
-   perBGrid.physicalGlobalStart = perBDt2Grid.physicalGlobalStart = EGrid.physicalGlobalStart = EDt2Grid.physicalGlobalStart
-      = EHallGrid.physicalGlobalStart = EGradPeGrid.physicalGlobalStart = EGradPeDt2Grid.physicalGlobalStart = momentsGrid.physicalGlobalStart
-      = momentsDt2Grid.physicalGlobalStart = dPerBGrid.physicalGlobalStart = dMomentsGrid.physicalGlobalStart = dMomentsDt2Grid.physicalGlobalStart
-      = BgBGrid.physicalGlobalStart = volGrid.physicalGlobalStart = technicalGrid.physicalGlobalStart
-      = {P::xmin, P::ymin, P::zmin};
+   FsGridWrapper fsgrids(fsGridDimensions, MPI_COMM_WORLD, periodicity, 
+         { P::dx_ini / pow(2, P::amrMaxSpatialRefLevel),
+          P::dy_ini / pow(2, P::amrMaxSpatialRefLevel),
+          P::dz_ini / pow(2, P::amrMaxSpatialRefLevel) },
+          {P::xmin, P::ymin, P::zmin});
 
    // Checking that spatial cells are cubic, otherwise field solver is incorrect (cf. derivatives in E, Hall term)
    constexpr Real uniformTolerance=1e-3;
-   if ((abs((technicalGrid.DX - technicalGrid.DY) / technicalGrid.DX) >uniformTolerance) ||
-       (abs((technicalGrid.DX - technicalGrid.DZ) / technicalGrid.DX) >uniformTolerance) ||
-       (abs((technicalGrid.DY - technicalGrid.DZ) / technicalGrid.DY) >uniformTolerance)) {
+   if ((abs((fsgrids.technicalGrid.DX - fsgrids.technicalGrid.DY) / fsgrids.technicalGrid.DX) >uniformTolerance) ||
+       (abs((fsgrids.technicalGrid.DX - fsgrids.technicalGrid.DZ) / fsgrids.technicalGrid.DX) >uniformTolerance) ||
+       (abs((fsgrids.technicalGrid.DY - fsgrids.technicalGrid.DZ) / fsgrids.technicalGrid.DY) >uniformTolerance)) {
       if (myRank == MASTER_RANK) {
          std::cerr << "WARNING: Your spatial cells seem not to be cubic. The simulation will now abort!" << std::endl;
       }
@@ -470,15 +441,7 @@ int simulate(int argn,char* args[]) {
       argn,
       args,
       mpiGrid,
-      perBGrid,
-      BgBGrid,
-      momentsGrid,
-      momentsDt2Grid,
-      dMomentsGrid,
-      EGrid,
-      EGradPeGrid,
-      volGrid,
-      technicalGrid,
+      fsgrids,
       sysBoundaryContainer,
       *project
    );
@@ -488,7 +451,7 @@ int simulate(int argn,char* args[]) {
    // because we need a copy of the value from initialization in both perBGrid and perBDt2Grid and it isn't
    // touched as we are in boundary cells for components that aren't solved. We do a straight full copy instead
    // of looping and detecting boundary types here.
-   perBDt2Grid.copyData(perBGrid);
+   fsgrids.perBDt2Grid.copyData(fsgrids.perBGrid);
 
    const std::vector<CellID>& cells = getLocalCells();
    
@@ -515,7 +478,7 @@ int simulate(int argn,char* args[]) {
       logFile << "Writing out full BGB components and derivatives and exiting." << endl << writeVerbose;
 
       // initialize the communicators so we can write out ionosphere grid metadata.
-      SBC::ionosphereGrid.updateIonosphereCommunicator(mpiGrid, technicalGrid);
+      SBC::ionosphereGrid.updateIonosphereCommunicator(mpiGrid, fsgrids.technicalGrid);
 
       P::systemWriteDistributionWriteStride.push_back(0);
       P::systemWriteName.push_back("bgb");
@@ -531,16 +494,7 @@ int simulate(int argn,char* args[]) {
 
       const bool writeGhosts = true;
       if( writeGrid(mpiGrid,
-            perBGrid,
-            EGrid,
-            EHallGrid,
-            EGradPeGrid,
-            momentsGrid,
-            dPerBGrid,
-            dMomentsGrid,
-            BgBGrid,
-            volGrid,
-            technicalGrid,
+            fsgrids,
             version,
             config,
             &outputReducer,
@@ -560,21 +514,21 @@ int simulate(int argn,char* args[]) {
       logFile.close();
       if (P::diagnosticInterval != 0) diagnostic.close();
       
-      perBGrid.finalize();
-      perBDt2Grid.finalize();
-      EGrid.finalize();
-      EDt2Grid.finalize();
-      EHallGrid.finalize();
-      EGradPeGrid.finalize();
-      EGradPeDt2Grid.finalize();
-      momentsGrid.finalize();
-      momentsDt2Grid.finalize();
-      dPerBGrid.finalize();
-      dMomentsGrid.finalize();
-      dMomentsDt2Grid.finalize();
-      BgBGrid.finalize();
-      volGrid.finalize();
-      technicalGrid.finalize();
+      fsgrids.perBGrid.finalize();
+      fsgrids.perBDt2Grid.finalize();
+      fsgrids.EGrid.finalize();
+      fsgrids.EDt2Grid.finalize();
+      fsgrids.EHallGrid.finalize();
+      fsgrids.EGradPeGrid.finalize();
+      fsgrids.EGradPeDt2Grid.finalize();
+      fsgrids.momentsGrid.finalize();
+      fsgrids.momentsDt2Grid.finalize();
+      fsgrids.dPerBGrid.finalize();
+      fsgrids.dMomentsGrid.finalize();
+      fsgrids.dMomentsDt2Grid.finalize();
+      fsgrids.BgBGrid.finalize();
+      fsgrids.volGrid.finalize();
+      fsgrids.technicalGrid.finalize();
 
       MPI_Finalize();
       return 0;
@@ -585,50 +539,29 @@ int simulate(int argn,char* args[]) {
    // At restart, all we need at this stage has been read from the restart, the rest will be recomputed in due time.
    if(P::isRestart == false) {
       propagateFields(
-         perBGrid,
-         perBDt2Grid,
-         EGrid,
-         EDt2Grid,
-         EHallGrid,
-         EGradPeGrid,
-         EGradPeDt2Grid,
-         momentsGrid,
-         momentsDt2Grid,
-         dPerBGrid,
-         dMomentsGrid,
-         dMomentsDt2Grid,
-         BgBGrid,
-         volGrid,
-         technicalGrid,
+         fsgrids,
          sysBoundaryContainer, 0.0, 1.0
       );
    }
 
    phiprof::Timer getFieldsTimer {"getFieldsFromFsGrid"};
-   volGrid.updateGhostCells();
-   getFieldsFromFsGrid(volGrid, BgBGrid, EGradPeGrid, dMomentsGrid, technicalGrid, mpiGrid, cells);
+   fsgrids.volGrid.updateGhostCells();
+   getFieldsFromFsGrid(fsgrids, mpiGrid, cells);
    getFieldsTimer.stop();
 
    // Build communicator for ionosphere solving
-   SBC::ionosphereGrid.updateIonosphereCommunicator(mpiGrid, technicalGrid);
+   SBC::ionosphereGrid.updateIonosphereCommunicator(mpiGrid, fsgrids.technicalGrid);
    // If not a restart, perBGrid and dPerBGrid are up to date after propagateFields just above. Otherwise, we should compute them.
    if(P::isRestart) {
       calculateDerivativesSimple(
-         perBGrid,
-         perBDt2Grid,
-         momentsGrid,
-         momentsDt2Grid,
-         dPerBGrid,
-         dMomentsGrid,
-         dMomentsDt2Grid,
-         technicalGrid,
+         fsgrids,
          sysBoundaryContainer,
          RK_ORDER1, // Update and compute on non-dt2 grids.
          false // Don't communicate moments, they are not needed here.
       );
-      dPerBGrid.updateGhostCells();
+      fsgrids.dPerBGrid.updateGhostCells();
    }
-   FieldTracing::calculateIonosphereFsgridCoupling(technicalGrid, perBGrid, dPerBGrid, SBC::ionosphereGrid.nodes, SBC::Ionosphere::radius);
+   FieldTracing::calculateIonosphereFsgridCoupling(fsgrids, SBC::ionosphereGrid.nodes, SBC::Ionosphere::radius);
    SBC::ionosphereGrid.initSolver(!P::isRestart); // If it is a restart we do not want to zero out everything
    if(SBC::Ionosphere::couplingInterval > 0 && P::isRestart) {
       SBC::Ionosphere::solveCount = floor(P::t / SBC::Ionosphere::couplingInterval)+1;
@@ -654,7 +587,7 @@ int simulate(int argn,char* args[]) {
       // Calculate these so refinement parameters can be tuned based on the vlsv
       calculateScaledDeltasSimple(mpiGrid);
 
-      FieldTracing::reduceData(technicalGrid, perBGrid, dPerBGrid, mpiGrid, SBC::ionosphereGrid.nodes); /*!< Call the reductions (e.g. field tracing) */
+      FieldTracing::reduceData(fsgrids, mpiGrid, SBC::ionosphereGrid.nodes); /*!< Call the reductions (e.g. field tracing) */
       
       phiprof::Timer timer {"write-initial-state"};
       
@@ -674,16 +607,7 @@ int simulate(int argn,char* args[]) {
 
       const bool writeGhosts = true;
       if( writeGrid(mpiGrid,
-            perBGrid, // TODO: Merge all the fsgrids passed here into one meta-object
-            EGrid,
-            EHallGrid,
-            EGradPeGrid,
-            momentsGrid,
-            dPerBGrid,
-            dMomentsGrid,
-            BgBGrid,
-            volGrid,
-            technicalGrid,
+            fsgrids,
             version,
             config,
             &outputReducer,
@@ -707,7 +631,7 @@ int simulate(int argn,char* args[]) {
    if (P::isRestart == false) {
       //compute new dt
       phiprof::Timer computeDtimer {"compute-dt"};
-      computeNewTimeStep(mpiGrid, technicalGrid, newDt, dtIsChanged);
+      computeNewTimeStep(mpiGrid, fsgrids.technicalGrid, newDt, dtIsChanged);
       if (P::dynamicTimestep == true && dtIsChanged == true) {
          // Only actually update the timestep if dynamicTimestep is on
          P::dt=newDt;
@@ -890,22 +814,13 @@ int simulate(int argn,char* args[]) {
             // Calculate these so refinement parameters can be tuned based on the vlsv
             calculateScaledDeltasSimple(mpiGrid);
             
-            FieldTracing::reduceData(technicalGrid, perBGrid, dPerBGrid, mpiGrid, SBC::ionosphereGrid.nodes); /*!< Call the reductions (e.g. field tracing) */
+            FieldTracing::reduceData(fsgrids, mpiGrid, SBC::ionosphereGrid.nodes); /*!< Call the reductions (e.g. field tracing) */
             
             phiprof::Timer writeSysTimer {"write-system"};
             logFile << "(IO): Writing spatial cell and reduced system data to disk, tstep = " << P::tstep << " t = " << P::t << endl << writeVerbose;
             const bool writeGhosts = true;
             if(writeGrid(mpiGrid,
-               perBGrid, // TODO: Merge all the fsgrids passed here into one meta-object
-               EGrid,
-               EHallGrid,
-               EGradPeGrid,
-               momentsGrid,
-               dPerBGrid,
-               dMomentsGrid,
-               BgBGrid,
-               volGrid,
-               technicalGrid,
+               fsgrids,
                version,
                config,
                &outputReducer,
@@ -984,16 +899,7 @@ int simulate(int argn,char* args[]) {
             logFile << "(IO): Writing restart data to disk, tstep = " << P::tstep << " t = " << P::t << endl << writeVerbose;
          //Write the restart:
          if( writeRestart(mpiGrid,
-                  perBGrid, // TODO: Merge all the fsgrids passed here into one meta-object
-                  EGrid,
-                  EHallGrid,
-                  EGradPeGrid,
-                  momentsGrid,
-                  dPerBGrid,
-                  dMomentsGrid,
-                  BgBGrid,
-                  volGrid,
-                  technicalGrid,
+                  fsgrids,
                   version,
                   config,
                   outputReducer,"restart",(uint)P::t,P::restartStripeFactor) == false ) {
@@ -1030,14 +936,14 @@ int simulate(int argn,char* args[]) {
          if (refineNow || (!dtIsChanged && P::adaptRefinement && P::tstep % (P::rebalanceInterval * P::refineCadence) == 0 && P::t > P::refineAfter)) { 
             logFile << "(AMR): Adapting refinement!"  << endl << writeVerbose;
             refineNow = false;
-            if (!adaptRefinement(mpiGrid, technicalGrid, sysBoundaryContainer, *project)) {
+            if (!adaptRefinement(mpiGrid, fsgrids.technicalGrid, sysBoundaryContainer, *project)) {
                // OOM, rebalance and try again
                logFile << "(LB) AMR rebalancing with heavier refinement weights." << endl;
                globalflags::bailingOut = false; // Reset this
                for (auto id : mpiGrid.get_local_cells_to_refine()) {
                   mpiGrid[id]->parameters[CellParams::LBWEIGHTCOUNTER] *= 8.0;
                }
-               balanceLoad(mpiGrid, sysBoundaryContainer, technicalGrid);
+               balanceLoad(mpiGrid, sysBoundaryContainer, fsgrids.technicalGrid);
                // We can /= 8.0 now as cells have potentially migrated. Go back to block-based count for now.
                for (auto id : mpiGrid.get_local_cells_to_refine()) {
                   mpiGrid[id]->parameters[CellParams::LBWEIGHTCOUNTER] = 0;
@@ -1047,7 +953,7 @@ int simulate(int argn,char* args[]) {
                }
 
                mpiGrid.cancel_refining();
-               if (!adaptRefinement(mpiGrid, technicalGrid, sysBoundaryContainer, *project)) {
+               if (!adaptRefinement(mpiGrid, fsgrids.technicalGrid, sysBoundaryContainer, *project)) {
                   for (auto id : mpiGrid.get_local_cells_to_refine()) {
                      mpiGrid[id]->parameters[CellParams::LBWEIGHTCOUNTER] *= 8.0;
                   }
@@ -1063,7 +969,7 @@ int simulate(int argn,char* args[]) {
             calculateAcceleration(mpiGrid,0.0);
          }
          // This now uses the block-based count just copied between the two refinement calls above.
-         balanceLoad(mpiGrid, sysBoundaryContainer, technicalGrid);
+         balanceLoad(mpiGrid, sysBoundaryContainer, fsgrids.technicalGrid);
          addTimedBarrier("barrier-end-load-balance");
          logFile << "(LB): ... done!"  << endl << writeVerbose;
          P::prepareForRebalance = false;
@@ -1072,7 +978,7 @@ int simulate(int argn,char* args[]) {
 
          // Make sure the ionosphere communicator is up-to-date, in case inner boundary cells
          // moved.
-         SBC::ionosphereGrid.updateIonosphereCommunicator(mpiGrid, technicalGrid);
+         SBC::ionosphereGrid.updateIonosphereCommunicator(mpiGrid, fsgrids.technicalGrid);
       }
       
       //get local cells
@@ -1091,7 +997,7 @@ int simulate(int argn,char* args[]) {
       //simulation loop
       // FIXME what if dt changes at a restart??
       if(P::dynamicTimestep  && P::tstep > P::tstep_min) {
-         computeNewTimeStep(mpiGrid, technicalGrid, newDt, dtIsChanged);
+         computeNewTimeStep(mpiGrid, fsgrids.technicalGrid, newDt, dtIsChanged);
          addTimedBarrier("barrier-check-dt");
          if(dtIsChanged) {
             phiprof::Timer updateDtimer {"update-dt"};
@@ -1132,7 +1038,7 @@ int simulate(int argn,char* args[]) {
       // Update boundary condition states (time-varying)
       if (P::propagateVlasovTranslation || P::propagateVlasovAcceleration) {
          phiprof::Timer timer {"Update system boundaries (Vlasov pre-translation)"};
-         sysBoundaryContainer.updateState(mpiGrid, perBGrid, BgBGrid, P::t + 0.5 * P::dt);
+         sysBoundaryContainer.updateState(mpiGrid, fsgrids, P::t + 0.5 * P::dt);
          timer.stop();
          addTimedBarrier("barrier-boundary-conditions");
       }
@@ -1177,27 +1083,13 @@ int simulate(int argn,char* args[]) {
 
          phiprof::Timer couplingInTimer {"fsgrid-coupling-in"};
          // Copy moments over into the fsgrid.
-         //setupTechnicalFsGrid(mpiGrid, cells, technicalGrid);
-         feedMomentsIntoFsGrid(mpiGrid, cells, momentsGrid, technicalGrid, false);
-         feedMomentsIntoFsGrid(mpiGrid, cells, momentsDt2Grid, technicalGrid, true);
+         //setupTechnicalFsGrid(mpiGrid, cells, fsgrids.technicalGrid);
+         feedMomentsIntoFsGrid(mpiGrid, cells, fsgrids, false);
+         feedMomentsIntoFsGrid(mpiGrid, cells, fsgrids, true);
          couplingInTimer.stop();
          
          propagateFields(
-            perBGrid,
-            perBDt2Grid,
-            EGrid,
-            EDt2Grid,
-            EHallGrid,
-            EGradPeGrid,
-            EGradPeDt2Grid,
-            momentsGrid,
-            momentsDt2Grid,
-            dPerBGrid,
-            dMomentsGrid,
-            dMomentsDt2Grid,
-            BgBGrid,
-            volGrid,
-            technicalGrid,
+            fsgrids,
             sysBoundaryContainer,
             P::dt,
             P::fieldSolverSubcycles
@@ -1205,9 +1097,9 @@ int simulate(int argn,char* args[]) {
 
          phiprof::Timer getFieldsTimer {"getFieldsFromFsGrid"};
          // Copy results back from fsgrid.
-         volGrid.updateGhostCells();
-         technicalGrid.updateGhostCells();
-         getFieldsFromFsGrid(volGrid, BgBGrid, EGradPeGrid, dMomentsGrid, technicalGrid, mpiGrid, cells);
+         fsgrids.volGrid.updateGhostCells();
+         fsgrids.technicalGrid.updateGhostCells();
+         getFieldsFromFsGrid(fsgrids, mpiGrid, cells);
          getFieldsTimer.stop();
          propagateTimer.stop(cells.size(),"SpatialCells");
          addTimedBarrier("barrier-after-field-solver");
@@ -1222,8 +1114,8 @@ int simulate(int argn,char* args[]) {
       // perBGrid was ghost-updated before derivatives were computed in the field solver.
       // dPerBGrid was updated before the electric fields.
       if(SBC::ionosphereGrid.nodes.size() > 0 && ((P::t > SBC::Ionosphere::solveCount * SBC::Ionosphere::couplingInterval && SBC::Ionosphere::couplingInterval > 0) || SBC::Ionosphere::couplingInterval == 0)) {
-         FieldTracing::calculateIonosphereFsgridCoupling(technicalGrid, perBGrid, dPerBGrid, SBC::ionosphereGrid.nodes, SBC::Ionosphere::radius);
-         SBC::ionosphereGrid.mapDownBoundaryData(perBGrid, dPerBGrid, momentsGrid, volGrid, technicalGrid);
+         FieldTracing::calculateIonosphereFsgridCoupling(fsgrids, SBC::ionosphereGrid.nodes, SBC::Ionosphere::radius);
+         SBC::ionosphereGrid.mapDownBoundaryData(fsgrids);
          SBC::ionosphereGrid.calculateConductivityTensor(SBC::Ionosphere::F10_7, SBC::Ionosphere::recombAlpha, SBC::Ionosphere::backgroundIonisation);
 
          // Solve ionosphere
@@ -1286,7 +1178,7 @@ int simulate(int argn,char* args[]) {
       propagateTimer.stop(computedCells,"Cells");
       
       phiprof::Timer endStepTimer {"Project endTimeStep"};
-      project->hook(hook::END_OF_TIME_STEP, mpiGrid, perBGrid);
+      project->hook(hook::END_OF_TIME_STEP, mpiGrid, fsgrids);
       endStepTimer.stop();
 
       // Check timestep


### PR DESCRIPTION
In order to de-bloat many function signatures, and enable possible separation-of-concerns looping constructs that can simply operate on all fsgrids.

This is a massive change, touching basically all files that have anything to do with the fields, of course. But the code looks somewhat nicer afterwards!

Things to still reconsider:
 - The ```FsGridWrapper``` struct is now defined in the object_wrapper.h source file. Should it rather move to, say, fs_common.h?
 - Now that all grids are typically accessed as ```fsgrids.somethingGrid```, should they all be renamed to ```fsgrids.something```? Otherwise we are in the department of redundancy department.