### PR TITLE
Fix un/refinement not working if no boxes are defined

### DIFF
--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -456,20 +456,22 @@ namespace projects {
          )
       };
 
-      bool outsideAllRefineBoxes = true;
-      for (int i = 0; i < P::refineBoxNumber; i++) {
-         if (
-            // If this cell is planned to be refined and is inside any of the refinement boxes, then go ahead with refinement.
-            // Induced refinement still possible just beyond that limit.
-            (xyz[0] >= P::refinementMinX.at(i)) && (xyz[0] <= P::refinementMaxX.at(i))
-            && (xyz[1] >= P::refinementMinY.at(i)) && (xyz[1] <= P::refinementMaxY.at(i))
-            && (xyz[2] >= P::refinementMinZ.at(i)) && (xyz[2] <= P::refinementMaxZ.at(i))) {
-            outsideAllRefineBoxes = false;
-            break;
+      if (P::refineBoxNumber > 0) {
+         bool outsideAllRefineBoxes = true;
+         for (int i = 0; i < P::refineBoxNumber; i++) {
+            if (
+               // If this cell is planned to be refined and is inside any of the refinement boxes, then go ahead with refinement.
+               // Induced refinement still possible just beyond that limit.
+               (xyz[0] >= P::refinementMinX.at(i)) && (xyz[0] <= P::refinementMaxX.at(i))
+               && (xyz[1] >= P::refinementMinY.at(i)) && (xyz[1] <= P::refinementMaxY.at(i))
+               && (xyz[2] >= P::refinementMinZ.at(i)) && (xyz[2] <= P::refinementMaxZ.at(i))) {
+               outsideAllRefineBoxes = false;
+               break;
+            }
          }
-      }
 
-      shouldRefine = shouldRefine && !outsideAllRefineBoxes;
+         shouldRefine = shouldRefine && !outsideAllRefineBoxes;
+      }
 
       return shouldRefine;
    }
@@ -499,21 +501,23 @@ namespace projects {
          )
       };
 
-      bool outsideAllRefineBoxes = true;
-      for (int i = 0; i < P::refineBoxNumber; i++) {
-         if (
-            // If this cell is planned to remain at the current refinement level, but is outside all the allowed refinement regions,
-            // attempt to unrefine it instead. (If it is already at the lowest refinement level, DCCRG should not go belly-up.)
-            // Induced refinement still possible just beyond that limit.
-            (xyz[0] >= P::refinementMinX.at(i)) && (xyz[0] <= P::refinementMaxX.at(i))
-            && (xyz[1] >= P::refinementMinY.at(i)) && (xyz[1] <= P::refinementMaxY.at(i))
-            && (xyz[2] >= P::refinementMinZ.at(i)) && (xyz[2] <= P::refinementMaxZ.at(i))) {
-            outsideAllRefineBoxes = false;
-            break;
+      if (P::refineBoxNumber > 0) {
+         bool outsideAllRefineBoxes = true;
+         for (int i = 0; i < P::refineBoxNumber; i++) {
+            if (
+               // If this cell is planned to remain at the current refinement level, but is outside all the allowed refinement regions,
+               // attempt to unrefine it instead. (If it is already at the lowest refinement level, DCCRG should not go belly-up.)
+               // Induced refinement still possible just beyond that limit.
+               (xyz[0] >= P::refinementMinX.at(i)) && (xyz[0] <= P::refinementMaxX.at(i))
+               && (xyz[1] >= P::refinementMinY.at(i)) && (xyz[1] <= P::refinementMaxY.at(i))
+               && (xyz[2] >= P::refinementMinZ.at(i)) && (xyz[2] <= P::refinementMaxZ.at(i))) {
+               outsideAllRefineBoxes = false;
+               break;
+            }
          }
-      }
 
-      shouldUnrefine = shouldUnrefine || outsideAllRefineBoxes;
+         shouldUnrefine = shouldUnrefine || outsideAllRefineBoxes;
+      }
 
       return shouldUnrefine;
    }


### PR DESCRIPTION
Checking whether the cell to be refined/unrefined is inside refinement boxes should only be done when boxes are defined.