### PR TITLE
Fix a broken error message in pencil construction.

### DIFF
--- a/vlasovsolver/cpu_trans_pencils.cpp
+++ b/vlasovsolver/cpu_trans_pencils.cpp
@@ -601,7 +601,7 @@ void computeSpatialSourceCellsForPencil(const dccrg::Dccrg<SpatialCell,dccrg::Ca
             const int diff = tc->SpatialCell::parameters[CellParams::REFINEMENT_LEVEL] - path.size();
             if (diff>0) {
                // Undefined behaviour! Cell is smaller than pencil (higher reflevel than path size)
-               std::cerr<<"Error in path size to cell size: __FILE__:__LINE__"<<std::endl;
+               std::cerr<<"Error in path size to cell size: " << __FILE__ << ":" << __LINE__ << std::endl;
                targetRatios[i] = 0.0;
             } else {
                const int ratio = 1 << -diff;


### PR DESCRIPTION
This triggered in BSC's tests, and they were confused by it. Interestingly, it had never triggered for us. Weird weird.