### PR TITLE
Reorder memory report lines in logfile.

### DIFF
--- a/memory_report.cpp
+++ b/memory_report.cpp
@@ -24,7 +24,6 @@
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
-#include <iomanip>
 #include <format>
 
 #ifdef _OPENMP

--- a/memory_report.cpp
+++ b/memory_report.cpp
@@ -120,7 +120,6 @@ void report_memory_consumption(
    int rank, nProcs, nodeRank, interRank;
    int nNodes;
    const double GiB = pow(2,30);
-   const double TiB = pow(2,40);
 
    std::hash<std::string> hasher;
    MPI_Comm nodeComm;
@@ -143,7 +142,7 @@ void report_memory_consumption(
    MPI_Comm_size(interComm, &nNodes);
 
    // string formatting
-   constexpr std::string_view formatString = "(MEM) tstep {} t {:.3g} {:<21} (GiB/node; avg, min, max): {:<7.5g} {:<7.5g} {:<7.5g} sum (TiB) {:<7.5g} on {} nodes\n";
+   constexpr std::string_view formatString = "(MEM) tstep {} t {:.3g} {:<21} (GiB/node; avg, min, max, sum): {:<8.3g} {:<8.3g} {:<8.3g} {:<8.3g} on {} nodes\n";
 
    // Report /proc/meminfo memory consumption first so we then get resident and HWM from Papi below, easier to compare by eye in logfile in this order.
    double mem_proc_free = (double)get_node_free_memory();
@@ -153,7 +152,7 @@ void report_memory_consumption(
    MPI_Reduce( &mem_proc_free, &total_mem_proc, numberOfParameters, MPI_DOUBLE, MPI_SUM, MASTER_RANK, MPI_COMM_WORLD );
    MPI_Reduce( &mem_proc_free, &min_free, numberOfParameters, MPI_DOUBLE, MPI_MIN, MASTER_RANK, MPI_COMM_WORLD );
    MPI_Reduce( &mem_proc_free, &max_free, numberOfParameters, MPI_DOUBLE, MPI_MAX, MASTER_RANK, MPI_COMM_WORLD );
-   logFile << std::format(formatString, P::tstep, P::t, "Free", total_mem_proc/nProcs/GiB, min_free/GiB, max_free/GiB, total_mem_proc/TiB, nNodes);
+   logFile << std::format(formatString, P::tstep, P::t, "Free", total_mem_proc/nProcs/GiB, min_free/GiB, max_free/GiB, total_mem_proc/GiB, nNodes);
 
 #ifdef PAPI_MEM
    /*If we have PAPI, we can report the resident usage of the process*/
@@ -181,10 +180,10 @@ void report_memory_consumption(
          if (max_mem_papi[3] != 0.0) {
             logFile << "(MEM) Estimating increased high water mark from refinement" << std::endl;
          }
-         logFile << std::format(formatString, P::tstep, P::t, "Resident",            sum_mem_papi[2]/nNodes/GiB, min_mem_papi[2]/GiB, max_mem_papi[2]/GiB, sum_mem_papi[2]/TiB, nNodes);
-         logFile << std::format(formatString, P::tstep, P::t, "High water mark \U0001F30A",     sum_mem_papi[0]/nNodes/GiB, min_mem_papi[0]/GiB, max_mem_papi[0]/GiB, sum_mem_papi[0]/TiB, nNodes);
+         logFile << std::format(formatString, P::tstep, P::t, "Resident",            sum_mem_papi[2]/nNodes/GiB, min_mem_papi[2]/GiB, max_mem_papi[2]/GiB, sum_mem_papi[2]/GiB, nNodes);
+         logFile << std::format(formatString, P::tstep, P::t, "High water mark \U0001F30A   ",     sum_mem_papi[0]/nNodes/GiB, min_mem_papi[0]/GiB, max_mem_papi[0]/GiB, sum_mem_papi[0]/GiB, nNodes);
          if(max_mem_papi[3] != 0.0) {
-            logFile << std::format(formatString, P::tstep, P::t, "HWM with refines", sum_mem_papi[1]/nNodes/GiB, min_mem_papi[1]/GiB, max_mem_papi[1]/GiB, sum_mem_papi[1]/TiB, nNodes);
+            logFile << std::format(formatString, P::tstep, P::t, "HWM with refines", sum_mem_papi[1]/nNodes/GiB, min_mem_papi[1]/GiB, max_mem_papi[1]/GiB, sum_mem_papi[1]/GiB, nNodes);
          }
       }
       if(rank == MASTER_RANK) {
@@ -244,13 +243,14 @@ void report_memory_consumption(
    MPI_Reduce(mem_usage_loc, min_mem, 3, MPI_DOUBLE_INT, MPI_MINLOC, 0, MPI_COMM_WORLD);
 
    // string formatting
-   constexpr std::string_view formatString2 = "(MEM) tstep {} t {:.3g} {:<21} (GiB/rank; avg, min, max): {:<7.5g} {:<7.5g} {:<7.5g} sum (TiB) {:<7.5g} min rank {} max rank {}\n";
+   constexpr std::string_view formatString2 = "(MEM) tstep {} t {:.3g} {:<21} (GiB/rank; avg, min, max, sum): {:<8.3g} {:<8.3g} {:<8.3g} {:<8.3g} min rank {} max rank {}\n";
 
-   logFile << std::format(formatString2, P::tstep, P::t, "Local cells capacity",  sum_mem[3]/nProcs/GiB, min_mem[0].val/GiB, max_mem[0].val/GiB, sum_mem[3]/TiB, min_mem[0].rank, max_mem[0].rank);
-   logFile << std::format(formatString2, P::tstep, P::t, "Remote cells capacity", sum_mem[4]/nProcs/GiB, min_mem[1].val/GiB, max_mem[1].val/GiB, sum_mem[4]/TiB, min_mem[1].rank, max_mem[1].rank);
-   logFile << std::format(formatString2, P::tstep, P::t, "Total cells capacity",  sum_mem[5]/nProcs/GiB, min_mem[2].val/GiB, max_mem[2].val/GiB, sum_mem[5]/TiB, min_mem[2].rank, max_mem[2].rank);
+   logFile << std::format(formatString2, P::tstep, P::t, "Local cells capacity",  sum_mem[3]/nProcs/GiB, min_mem[0].val/GiB, max_mem[0].val/GiB, sum_mem[3]/GiB, min_mem[0].rank, max_mem[0].rank);
+   logFile << std::format(formatString2, P::tstep, P::t, "Remote cells capacity", sum_mem[4]/nProcs/GiB, min_mem[1].val/GiB, max_mem[1].val/GiB, sum_mem[4]/GiB, min_mem[1].rank, max_mem[1].rank);
+   logFile << std::format(formatString2, P::tstep, P::t, "Total cells capacity",  sum_mem[5]/nProcs/GiB, min_mem[2].val/GiB, max_mem[2].val/GiB, sum_mem[5]/GiB, min_mem[2].rank, max_mem[2].rank);
 
-   logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Total size and capacity of SpatialCells (TiB) " << sum_mem[2] / TiB << " " << sum_mem[5] / TiB << std::endl;
+   constexpr std::string_view formatString3 = "(MEM) tstep {} t {:.3g} Total size and capacity of SpatialCells        (GiB): {:<8.3g} {:<8.3g}\n";
+   logFile << std::format(formatString3, P::tstep, P::t, sum_mem[2]/GiB, sum_mem[5]/GiB);
 
    logFile << writeVerbose;
 

--- a/memory_report.cpp
+++ b/memory_report.cpp
@@ -24,7 +24,9 @@
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
-#include <format>
+#if __GNUC__ >= 13
+   #include <format>
+#endif
 
 #ifdef _OPENMP
   #include <omp.h>
@@ -141,8 +143,10 @@ void report_memory_consumption(
    MPI_Comm_rank(interComm, &interRank);
    MPI_Comm_size(interComm, &nNodes);
 
+#if __GNUC__ >= 13
    // string formatting
    constexpr std::string_view formatString = "(MEM) tstep {} t {:.3g} {:<21} (GiB/node; avg, min, max, sum): {:<8.3g} {:<8.3g} {:<8.3g} {:<8.3g} on {} nodes\n";
+#endif
 
    // Report /proc/meminfo memory consumption first so we then get resident and HWM from Papi below, easier to compare by eye in logfile in this order.
    double mem_proc_free = (double)get_node_free_memory();
@@ -152,7 +156,12 @@ void report_memory_consumption(
    MPI_Reduce( &mem_proc_free, &total_mem_proc, numberOfParameters, MPI_DOUBLE, MPI_SUM, MASTER_RANK, MPI_COMM_WORLD );
    MPI_Reduce( &mem_proc_free, &min_free, numberOfParameters, MPI_DOUBLE, MPI_MIN, MASTER_RANK, MPI_COMM_WORLD );
    MPI_Reduce( &mem_proc_free, &max_free, numberOfParameters, MPI_DOUBLE, MPI_MAX, MASTER_RANK, MPI_COMM_WORLD );
+#if __GNUC__ >= 13
    logFile << std::format(formatString, P::tstep, P::t, "Free", total_mem_proc/nProcs/GiB, min_free/GiB, max_free/GiB, total_mem_proc/GiB, nNodes);
+#else
+   logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " Free             (GiB/node; avg, min, max): " << total_mem_proc/nProcs / GiB << " " << min_free / GiB << " " << max_free / GiB <<
+      " sum (TiB): " << total_mem_proc/TiB << " on "<< nNodes << " nodes" << std::endl;
+#endif
 
 #ifdef PAPI_MEM
    /*If we have PAPI, we can report the resident usage of the process*/
@@ -180,11 +189,22 @@ void report_memory_consumption(
          if (max_mem_papi[3] != 0.0) {
             logFile << "(MEM) Estimating increased high water mark from refinement" << std::endl;
          }
+#if __GNUC__ >= 13
          logFile << std::format(formatString, P::tstep, P::t, "Resident",            sum_mem_papi[2]/nNodes/GiB, min_mem_papi[2]/GiB, max_mem_papi[2]/GiB, sum_mem_papi[2]/GiB, nNodes);
          logFile << std::format(formatString, P::tstep, P::t, "High water mark \U0001F30A   ",     sum_mem_papi[0]/nNodes/GiB, min_mem_papi[0]/GiB, max_mem_papi[0]/GiB, sum_mem_papi[0]/GiB, nNodes);
          if(max_mem_papi[3] != 0.0) {
             logFile << std::format(formatString, P::tstep, P::t, "HWM with refines", sum_mem_papi[1]/nNodes/GiB, min_mem_papi[1]/GiB, max_mem_papi[1]/GiB, sum_mem_papi[1]/GiB, nNodes);
          }
+#else
+         logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " Resident         (GiB/node; avg, min, max): " << sum_mem_papi[2]/nNodes/GiB << " " << min_mem_papi[2]/GiB << " "  << max_mem_papi[2]/GiB <<
+            " sum (TiB): " << sum_mem_papi[2]/TiB << " on "<< nNodes << " nodes" << std::endl;
+         logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " High water mark  (GiB/node; avg, min, max): " << sum_mem_papi[0]/nNodes/GiB << " " << min_mem_papi[0]/GiB << " "  << max_mem_papi[0]/GiB <<
+            " sum (TiB): " << sum_mem_papi[0]/TiB << " on "<< nNodes << " nodes" << std::endl;
+         if(max_mem_papi[3] != 0.0) {
+            logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " HWM with refines (GiB/node; avg, min, max): " << sum_mem_papi[1]/nNodes/GiB << " " << min_mem_papi[1]/GiB << " "  << max_mem_papi[1]/GiB <<
+               " sum (TiB): " << sum_mem_papi[1]/TiB << " on "<< nNodes << " nodes" << std::endl;
+         }
+#endif
       }
       if(rank == MASTER_RANK) {
          bailout(max_mem_papi[1]/GiB > Parameters::bailout_max_memory, "Memory high water mark per node exceeds bailout threshold", __FILE__, __LINE__);
@@ -242,6 +262,7 @@ void report_memory_consumption(
    MPI_Reduce(mem_usage_loc, max_mem, 3, MPI_DOUBLE_INT, MPI_MAXLOC, 0, MPI_COMM_WORLD);
    MPI_Reduce(mem_usage_loc, min_mem, 3, MPI_DOUBLE_INT, MPI_MINLOC, 0, MPI_COMM_WORLD);
 
+#if __GNUC__ >= 13
    // string formatting
    constexpr std::string_view formatString2 = "(MEM) tstep {} t {:.3g} {:<21} (GiB/rank; avg, min, max, sum): {:<8.3g} {:<8.3g} {:<8.3g} {:<8.3g} min rank {} max rank {}\n";
 
@@ -251,6 +272,12 @@ void report_memory_consumption(
 
    constexpr std::string_view formatString3 = "(MEM) tstep {} t {:.3g} Total size and capacity of SpatialCells        (GiB): {:<8.3g} {:<8.3g}\n";
    logFile << std::format(formatString3, P::tstep, P::t, sum_mem[2]/GiB, sum_mem[5]/GiB);
+#else
+   
+   logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Average capacity (GiB/rank) " << sum_mem[5]/nProcs / GiB << " local cells " << sum_mem[3]/nProcs / GiB << " remote cells " << sum_mem[4]/nProcs / GiB << std::endl;
+   logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Max capacity (GiB/rank)     " << max_mem[2].val / GiB  << " on rank " << max_mem[2].rank << " min capacity (GiB/rank) " << min_mem[2].val / GiB  << " on rank " << min_mem[2].rank << std::endl;
+   logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Total size and capacity of SpatialCells (TiB) " << sum_mem[2] / TiB << " " << sum_mem[5] / TiB << std::endl;
+#endif
 
    logFile << writeVerbose;
 

--- a/memory_report.cpp
+++ b/memory_report.cpp
@@ -246,7 +246,7 @@ void report_memory_consumption(
    MPI_Reduce(mem_usage_loc, min_mem, 3, MPI_DOUBLE_INT, MPI_MINLOC, 0, MPI_COMM_WORLD);
 
    logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Average capacity (GiB/rank) " << sum_mem[5]/nProcs / GiB << " local cells " << sum_mem[3]/nProcs / GiB << " remote cells " << sum_mem[4]/nProcs / GiB << std::endl;
-   logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Max capacity (GiB/rank)     " << max_mem[2].val / GiB  << " on rank " << max_mem[2].rank << " min capacity (GiB/rank) " << min_mem[2].val / GiB  << " on rank " << min_mem[2].rank << std::endl;
+   logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Max capacity     (GiB/rank) " << max_mem[2].val / GiB  << " on rank " << max_mem[2].rank << " min capacity (GiB/rank) " << min_mem[2].val / GiB  << " on rank " << min_mem[2].rank << std::endl;
 
    logFile << writeVerbose;
 

--- a/memory_report.cpp
+++ b/memory_report.cpp
@@ -143,7 +143,7 @@ void report_memory_consumption(
    MPI_Comm_rank(interComm, &interRank);
    MPI_Comm_size(interComm, &nNodes);
 
-   // https://www.boost.org/doc/libs/1_53_0/libs/format/doc/format.html
+   // https://www.boost.org/doc/libs/1_87_0/libs/format/doc/format.html
    // % start of the format
    // | delimiter
    // 1 index

--- a/memory_report.cpp
+++ b/memory_report.cpp
@@ -25,6 +25,8 @@
 #include <iostream>
 #include <sstream>
 #include <iomanip>
+#include <format>
+
 #ifdef _OPENMP
   #include <omp.h>
 #endif
@@ -33,8 +35,6 @@
 #include "object_wrapper.h"
 
 #include "memory_report.h"
-
-#include <boost/format.hpp>
 
 #ifdef PAPI_MEM
 #include "papi.h"
@@ -143,18 +143,6 @@ void report_memory_consumption(
    MPI_Comm_rank(interComm, &interRank);
    MPI_Comm_size(interComm, &nNodes);
 
-   // https://www.boost.org/doc/libs/1_87_0/libs/format/doc/format.html
-   // % start of the format
-   // | delimiter
-   // 1 index
-   // $ end of index
-   // - left align
-   // 7 min field width
-   // .5 decimal precision
-   // g general number format
-   // | delimiter
-   boost::format aligned_output_formatter("(GiB/node; avg, min, max): %|1$-7.5g| %|2$-7.5g| %|3$-7.5g| sum (TiB) %|4$-7.5g| on %|5$-| nodes\n");
-
    // Report /proc/meminfo memory consumption first so we then get resident and HWM from Papi below, easier to compare by eye in logfile in this order.
    double mem_proc_free = (double)get_node_free_memory();
    double total_mem_proc = 0;
@@ -163,7 +151,12 @@ void report_memory_consumption(
    MPI_Reduce( &mem_proc_free, &total_mem_proc, numberOfParameters, MPI_DOUBLE, MPI_SUM, MASTER_RANK, MPI_COMM_WORLD );
    MPI_Reduce( &mem_proc_free, &min_free, numberOfParameters, MPI_DOUBLE, MPI_MIN, MASTER_RANK, MPI_COMM_WORLD );
    MPI_Reduce( &mem_proc_free, &max_free, numberOfParameters, MPI_DOUBLE, MPI_MAX, MASTER_RANK, MPI_COMM_WORLD );
-   logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " Free             " << aligned_output_formatter % (total_mem_proc/nProcs / GiB) % (min_free / GiB) % (max_free / GiB) % (total_mem_proc/TiB) % nNodes;
+   logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " Free             (GiB/node; avg, min, max): "
+      << std::format("{:<7.5g}", total_mem_proc/nProcs / GiB) << " "
+      << std::format("{:<7.5g}", min_free / GiB) << " "
+      << std::format("{:<7.5g}", max_free / GiB) << " sum (TiB) "
+      << std::format("{:<7.5g}", total_mem_proc/TiB)
+      << " on " << nNodes << " nodes." << endl;
 
 
 #ifdef PAPI_MEM
@@ -192,10 +185,25 @@ void report_memory_consumption(
          if (max_mem_papi[3] != 0.0) {
             logFile << "(MEM) Estimating increased high water mark from refinement" << std::endl;
          }
-         logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " Resident         "    << aligned_output_formatter % (sum_mem_papi[2]/nNodes/GiB) % (min_mem_papi[2]/GiB) % (max_mem_papi[2]/GiB) % (sum_mem_papi[2]/TiB) % nNodes;
-         logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " High water mark  "    << aligned_output_formatter % (sum_mem_papi[0]/nNodes/GiB) % (min_mem_papi[0]/GiB) % (max_mem_papi[0]/GiB) % (sum_mem_papi[0]/TiB) % nNodes;
+         logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " Resident         (GiB/node; avg, min, max): "
+            << std::format("{:<7.5g}", sum_mem_papi[2]/nNodes/GiB) << " "
+            << std::format("{:<7.5g}", min_mem_papi[2]/GiB) << " "
+            << std::format("{:<7.5g}", max_mem_papi[2]/GiB) << " sum (TiB) "
+            << std::format("{:<7.5g}", sum_mem_papi[2]/TiB)
+            << " on " << nNodes << " nodes" << endl;
+         logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " High water mark  (GiB/node; avg, min, max): "
+            << std::format("{:<7.5g}", sum_mem_papi[0]/nNodes/GiB) << " "
+            << std::format("{:<7.5g}", min_mem_papi[0]/GiB) << " "
+            << std::format("{:<7.5g}", max_mem_papi[0]/GiB) << " sum (TiB) "
+            << std::format("{:<7.5g}", sum_mem_papi[0]/TiB)
+            << " on " << nNodes << " nodes" << endl;
          if(max_mem_papi[3] != 0.0) {
-            logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " HWM with refines " << aligned_output_formatter % (sum_mem_papi[1]/nNodes/GiB) % (min_mem_papi[1]/GiB) % (max_mem_papi[1]/GiB) % (sum_mem_papi[1]/TiB) % nNodes;
+            logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " HWM with refines (GiB/node; avg, min, max): "
+               << std::format("{:<7.5g}", sum_mem_papi[1]/nNodes/GiB) << " "
+               << std::format("{:<7.5g}", min_mem_papi[1]/GiB) << " "
+               << std::format("{:<7.5g}", max_mem_papi[1]/GiB) << " sum (TiB) "
+               << std::format("{:<7.5g}", sum_mem_papi[1]/TiB)
+               << " on " << nNodes << " nodes" << endl;;
          }
       }
       if(rank == MASTER_RANK) {

--- a/memory_report.cpp
+++ b/memory_report.cpp
@@ -160,7 +160,7 @@ void report_memory_consumption(
    logFile << std::format(formatString, P::tstep, P::t, "Free", total_mem_proc/nProcs/GiB, min_free/GiB, max_free/GiB, total_mem_proc/GiB, nNodes);
 #else
    logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " Free             (GiB/node; avg, min, max): " << total_mem_proc/nProcs / GiB << " " << min_free / GiB << " " << max_free / GiB <<
-      " sum (TiB): " << total_mem_proc/TiB << " on "<< nNodes << " nodes" << std::endl;
+      " sum (GiB): " << total_mem_proc/GiB << " on "<< nNodes << " nodes" << std::endl;
 #endif
 
 #ifdef PAPI_MEM
@@ -197,12 +197,12 @@ void report_memory_consumption(
          }
 #else
          logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " Resident         (GiB/node; avg, min, max): " << sum_mem_papi[2]/nNodes/GiB << " " << min_mem_papi[2]/GiB << " "  << max_mem_papi[2]/GiB <<
-            " sum (TiB): " << sum_mem_papi[2]/TiB << " on "<< nNodes << " nodes" << std::endl;
+            " sum (GiB): " << sum_mem_papi[2]/GiB << " on "<< nNodes << " nodes" << std::endl;
          logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " High water mark  (GiB/node; avg, min, max): " << sum_mem_papi[0]/nNodes/GiB << " " << min_mem_papi[0]/GiB << " "  << max_mem_papi[0]/GiB <<
-            " sum (TiB): " << sum_mem_papi[0]/TiB << " on "<< nNodes << " nodes" << std::endl;
+            " sum (GiB): " << sum_mem_papi[0]/GiB << " on "<< nNodes << " nodes" << std::endl;
          if(max_mem_papi[3] != 0.0) {
             logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " HWM with refines (GiB/node; avg, min, max): " << sum_mem_papi[1]/nNodes/GiB << " " << min_mem_papi[1]/GiB << " "  << max_mem_papi[1]/GiB <<
-               " sum (TiB): " << sum_mem_papi[1]/TiB << " on "<< nNodes << " nodes" << std::endl;
+               " sum (GiB): " << sum_mem_papi[1]/GiB << " on "<< nNodes << " nodes" << std::endl;
          }
 #endif
       }
@@ -276,7 +276,7 @@ void report_memory_consumption(
    
    logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Average capacity (GiB/rank) " << sum_mem[5]/nProcs / GiB << " local cells " << sum_mem[3]/nProcs / GiB << " remote cells " << sum_mem[4]/nProcs / GiB << std::endl;
    logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Max capacity (GiB/rank)     " << max_mem[2].val / GiB  << " on rank " << max_mem[2].rank << " min capacity (GiB/rank) " << min_mem[2].val / GiB  << " on rank " << min_mem[2].rank << std::endl;
-   logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Total size and capacity of SpatialCells (TiB) " << sum_mem[2] / TiB << " " << sum_mem[5] / TiB << std::endl;
+   logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Total size and capacity of SpatialCells (GiB) " << sum_mem[2] / GiB << " " << sum_mem[5] / GiB << std::endl;
 #endif
 
    logFile << writeVerbose;

--- a/memory_report.cpp
+++ b/memory_report.cpp
@@ -159,7 +159,7 @@ void report_memory_consumption(
 #if __GNUC__ >= 13
    logFile << std::format(formatString, P::tstep, P::t, "Free", total_mem_proc/nProcs/GiB, min_free/GiB, max_free/GiB, total_mem_proc/GiB, nNodes);
 #else
-   logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " Free             (GiB/node; avg, min, max): " << total_mem_proc/nProcs / GiB << " " << min_free / GiB << " " << max_free / GiB <<
+   logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Free             (GiB/node; avg, min, max): " << total_mem_proc/nProcs / GiB << " " << min_free / GiB << " " << max_free / GiB <<
       " sum (GiB): " << total_mem_proc/GiB << " on "<< nNodes << " nodes" << std::endl;
 #endif
 
@@ -196,18 +196,18 @@ void report_memory_consumption(
             logFile << std::format(formatString, P::tstep, P::t, "HWM with refines", sum_mem_papi[1]/nNodes/GiB, min_mem_papi[1]/GiB, max_mem_papi[1]/GiB, sum_mem_papi[1]/GiB, nNodes);
          }
 #else
-         logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " Resident         (GiB/node; avg, min, max): " << sum_mem_papi[2]/nNodes/GiB << " " << min_mem_papi[2]/GiB << " "  << max_mem_papi[2]/GiB <<
+         logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " Resident         (GiB/node; avg, min, max): " << sum_mem_papi[2]/nNodes/GiB << " " << min_mem_papi[2]/GiB << " "  << max_mem_papi[2]/GiB <<
             " sum (GiB): " << sum_mem_papi[2]/GiB << " on "<< nNodes << " nodes" << std::endl;
-         logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " High water mark  (GiB/node; avg, min, max): " << sum_mem_papi[0]/nNodes/GiB << " " << min_mem_papi[0]/GiB << " "  << max_mem_papi[0]/GiB <<
+         logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " High water mark  (GiB/node; avg, min, max): " << sum_mem_papi[0]/nNodes/GiB << " " << min_mem_papi[0]/GiB << " "  << max_mem_papi[0]/GiB <<
             " sum (GiB): " << sum_mem_papi[0]/GiB << " on "<< nNodes << " nodes" << std::endl;
          if(max_mem_papi[3] != 0.0) {
-            logFile << "(MEM) tstep " << Parameters::tstep << " t " << Parameters::t << " HWM with refines (GiB/node; avg, min, max): " << sum_mem_papi[1]/nNodes/GiB << " " << min_mem_papi[1]/GiB << " "  << max_mem_papi[1]/GiB <<
+            logFile << "(MEM) tstep " << P::tstep << " t " << P::t << " HWM with refines (GiB/node; avg, min, max): " << sum_mem_papi[1]/nNodes/GiB << " " << min_mem_papi[1]/GiB << " "  << max_mem_papi[1]/GiB <<
                " sum (GiB): " << sum_mem_papi[1]/GiB << " on "<< nNodes << " nodes" << std::endl;
          }
 #endif
       }
       if(rank == MASTER_RANK) {
-         bailout(max_mem_papi[1]/GiB > Parameters::bailout_max_memory, "Memory high water mark per node exceeds bailout threshold", __FILE__, __LINE__);
+         bailout(max_mem_papi[1]/GiB > P::bailout_max_memory, "Memory high water mark per node exceeds bailout threshold", __FILE__, __LINE__);
       }
    }
 #endif

--- a/spatial_cells/velocity_block_container.h
+++ b/spatial_cells/velocity_block_container.h
@@ -749,7 +749,7 @@ namespace vmesh {
    inline ARCH_HOSTDEV size_t VelocityBlockContainer::sizeInBytes() const {
 #ifdef USE_GPU
       #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-      return block_data.size()*WID3*sizeof(Realf) + parameters.size()*sizeof(Real);
+      return block_data.size()*sizeof(Realf) + parameters.size()*sizeof(Real);
       #else
       #ifdef DEBUG_VBC
       const size_t currentSize = block_data.size() / WID3;
@@ -757,10 +757,10 @@ namespace vmesh {
          printf("VBC CHECK ERROR: cached size mismatch, %lu vs %lu in %s : %d\n",currentSize,cachedSize,__FILE__,__LINE__);
       }
       #endif
-      return cachedSize*WID3*sizeof(Realf) + cachedSize*BlockParams::N_VELOCITY_BLOCK_PARAMS*sizeof(Real);
+      return cachedSize*sizeof(Realf) + cachedSize*BlockParams::N_VELOCITY_BLOCK_PARAMS*sizeof(Real);
       #endif
 #else
-      return block_data.size()*WID3*sizeof(Realf) + parameters.size()*sizeof(Real);
+      return block_data.size()*sizeof(Realf) + parameters.size()*sizeof(Real);
 #endif
    }
 

--- a/spatial_cells/velocity_block_container.h
+++ b/spatial_cells/velocity_block_container.h
@@ -757,7 +757,7 @@ namespace vmesh {
          printf("VBC CHECK ERROR: cached size mismatch, %lu vs %lu in %s : %d\n",currentSize,cachedSize,__FILE__,__LINE__);
       }
       #endif
-      return cachedSize*sizeof(Realf) + cachedSize*BlockParams::N_VELOCITY_BLOCK_PARAMS*sizeof(Real);
+      return cachedSize*WID3*sizeof(Realf) + cachedSize*BlockParams::N_VELOCITY_BLOCK_PARAMS*sizeof(Real);
       #endif
 #else
       return block_data.size()*sizeof(Realf) + parameters.size()*sizeof(Real);


### PR DESCRIPTION
I find it easier to have free and resident next to each other instead of HWM in between.