### PR TITLE
Periodically overwriting restarts

### DIFF
--- a/common.h
+++ b/common.h
@@ -527,8 +527,8 @@ template<typename T> inline int sign(const T& value) {
  */
 struct globalflags {
    static int bailingOut; /*!< Global flag raised to true if a run bailout (write restart if requested/set and stop the simulation peacefully) is needed. */
-   static bool writeRestart; /*!< Global flag raised to true if a restart writing is needed (manually triggered). NOTE: used only by MASTER_RANK in vlasiator.cpp. */
-   static bool writeRecover; /*!< Global flag raised to true if a recover writing is needed (manually triggered). NOTE: used only by MASTER_RANK in vlasiator.cpp. */
+   static bool writeRestart; /*!< Global flag raised to true if a restart writing is needed. NOTE: used only by MASTER_RANK in vlasiator.cpp. */
+   static bool writeRecover; /*!< Global flag raised to true if a recover writing is needed. NOTE: used only by MASTER_RANK in vlasiator.cpp. */
    static bool balanceLoad; /*!< Global flag raised to true if a load balancing is needed. NOTE: used only by MASTER_RANK in vlasiator.cpp. */
    static bool doRefine; /*!< Global flag raised to true if a re-refine is needed. NOTE: used only by MASTER_RANK in vlasiator.cpp. */
    static bool ionosphereJustSolved; /*!< Flag used to notify that the ionosphere has been freshly solved, used to check whether the Vlasov boundary/bulk forcing need updating. */

--- a/common.h
+++ b/common.h
@@ -527,7 +527,8 @@ template<typename T> inline int sign(const T& value) {
  */
 struct globalflags {
    static int bailingOut; /*!< Global flag raised to true if a run bailout (write restart if requested/set and stop the simulation peacefully) is needed. */
-   static bool writeRestart; /*!< Global flag raised to true if a restart writing is needed (without bailout). NOTE: used only by MASTER_RANK in vlasiator.cpp. */
+   static bool writeRestart; /*!< Global flag raised to true if a restart writing is needed (manually triggered). NOTE: used only by MASTER_RANK in vlasiator.cpp. */
+   static bool writeRecover; /*!< Global flag raised to true if a recover writing is needed (manually triggered). NOTE: used only by MASTER_RANK in vlasiator.cpp. */
    static bool balanceLoad; /*!< Global flag raised to true if a load balancing is needed. NOTE: used only by MASTER_RANK in vlasiator.cpp. */
    static bool doRefine; /*!< Global flag raised to true if a re-refine is needed. NOTE: used only by MASTER_RANK in vlasiator.cpp. */
    static bool ionosphereJustSolved; /*!< Flag used to notify that the ionosphere has been freshly solved, used to check whether the Vlasov boundary/bulk forcing need updating. */

--- a/common.h
+++ b/common.h
@@ -534,6 +534,17 @@ struct globalflags {
    static bool ionosphereJustSolved; /*!< Flag used to notify that the ionosphere has been freshly solved, used to check whether the Vlasov boundary/bulk forcing need updating. */
 };
 
+namespace donow {
+   enum {
+      SAVE,
+      DORC,
+      DOLB,
+      DOMR,
+      N_DONOW
+   };
+}
+
+
 /*!
  * Name space for flags going into the project hook function.
  */

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -92,6 +92,17 @@ void checkExternalCommands() {
       rename("SAVE", newName);
       return;
    }
+   if(stat("RECO", &tempStat) == 0) {
+      cerr << "Received an external RECO command. Writing a recover file." << endl;
+      globalflags::writeRecover = true;
+      char newName[80];
+      // Get the current time.
+      const time_t rawTime = time(NULL);
+      const struct tm * timeInfo = localtime(&rawTime);
+      strftime(newName, 80, "RECO_%F_%H-%M-%S", timeInfo);
+      rename("RECO", newName);
+      return;
+   }
    if(stat("DOLB", &tempStat) == 0) {
       cerr << "Received an external DOLB command. Balancing load." << endl;
       globalflags::balanceLoad = true;

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -82,7 +82,7 @@ void checkExternalCommands() {
       return;
    }
    if(stat("SAVE", &tempStat) == 0) {
-      cerr << "Received an external SAVE command. Writing a restart file." << endl;
+      logFile << "Received an external SAVE command. Writing a restart file." << endl;
       globalflags::writeRestart = true;
       char newName[80];
       // Get the current time.
@@ -93,7 +93,7 @@ void checkExternalCommands() {
       return;
    }
    if(stat("DORC", &tempStat) == 0) {
-      cerr << "Received an external RECO command. Writing a recover file." << endl;
+      logFile << "Received an external DORC command. Writing a recover file." << endl;
       globalflags::writeRecover = true;
       char newName[80];
       // Get the current time.
@@ -104,7 +104,7 @@ void checkExternalCommands() {
       return;
    }
    if(stat("DOLB", &tempStat) == 0) {
-      cerr << "Received an external DOLB command. Balancing load." << endl;
+      logFile << "Received an external DOLB command. Balancing load." << endl;
       globalflags::balanceLoad = true;
       char newName[80];
       // Get the current time.
@@ -115,7 +115,7 @@ void checkExternalCommands() {
       return;
    }
    if(stat("DOMR", &tempStat) == 0) {
-      cerr << "Received an external DOMR command. Refining grid." << endl;
+      logFile << "Received an external DOMR command. Refining grid." << endl;
       globalflags::doRefine = true;
       char newName[80];
       // Get the current time.

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -92,15 +92,15 @@ void checkExternalCommands() {
       rename("SAVE", newName);
       return;
    }
-   if(stat("RECO", &tempStat) == 0) {
+   if(stat("DORC", &tempStat) == 0) {
       cerr << "Received an external RECO command. Writing a recover file." << endl;
       globalflags::writeRecover = true;
       char newName[80];
       // Get the current time.
       const time_t rawTime = time(NULL);
       const struct tm * timeInfo = localtime(&rawTime);
-      strftime(newName, 80, "RECO_%F_%H-%M-%S", timeInfo);
-      rename("RECO", newName);
+      strftime(newName, 80, "DORC_%F_%H-%M-%S", timeInfo);
+      rename("DORC", newName);
       return;
    }
    if(stat("DOLB", &tempStat) == 0) {

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -1564,6 +1564,7 @@ bool writeRestart(
    DataReducer& dataReducer,
    const string& name,
    const uint& fileIndex,
+   const bool dateInFileName,
    const int& stripe) 
 {
    // Writes a restart
@@ -1584,19 +1585,31 @@ bool writeRestart(
    // Get the current time.
    // Avoid different times on different processes!
    char currentDate[80];
-   if(myRank == MASTER_RANK) {
-      const time_t rawTime = time(NULL);
-      const struct tm * timeInfo = localtime(&rawTime);
-      strftime(currentDate, 80, "%F_%H-%M-%S", timeInfo);
+   if(dateInFileName) {
+      if(myRank == MASTER_RANK) {
+         const time_t rawTime = time(NULL);
+         const struct tm * timeInfo = localtime(&rawTime);
+         strftime(currentDate, 80, "%F_%H-%M-%S", timeInfo);
+      }
+      MPI_Bcast(&currentDate,80,MPI_CHAR,MASTER_RANK,MPI_COMM_WORLD);
    }
-   MPI_Bcast(&currentDate,80,MPI_CHAR,MASTER_RANK,MPI_COMM_WORLD);
-   
    // Create a name for the output file and open it with VLSVWriter:
    stringstream fname;
-   fname << P::restartWritePath << "/" << name << ".";
-   fname.width(7);
-   fname.fill('0');
-   fname << fileIndex << "." << currentDate << ".vlsv";
+   if(dateInFileName) {
+      fname << P::restartWritePath;
+   } else {
+      fname << P::recoverWritePath;
+   }
+   fname << "/" << name << ".";
+   if(dateInFileName) {
+      fname.width(7);
+      fname.fill('0');
+   }
+   fname << fileIndex;
+   if(dateInFileName) {
+      fname << "." << currentDate;
+   }
+   fname << ".vlsv";
 
    phiprof::Timer openTimer {"open"};
    //Open the file with vlsvWriter:

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -1589,10 +1589,13 @@ bool writeRestart(
       if(myRank == MASTER_RANK) {
          const time_t rawTime = time(NULL);
          const struct tm * timeInfo = localtime(&rawTime);
-         strftime(currentDate, 80, "%F_%H-%M-%S", timeInfo);
+         strftime(currentDate, 80, ".%F_%H-%M-%S", timeInfo); // note the dot prefixed
       }
       MPI_Bcast(&currentDate,80,MPI_CHAR,MASTER_RANK,MPI_COMM_WORLD);
+   } else {
+      currentDate[0] = '\0';
    }
+
    // Create a name for the output file and open it with VLSVWriter:
    stringstream fname;
    if(dateInFileName) {
@@ -1605,11 +1608,7 @@ bool writeRestart(
       fname.width(7);
       fname.fill('0');
    }
-   fname << fileIndex;
-   if(dateInFileName) {
-      fname << "." << currentDate;
-   }
-   fname << ".vlsv";
+   fname << fileIndex << currentDate << ".vlsv";
 
    phiprof::Timer openTimer {"open"};
    //Open the file with vlsvWriter:

--- a/iowrite.h
+++ b/iowrite.h
@@ -65,10 +65,24 @@ bool writeGrid(
 
 \brief Write out a restart of the simulation into a vlsv file. All block data in remote cells will be reset.
 
-\param mpiGrid   The DCCRG grid with spatial cells
-\param dataReducer Contains datareductionoperators that are used to compute data that is added into file
-\param name       File name prefix, file will be called "name.index.vlsv"
-\param fileIndex  File index, file will be called "name.index.vlsv"
+\param mpiGrid        The DCCRG grid with spatial cells
+\param perBGrid       fsgrid with perturbed B
+\param EGrid          fsgrid with E
+\param EHallGrid      fsgrid with Hall term
+\param EGradPeGrid    fsgrid with E grad(Pe) term
+\param momentsGrid    fsgrid with moments
+\param dPerBGrid      fsgrid with derivatives of perturbed B
+\param dMomentsGrid   fsgrid with derivatives of moments
+\param BgBGrid        fsgrid with background B
+\param volGrid        fsgrid with volume fields
+\param technicalGrid  fsgrid with technical info
+\param versionInfo    version info string
+\param configInfo     cfg file string
+\param dataReducer    Contains datareductionoperators that are used to compute data that is added into file
+\param name           File name prefix, file will be called "name.index.vlsv"
+\param fileIndex      File index, file will be called "name.index.vlsv"
+\param dateInFileName Write the date (restarts) or not (recovers)
+\param stripe         lustre stripe count
 */
 bool writeRestart(
    dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
@@ -87,6 +101,7 @@ bool writeRestart(
    DataReducer& dataReducer,
    const std::string& name,
    const uint& fileIndex,
+   const bool dateInFileName,
    const int& stripe
 );
 

--- a/mini-apps/ionosphereSolverTests/main.cpp
+++ b/mini-apps/ionosphereSolverTests/main.cpp
@@ -15,9 +15,10 @@ using namespace vlsv;
 
 Logger logFile,diagnostic;
 int globalflags::bailingOut=0;
-bool globalflags::writeRestart=0;
-bool globalflags::balanceLoad=0;
-bool globalflags::doRefine=0;
+bool globalflags::writeRestart=false;
+bool globalflags::writeRecover=false;
+bool globalflags::balanceLoad=false;
+bool globalflags::doRefine=false;
 bool globalflags::ionosphereJustSolved = false;
 ObjectWrapper objectWrapper;
 ObjectWrapper& getObjectWrapper() {

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -267,7 +267,7 @@ bool P::addParameters() {
            numeric_limits<uint>::max());
    RP::add("io.recover_tstep_interval",
            "Save the complete simulation in given tstep intervals. 0 disables writes.", 0);
-   RP::add("io.number_of_recovers", "Overwrite recovers cyclically after this number of recovers written.", 0);
+   RP::add("io.number_of_recovers", "Overwrite recovers cyclically after this number of recovers written.", 2);
    RP::add("io.vlsv_buffer_size",
            "Buffer size passed to VLSV writer (bytes, up to uint64_t), default 0 as this is sensible on sisu", 0);
    RP::add("io.write_restart_stripe_factor", "Stripe factor for restart and initial grid writing. Default 0 to inherit.", 0);

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -107,7 +107,7 @@ vector<pair<string, string>> P::restartReadHints;
 Real P::saveRestartWalltimeInterval = -1.0;
 uint P::saveRecoverTstepInterval = 0;
 uint P::exitAfterRestarts = numeric_limits<uint>::max();
-uint P::recoverFileCount = 0;
+uint P::recoverMaxFiles = 0;
 uint64_t P::vlsvBufferSize = 0;
 int P::restartStripeFactor = 0;
 int P::systemStripeFactor = 0;
@@ -565,7 +565,7 @@ void Parameters::getParameters() {
    RP::get("io.restart_walltime_interval", P::saveRestartWalltimeInterval);
    RP::get("io.recover_tstep_interval", P::saveRecoverTstepInterval);
    RP::get("io.number_of_restarts", P::exitAfterRestarts);
-   RP::get("io.number_of_recovers", P::recoverFileCount);
+   RP::get("io.number_of_recovers", P::recoverMaxFiles);
    RP::get("io.vlsv_buffer_size", P::vlsvBufferSize);
    RP::get("io.write_restart_stripe_factor", P::restartStripeFactor);
    RP::get("io.write_system_stripe_factor", P::systemStripeFactor);
@@ -591,8 +591,8 @@ void Parameters::getParameters() {
       }
       P::recoverWritePath = prefix;
    }
-   if (P::recoverFileCount == 0) {
-      P::recoverFileCount = 1; // If we leave it at zero a manual DORC will divide by zero when computing the index.
+   if (P::recoverMaxFiles == 0) {
+      P::recoverMaxFiles = 1; // If we leave it at zero a manual DORC will divide by zero when computing the index.
    }
    size_t maxSize = 0;
    maxSize = max(maxSize, P::systemWriteTimeInterval.size());

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -591,6 +591,9 @@ void Parameters::getParameters() {
       }
       P::recoverWritePath = prefix;
    }
+   if (P::recoverFileCount == 0) {
+      P::recoverFileCount = 1; // If we leave it at zero a manual DORC will divide by zero when computing the index.
+   }
    size_t maxSize = 0;
    maxSize = max(maxSize, P::systemWriteTimeInterval.size());
    maxSize = max(maxSize, P::systemWriteName.size());

--- a/parameters.h
+++ b/parameters.h
@@ -113,7 +113,7 @@ struct Parameters {
    static Real saveRestartWalltimeInterval; /*!< Interval in walltime seconds for restart data*/
    static uint saveRecoverTstepInterval;    /*!< Interval in timesteps for recover data*/
    static uint exitAfterRestarts;           /*!< Exit after this many restarts*/
-   static uint recoverFileCount;            /*<! Write cyclically this many recover files before overwriting older ones.*/
+   static uint recoverMaxFiles;             /*<! Write cyclically this many recover files before overwriting older ones.*/
    static uint64_t vlsvBufferSize;          /*!< Buffer size in bytes passed to VLSV writer. */
    static int restartStripeFactor;          /*!< stripe_factor for restart writing*/
    static int systemStripeFactor;             /*!< stripe_factor for bulk and initial grid writing*/

--- a/parameters.h
+++ b/parameters.h
@@ -111,17 +111,16 @@ struct Parameters {
                                      are always written out after propagation of 0.5dt in real space.*/
    static bool writeFullBGB; /*!< If true, write full BGB components and derivatives in a dedicated file, then exit.*/
    static Real saveRestartWalltimeInterval; /*!< Interval in walltime seconds for restart data*/
+   static uint saveRecoverTstepInterval;    /*!< Interval in timesteps for recover data*/
    static uint exitAfterRestarts;           /*!< Exit after this many restarts*/
+   static uint recoverFileCount;            /*<! Write cyclically this many recover files before overwriting older ones.*/
    static uint64_t vlsvBufferSize;          /*!< Buffer size in bytes passed to VLSV writer. */
    static int restartStripeFactor;          /*!< stripe_factor for restart writing*/
    static int systemStripeFactor;             /*!< stripe_factor for bulk and initial grid writing*/
    static std::string restartWritePath; /*!< Path to the location where restart files should be written. Defaults to the
                                            local directory, also if the specified destination is not writeable. */
-
-   static uint transmit;
-   /*!< Indicates the data that needs to be transmitted to remote nodes.
-    * This is created with bitwise or from the values defined in
-    * namespace Transmit.*/
+   static std::string recoverWritePath; /*!< Path to the location where recover files should be written. Defaults to the
+                                           local directory, also if the specified destination is not writeable. */
 
    static bool recalculateStencils; /*!< If true, MPI stencils should be recalculated because of load balancing.*/
 

--- a/testpackage/tests/restart_write/restart_write.cfg
+++ b/testpackage/tests/restart_write/restart_write.cfg
@@ -13,6 +13,9 @@ ParticlePopulations = proton
 write_initial_state = 0
 restart_walltime_interval = 1000 # setting to nonzero activates restart writing on exit
 
+recover_tstep_interval = 3
+number_of_recovers = 2
+
 system_write_t_interval = 10.0
 system_write_file_name = bulk
 system_write_distribution_stride = 1

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -947,10 +947,10 @@ int simulate(int argn,char* args[]) {
                globalflags::writeRestart = false; // This flag is only used by MASTER_RANK here and it needs to be reset after a restart write has been issued.
             }
          }
-         if (  P::saveRecoverTstepInterval > 0
-            && ((P::tstep % P::saveRecoverTstepInterval == 0
-                  && P::tstep != P::tstep_min)
-               || globalflags::writeRecover)
+         if (  (P::saveRecoverTstepInterval > 0
+            && P::tstep % P::saveRecoverTstepInterval == 0
+            && P::tstep != P::tstep_min)
+            || globalflags::writeRecover
          ) {
             doNow[1] = 1;
             if (globalflags::writeRecover == true) {

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -951,7 +951,8 @@ int simulate(int argn,char* args[]) {
          }
          if (  P::saveRecoverTstepInterval > 0
             && P::recoverFileCount > 0
-            && (P::tstep % P::saveRecoverTstepInterval == 0
+            && ((P::tstep % P::saveRecoverTstepInterval == 0
+                  && P::tstep != P::tstep_min)
                || globalflags::writeRecover)
          ) {
             doNow[1] = 1;

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -797,8 +797,6 @@ int simulate(int argn,char* args[]) {
    uint recoverCounter=0;
 
    int doNow[4] = {0}; // 0: writeRestartNow, 1: writeRecoverNow, 2: balanceLoadNow, 3: refineNow ; declared outside main loop
-   int writeRestartNow; // declared outside main loop
-   int writeRecoverNow; // declared outside main loop
    bool overrideRebalanceNow = false; // declared outside main loop
    bool refineNow = false; // declared outside main loop
 
@@ -971,10 +969,6 @@ int simulate(int argn,char* args[]) {
          }
       }
       MPI_Bcast( &doNow, 4 , MPI_INT , MASTER_RANK ,MPI_COMM_WORLD);
-      writeRestartNow = doNow[0];
-      doNow[0] = 0;
-      writeRecoverNow = doNow[1];
-      doNow[1] = 0;
       if (doNow[2] == 1) {
          P::prepareForRebalance = true;
          doNow[2] = 0;
@@ -985,9 +979,9 @@ int simulate(int argn,char* args[]) {
       }
       restartCheckTimer.stop();
 
-      if (writeRestartNow >= 1){
+      if (doNow[0] >= 1){ // write restart
          phiprof::Timer timer {"write-restart"};
-         if (writeRestartNow == 1) {
+         if (doNow[0] == 1) { // write restart
             wallTimeRestartCounter++;
          }
 
@@ -1021,10 +1015,11 @@ int simulate(int argn,char* args[]) {
          if (myRank == MASTER_RANK) {
             logFile << "(IO): .... done!"<< endl << writeVerbose;
          }
+         doNow[0] = 0; // write restart
          timer.stop();
       }
       
-      if (writeRecoverNow == 1){
+      if (doNow[1] == 1){ // write recover
          phiprof::Timer timer {"write-recover"};
 
          // Refinement params for restart refinement
@@ -1058,6 +1053,7 @@ int simulate(int argn,char* args[]) {
          if (myRank == MASTER_RANK) {
             logFile << "(IO): .... done!"<< endl << writeVerbose;
          }
+         doNow[1] = 0; // write recover
          timer.stop();
       }
 

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -1026,7 +1026,6 @@ int simulate(int argn,char* args[]) {
       
       if (writeRecoverNow == 1){
          phiprof::Timer timer {"write-recover"};
-         recoverCounter++;
 
          // Refinement params for restart refinement
          calculateScaledDeltasSimple(mpiGrid);
@@ -1055,6 +1054,7 @@ int simulate(int argn,char* args[]) {
             logFile << "(IO): ERROR Failed to write recover!" << endl << writeVerbose;
             cerr << "FAILED TO WRITE RECOVER" << endl;
          }
+         recoverCounter++;
          if (myRank == MASTER_RANK) {
             logFile << "(IO): .... done!"<< endl << writeVerbose;
          }

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -950,7 +950,6 @@ int simulate(int argn,char* args[]) {
             doNow[0] = 0;
          }
          if (  P::saveRecoverTstepInterval > 0
-            && P::recoverFileCount > 0
             && ((P::tstep % P::saveRecoverTstepInterval == 0
                   && P::tstep != P::tstep_min)
                || globalflags::writeRecover)
@@ -1032,7 +1031,7 @@ int simulate(int argn,char* args[]) {
          calculateScaledDeltasSimple(mpiGrid);
 
          if (myRank == MASTER_RANK)
-            logFile << "(IO): Writing recover data to disk, index = " << recoverCounter % P::recoverFileCount << ", tstep = " << P::tstep << " t = " << P::t << endl << writeVerbose;
+            logFile << "(IO): Writing recover data to disk, index = " << recoverCounter % P::recoverMaxFiles << ", tstep = " << P::tstep << " t = " << P::t << endl << writeVerbose;
          //Write the recover:
          if( writeRestart(mpiGrid,
                   perBGrid, // TODO: Merge all the fsgrids passed here into one meta-object
@@ -1049,7 +1048,7 @@ int simulate(int argn,char* args[]) {
                   config,
                   outputReducer,
                   "recover",
-                  recoverCounter % P::recoverFileCount,
+                  recoverCounter % P::recoverMaxFiles,
                   false, // overwrite so do not put date in file name
                   P::restartStripeFactor) == false ) {
             logFile << "(IO): ERROR Failed to write recover!" << endl << writeVerbose;

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -970,7 +970,7 @@ int simulate(int argn,char* args[]) {
       if (doNow[2] == 1) {
          P::prepareForRebalance = true;
       }
-      if (doNow[3]) {
+      if (doNow[3] == 1) {
          refineNow = true;
       }
       restartCheckTimer.stop();
@@ -1055,10 +1055,7 @@ int simulate(int argn,char* args[]) {
       addTimedBarrier("barrier-end-io");
 
       // reset these for next time around
-      doNow[0] = 0;
-      doNow[1] = 0;
-      doNow[2] = 0;
-      doNow[3] = false;
+      doNow[0] = doNow[1] = doNow[2] = doNow[3] = 0;
 
       //no need to propagate if we are on the final step, we just
       //wanted to make sure all IO is done even for final step

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -796,7 +796,7 @@ int simulate(int argn,char* args[]) {
    uint wallTimeRestartCounter=1;
    uint recoverCounter=0;
 
-   int doNow[4] = {0}; // 0: writeRestartNow, 1: writeRecoverNow, 2: balanceLoadNow, 3: refineNow ; declared outside main loop
+   int doNow[donow::N_DONOW] = {0}; // 0: writeRestartNow, 1: writeRecoverNow, 2: balanceLoadNow, 3: refineNow ; declared outside main loop
    bool overrideRebalanceNow = false; // declared outside main loop
    bool refineNow = false; // declared outside main loop
 


### PR DESCRIPTION
Allow to write "recover" files (at the moment they are like restart files) at a set tstep interval, and they overwrite themselves periodically according to the number of files set to be used.
```
recover_tstep_interval = 3
number_of_recovers = 2
```

Includes a `touch RECO` to trigger manually a new one.

Does not include duplication of MPI-IO flags, striping etc, those are taken from restart parameters. This is changing soon if e.g. compression is allowed for the recovers, I suppose.

Functionality tested in testpackage in restart_write (but no checks implemented, not needed I suppose as long as they're identical to restarts).