### PR TITLE
Return to considering has_content blocks of spatial neighbours at all…

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -761,20 +761,18 @@ bool adjustVelocityBlocks(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& m
    // Batch call
    update_velocity_block_content_lists(mpiGrid,cells,popID);
 
-   if (doPrepareToReceiveBlocks) {
-      // We are in the last substep of acceleration, so need to account for neighbours
-      phiprof::Timer transferTimer {"Transfer with_content_list", {"MPI"}};
-      SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_WITH_CONTENT_STAGE1 );
-      mpiGrid.update_copies_of_remote_neighbors(Neighborhoods::NEAREST);
-      SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_WITH_CONTENT_STAGE2 );
-      mpiGrid.update_copies_of_remote_neighbors(Neighborhoods::NEAREST);
-      transferTimer.stop();
-   }
+   // Get updated lists for blocks with content in spatial neighbours
+   phiprof::Timer transferTimer {"Transfer with_content_list", {"MPI"}};
+   SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_WITH_CONTENT_STAGE1 );
+   mpiGrid.update_copies_of_remote_neighbors(Neighborhoods::NEAREST);
+   SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_WITH_CONTENT_STAGE2 );
+   mpiGrid.update_copies_of_remote_neighbors(Neighborhoods::NEAREST);
+   transferTimer.stop();
 
    // Batch adjusts velocity blocks in local spatial cells, doesn't adjust velocity blocks in remote cells.
-   adjust_velocity_blocks_in_cells(mpiGrid, cellsToAdjust, popID, doPrepareToReceiveBlocks);
+   adjust_velocity_blocks_in_cells(mpiGrid, cellsToAdjust, popID);
 
-   // prepare to receive block data
+   // prepare to receive full block data for all cells (irrespective of list of cells to adjust)
    if (doPrepareToReceiveBlocks) {
       if (P::vlasovSolverGhostTranslate) {
          updateRemoteVelocityBlockLists(mpiGrid,popID,Neighborhoods::VLASOV_SOLVER_GHOST);

--- a/grid.h
+++ b/grid.h
@@ -101,7 +101,7 @@ void deallocateRemoteCellBlocks(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geomet
 bool adjustVelocityBlocks(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
                           const std::vector<CellID>& cellsToAdjust,
                           bool doPrepareToReceiveBlocks,
-                            const uint popID);
+                          const uint popID);
 
 /*! Shrink to fit velocity space data to save memory.
  * \param mpiGrid Spatial grid

--- a/spatial_cells/block_adjust_cpu.hpp
+++ b/spatial_cells/block_adjust_cpu.hpp
@@ -51,8 +51,7 @@ namespace spatial_cell {
    void adjust_velocity_blocks_in_cells(
       dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
       const vector<CellID>& cells,
-      const uint popID=0,
-      bool includeNeighbours=true);
+      const uint popID=0);
 
 } // namespaces
 #endif

--- a/spatial_cells/block_adjust_gpu.hpp
+++ b/spatial_cells/block_adjust_gpu.hpp
@@ -50,8 +50,7 @@ namespace spatial_cell {
    void adjust_velocity_blocks_in_cells(
       dccrg::Dccrg<spatial_cell::SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
       const vector<CellID>& cells,
-      const uint popID=0,
-      bool includeNeighbours=true);
+      const uint popID=0);
 
 } // namespaces
 

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -435,13 +435,13 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
 
       /**
          Compute subcycle dt. The length is maxVdt on all steps
-         except the last one. This used to be to keep the neighboring
-         spatial cells in sync, so that two neighboring cells with
-         different number of subcycles have similar timesteps,
-         except that one takes an additional short step. This kept
-         spatial block neighbors as much in sync as possible for
-         adjust blocks. Nowadays this would no longer be needed, as
-         block adjust considers neighbours only on the last adjustment.
+         except the (possible) last one. This was to keep neighboring
+         spatial cells in sync (with respect to gyration), so that
+         two neighboring cells with different number of subcycles 
+         have similar gyration angles, but adjusting the length of the
+         last step so all are accelerated for the same amount of time.
+         This keeps spatial block neighbors as much in sync as possible
+         for block adjustment.
       **/
 
       Real thisSubcycleDt;
@@ -466,9 +466,10 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
 
    /**
       Adjust velocity blocks after each subcycle to keep number of blocks managable. This
-      call does not consider spatial neighbours and is only performed for intermediate
-      subcycling steps. The last subcycle adjustment is performed in a higher level function,
-      does consider spatial neighbours, and is called for all accelerated cells..
+      call does not perform a full neighbour block list update (third argument) but
+      still needs to consider has_content lists for spatial neighbours.
+      The last subcycle adjustment is performed in a higher level function, and it
+      performs a full neighbour block list update, and is called for all accelerated cells.
    **/
    if (step < (globalMaxSubcycles - 1)) {
       adjustVelocityBlocks(mpiGrid, acceleratedCells, false, popID);
@@ -561,7 +562,7 @@ void calculateAcceleration(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
             calculateAcceleration(popID,(uint)globalMaxSubcycles,step,mpiGrid,acceleratedCells,dt);
          } // for-loop over acceleration substeps
 
-         // final adjust for all cells, also fixing remote cells.
+         // final adjust for all cells, also updating full remote block lists
          adjustVelocityBlocks(mpiGrid, cells, true, popID);
       } // for-loop over particle species
    }


### PR DESCRIPTION
Reverts #919  as it was found to hinder foreshock formation