### PR TITLE
Fix generate ref data on Carrington

### DIFF
--- a/.github/workflows/generate-reference-data.yml
+++ b/.github/workflows/generate-reference-data.yml
@@ -5,10 +5,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  # This should be kept identical to the build_testpackage job in github-ci.yml
+  # This should be kept ~identical to the build_testpackage job in github-ci.yml
   build_testpackage:
     # Build Vlasiator with testpackage flags, on the carrington cluster
     # (for subsequent running of the integration test package)
+    # also builds the fluxfunction tool
     runs-on: carrington
 
     steps:
@@ -28,7 +29,7 @@ jobs:
     - name: Make clean
       run: VLASIATOR_ARCH=carrington_gcc_openmpi make clean
     - uses: ursg/gcc-problem-matcher@master
-    - name: Compile vlasiator (Testpackage build)
+    - name: Compile vlasiator (Testpackage build) and fluxfunction
       run: |
         srun -M carrington --job-name CI_ref_tp_compile --interactive --nodes=1 -n 1 -c 16 --mem=40G -p short -t 0:10:0 bash -c 'module purge; module load GCC/13.2.0; module load OpenMPI/4.1.6-GCC-13.2.0 ; module load PMIx/4.2.6-GCCcore-13.2.0; module load PAPI/7.1.0-GCCcore-13.2.0; export VLASIATOR_ARCH=carrington_gcc_openmpi; make -j 16 testpackage fluxfunction; sleep 10s'
     - name: Make sure the output binary is visible in lustre
@@ -78,8 +79,11 @@ jobs:
         sed -i 's/create_verification_files=0/create_verification_files=1/' ./small_test_carrington.sh
         sbatch -W -o testpackage_run_output.txt --job-name CI_ref_generate ./small_test_carrington.sh
         cat testpackage_run_output.txt
-        # Generate reference fluxfunction files
-        $GITHUB_WORKSPACE/fluxfunction run_*/Magnetosphere_small/bulk.0000001.vlsv equatorial.bin
-        $GITHUB_WORKSPACE/fluxfunction run_*/Magnetosphere_polar_small/bulk.0000001.vlsv polar.bin
-        cp equatorial.bin polar.bin /proj/group/spacephysics/vlasiator_testpackage/CI_reference/
+    - name: Generate reference fluxfunction files
+      run: |
+        chmod +x $GITHUB_WORKSPACE/fluxfunction
+        srun --job-name fluxtest -M carrington -N 1 -c 1 --mem=1G bash -c "module purge; module load GCC/13.2.0; module load OpenMPI/4.1.6-GCC-13.2.0 ; module load PMIx/4.2.6-GCCcore-13.2.0; module load PAPI/7.1.0-GCCcore-13.2.0; $GITHUB_WORKSPACE/fluxfunction testpackage/run_*/Magnetosphere_small/bulk.0000001.vlsv equatorial.bin"
+        srun --job-name fluxtest -M carrington -N 1 -c 1 --mem=1G bash -c "module purge; module load GCC/13.2.0; module load OpenMPI/4.1.6-GCC-13.2.0 ; module load PMIx/4.2.6-GCCcore-13.2.0; module load PAPI/7.1.0-GCCcore-13.2.0; $GITHUB_WORKSPACE/fluxfunction testpackage/run_*/Magnetosphere_polar_small/bulk.0000001.vlsv polar.bin"
+        cp equatorial.bin polar.bin $REFERENCE_REVISION
+        # No longer overwrites files in /proj/group/spacephysics/vlasiator_testpackage/CI_reference/ but places in proper folder
     # We don't bother to create artefacts or anything here.

--- a/.github/workflows/generate-reference-data.yml
+++ b/.github/workflows/generate-reference-data.yml
@@ -75,6 +75,7 @@ jobs:
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/libraries/lib
         # Fudge the run script
         sed -i 's/\/proj\/USERNAME\/BINARYNAME/$GITHUB_WORKSPACE\/vlasiator/' ./small_test_carrington.sh
+        sed -i 's/create_verification_files=0/create_verification_files=1/' ./small_test_carrington.sh
         sbatch -W -o testpackage_run_output.txt --job-name CI_ref_generate ./small_test_carrington.sh
         cat testpackage_run_output.txt
         # Generate reference fluxfunction files

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -447,7 +447,7 @@ jobs:
         VLASIATOR_ARCH=appleM1 make -j 3
 
   build_tools:
-    # Build vlsvdiff and vlsvextract for testpackage use
+    # Build vlsvdiff, vlsvextract, and fluxfunction for testpackage use
     runs-on: carrington
 
     steps:

--- a/testpackage/run_tests.sh
+++ b/testpackage/run_tests.sh
@@ -37,6 +37,7 @@ then
     #automatically obtained from the --version output
     reference_revision=${revision}${solveropts}
     echo "Computing reference results into ${reference_dir}/${reference_revision}"
+    echo "REFERENCE_REVISION=${reference_dir}/${reference_revision}" >> "$GITHUB_ENV"
 fi
 
 


### PR DESCRIPTION
The basic Carrington job script had recently been updated to default to comparing against reference data instead of creating new data. This updates the github workflow for generating new data to also use `sed` on `small_test_carrington.sh` for creating new data instead of comparing against existing data. 