### PR TITLE
Vlasiator GPU to propagate WID3 at once in acceleration as well

### DIFF
--- a/MAKE/Makefile.Freezer_cuda
+++ b/MAKE/Makefile.Freezer_cuda
@@ -52,8 +52,7 @@ LNK = OMPI_CXX='nvcc' OMPI_CXXFLAGS='-arch=sm_60' OMPI_LIBS='-L/usr/lib/x86_64-l
 # https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
 
 CXXFLAGS = -g -O3 -x cu -std=c++20 -Xcompiler -std=c++20 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_60,code=sm_60 -Xcompiler -fopenmp --generate-line-info -line-info -Xcompiler="-fpermissive"  --extra-device-vectorization
-testpackage: CXXFLAGS = -g -G -O2 -x cu -std=c++20 -Xcompiler -std=c++20 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_60,code=sm_60 -Xcompiler -fopenmp -line-info -Xcompiler="-fpermissive"
-#--generate-line-info
+testpackage: CXXFLAGS = -g -O2 -x cu -std=c++20 -Xcompiler -std=c++20 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_60,code=sm_60 -Xcompiler -fopenmp --generate-line-info -line-info -Xcompiler="-fpermissive"
 
 MATHFLAGS = --use_fast_math
 # nvcc fast_math does not assume only finite math

--- a/MAKE/Makefile.Freezer_cuda
+++ b/MAKE/Makefile.Freezer_cuda
@@ -52,7 +52,8 @@ LNK = OMPI_CXX='nvcc' OMPI_CXXFLAGS='-arch=sm_60' OMPI_LIBS='-L/usr/lib/x86_64-l
 # https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
 
 CXXFLAGS = -g -O3 -x cu -std=c++20 -Xcompiler -std=c++20 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_60,code=sm_60 -Xcompiler -fopenmp --generate-line-info -line-info -Xcompiler="-fpermissive"  --extra-device-vectorization
-testpackage: CXXFLAGS = -g -O2 -x cu -std=c++20 -Xcompiler -std=c++20 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_60,code=sm_60 -Xcompiler -fopenmp --generate-line-info -line-info -Xcompiler="-fpermissive"
+testpackage: CXXFLAGS = -g -G -O2 -x cu -std=c++20 -Xcompiler -std=c++20 --extended-lambda --expt-relaxed-constexpr -gencode arch=compute_60,code=sm_60 -Xcompiler -fopenmp -line-info -Xcompiler="-fpermissive"
+#--generate-line-info
 
 MATHFLAGS = --use_fast_math
 # nvcc fast_math does not assume only finite math

--- a/MAKE/Makefile.Freezer_cuda
+++ b/MAKE/Makefile.Freezer_cuda
@@ -6,27 +6,16 @@
 # this is fixed by installing at least version 11.6
 
 #======== Vectorization ==========
-#Set vector backend type for vlasov solvers, sets precision and length.
+#GPU Vlasov solvers no longer use any vectorclass.
 #Options:
 # AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
 # AVX512:   VEC8D_AGNER, VEC16F_AGNER
-# Fallback: VECTORCLASS = VEC_FALLBACK_GENERIC (Defaults to VECL8)
+# Fallback: VECTORCLASS = VEC_FALLBACK_GENERIC
+VECTORCLASS = VEC_FALLBACK_GENERIC
 
-ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
-#Single-precision        
-        VECTORCLASS = VEC_FALLBACK_GENERIC
-else
-#Double-precision
-        VECTORCLASS = VEC_FALLBACK_GENERIC
-endif
-
-#===== Vector Lengths ====
-# Default for VEC_FALLBACK_GENERIC is WID=4, VECL=8
-# NOTE: A bug currently results in garbage data already on cell init if VECL is not equal to WID2
+# VMesh Block size: (historical value 4, also 8 supported)
 #WID=8
-#VECL=64
 WID=4
-VECL=16
 
 #======= Compiler and compilation flags =========
 # NOTES on compiler flags:

--- a/MAKE/Makefile.hile_gpu
+++ b/MAKE/Makefile.hile_gpu
@@ -23,19 +23,16 @@ CMP = OMPI_CXX='hipcc' CC
 LNK = OMPI_CXX='hipcc' CC
  
 #======== Vectorization ==========
-#Set vector backend type for vlasov solvers, sets precision and length. 
-#Options: 
+#GPU Vlasov solvers no longer use any vectorclass.
+#Options:
 # AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
 # AVX512:   VEC8D_AGNER, VEC16F_AGNER
-# Fallback: VECTORCLASS = VEC_FALLBACK_GENERIC (Defaults to VECL8)
+# Fallback: VECTORCLASS = VEC_FALLBACK_GENERIC
 VECTORCLASS = VEC_FALLBACK_GENERIC
 
-#===== Vector Lengths ====
-# Default for VEC_FALLBACK_GENERIC is WID=4, VECL=8 
+# VMesh Block size: (historical value 4, also 8 supported)
 #WID=8
-#VECL=64
 WID=4
-VECL=16
 
 # Compile with GPU support (USE_HIP or USE_CUDA)
 USE_HIP=1

--- a/MAKE/Makefile.karolina_cuda
+++ b/MAKE/Makefile.karolina_cuda
@@ -12,20 +12,16 @@
 #  mpirun -n $SLURM_NTASKS --map-by ppr:$SLURM_NTASKS_PER_NODE:node:PE=$OMP_NUM_THREADS --bind-to core --report-bindings $EXE $CFG
 
 #======== Vectorization ==========
-#Set vector backend type for vlasov solvers, sets precision and length.
+#GPU Vlasov solvers no longer use any vectorclass.
 #Options:
 # AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
 # AVX512:   VEC8D_AGNER, VEC16F_AGNER
 # Fallback: VECTORCLASS = VEC_FALLBACK_GENERIC
 VECTORCLASS = VEC_FALLBACK_GENERIC
 
-#===== Vector Lengths ====
-# Default for VEC_FALLBACK_GENERIC is WID=4, VECL=8
-# NOTE: A bug currently results in garbage data already on cell init if VECL is not equal to WID2
+# VMesh Block size: (historical value 4, also 8 supported)
 #WID=8
-#VECL=64
 WID=4
-VECL=16
 
 #======== Libraries ===========
 LIBRARY_PREFIX = libraries-karolina_cuda

--- a/MAKE/Makefile.leonardo_booster
+++ b/MAKE/Makefile.leonardo_booster
@@ -5,20 +5,16 @@
 # Build libraries with ./build_libraries.sh leonardo_booster
 
 #======== Vectorization ==========
-#Set vector backend type for vlasov solvers, sets precision and length.
+#GPU Vlasov solvers no longer use any vectorclass.
 #Options:
 # AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
 # AVX512:   VEC8D_AGNER, VEC16F_AGNER
 # Fallback: VECTORCLASS = VEC_FALLBACK_GENERIC
 VECTORCLASS = VEC_FALLBACK_GENERIC
 
-#===== Vector Lengths ====
-# Default for VEC_FALLBACK_GENERIC is WID=4, VECL=8
-# NOTE: A bug currently results in garbage data already on cell init if VECL is not equal to WID2
-WID=8
-VECL=64
-#WID=4
-#VECL=16
+# VMesh Block size: (historical value 4, also 8 supported)
+#WID=8
+WID=4
 
 #======== Libraries ===========
 LIBRARY_PREFIX = libraries-leonardo_booster

--- a/MAKE/Makefile.lumi_hipcc
+++ b/MAKE/Makefile.lumi_hipcc
@@ -26,19 +26,16 @@
 #  // #include <hip/hip_runtime.h>
 
 #======== Vectorization ==========
-#Set vector backend type for vlasov solvers, sets precision and length. 
-#Options: 
+#GPU Vlasov solvers no longer use any vectorclass.
+#Options:
 # AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
 # AVX512:   VEC8D_AGNER, VEC16F_AGNER
 # Fallback: VECTORCLASS = VEC_FALLBACK_GENERIC
 VECTORCLASS = VEC_FALLBACK_GENERIC
 
-#===== Vector Lengths ====
-# Default for VEC_FALLBACK_GENERIC is WID=4, VECL=8 
+# VMesh Block size: (historical value 4, also 8 supported)
 #WID=8
-#VECL=64
 WID=4
-VECL=16
 
 # Compile with GPU support (USE_HIP or USE_CUDA)
 USE_HIP=1

--- a/MAKE/Makefile.mahti_cuda
+++ b/MAKE/Makefile.mahti_cuda
@@ -4,20 +4,16 @@
 # ml gcc/10.4.0 openmpi/4.1.5-cuda cuda/12.1.1 boost/1.82.0-mpi papi/7.1.0
 
 #======== Vectorization ==========
-#Set vector backend type for vlasov solvers, sets precision and length.
+#GPU Vlasov solvers no longer use any vectorclass.
 #Options:
 # AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
 # AVX512:   VEC8D_AGNER, VEC16F_AGNER
 # Fallback: VECTORCLASS = VEC_FALLBACK_GENERIC
 VECTORCLASS = VEC_FALLBACK_GENERIC
 
-#===== Vector Lengths ====
-# Default for VEC_FALLBACK_GENERIC is WID=4, VECL=8
-# NOTE: A bug currently results in garbage data already on cell init if VECL is not equal to WID2
+# VMesh Block size: (historical value 4, also 8 supported)
 #WID=8
-#VECL=64
 WID=4
-VECL=16
 
 #======= Compiler and compilation flags =========
 # NOTES on compiler flags:

--- a/MAKE/Makefile.puhti_gcc_cuda
+++ b/MAKE/Makefile.puhti_gcc_cuda
@@ -8,27 +8,19 @@
 # oneliner:
 # module load gcc/9.1.0 cuda/11.1.0 openmpi/4.0.5-cuda papi/5.7.0 boost/1.68.0 
 
+# WARNING! Untested since long ago!
+
 #======== Vectorization ==========
-#Set vector backend type for vlasov solvers, sets precision and length.
+#GPU Vlasov solvers no longer use any vectorclass.
 #Options:
 # AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
 # AVX512:   VEC8D_AGNER, VEC16F_AGNER
 # Fallback: VECTORCLASS = VEC_FALLBACK_GENERIC
+VECTORCLASS = VEC_FALLBACK_GENERIC
 
-ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
-#Single-precision
-        VECTORCLASS = VEC_FALLBACK_GENERIC
-else
-#Double-precision
-        VECTORCLASS = VEC_FALLBACK_GENERIC
-endif
-#===== Vector Lenghts ====
-# Default for VEC_FALLBACK_GENERIC is WID=4, VECL=8 
-WID=8
-VECL=64 
-#VECL=32
-#WID=4
-#VECL=16
+# VMesh Block size: (historical value 4, also 8 supported)
+#WID=8
+WID=4
 
 #======= Compiler and compilation flags =========
 # NOTES on compiler flags:

--- a/MAKE/Makefile.ukko_a100
+++ b/MAKE/Makefile.ukko_a100
@@ -10,17 +10,16 @@
 # module purge; ml OpenMPI/4.1.6.withucx-GCC-13.2.0 PAPI/7.1.0-GCCcore-13.2.0 CUDA/12.6.0
 
 #======== Vectorization ==========
-#Set vector backend type for vlasov solvers, sets precision and length.
+#GPU Vlasov solvers no longer use any vectorclass.
 #Options:
+# AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
+# AVX512:   VEC8D_AGNER, VEC16F_AGNER
+# Fallback: VECTORCLASS = VEC_FALLBACK_GENERIC
 VECTORCLASS = VEC_FALLBACK_GENERIC
 
-#===== Vector Lengths ====
-# Default for VEC_FALLBACK_GENERIC is WID=4, VECL=8
-# NOTE: A bug currently results in garbage data already on cell init if VECL is not equal to WID2
+# VMesh Block size: (historical value 4, also 8 supported)
 #WID=8
-#VECL=64
 WID=4
-VECL=16
 
 #======= Compiler and compilation flags =========
 # NOTES on compiler flags:

--- a/MAKE/Makefile.ukko_dgx
+++ b/MAKE/Makefile.ukko_dgx
@@ -10,17 +10,16 @@
 # module purge; ml OpenMPI/4.1.6.withucx-GCC-13.2.0 PAPI/7.1.0-GCCcore-13.2.0 CUDA/12.6.0
 
 #======== Vectorization ==========
-#Set vector backend type for vlasov solvers, sets precision and length.
+#GPU Vlasov solvers no longer use any vectorclass.
 #Options:
+# AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
+# AVX512:   VEC8D_AGNER, VEC16F_AGNER
+# Fallback: VECTORCLASS = VEC_FALLBACK_GENERIC
 VECTORCLASS = VEC_FALLBACK_GENERIC
 
-#===== Vector Lengths ====
-# Default for VEC_FALLBACK_GENERIC is WID=4, VECL=8
-# NOTE: A bug currently results in garbage data already on cell init if VECL is not equal to WID2
+# VMesh Block size: (historical value 4, also 8 supported)
 #WID=8
-#VECL=64
 WID=4
-VECL=16
 
 #======= Compiler and compilation flags =========
 # NOTES on compiler flags:

--- a/arch/arch_device_cuda.h
+++ b/arch/arch_device_cuda.h
@@ -476,6 +476,7 @@ namespace arch{
          CHK_ERR(cudaPeekAtLastError());
          /* Synchronize after kernel call */
          CHK_ERR(cudaStreamSynchronize(gpuStreamList[thread_id]));
+         CHK_ERR(cudaFreeAsync(d_limits, gpuStreamList[thread_id]));
          return;
       }
 

--- a/arch/arch_device_hip.h
+++ b/arch/arch_device_hip.h
@@ -452,6 +452,7 @@ namespace arch{
          CHK_ERR(hipPeekAtLastError());
          /* Synchronize after kernel call */
          CHK_ERR(hipStreamSynchronize(gpuStreamList[thread_id]));
+         CHK_ERR(hipFreeAsync(d_limits, gpuStreamList[thread_id]));
          return;
       }
 

--- a/arch/gpu_base.cpp
+++ b/arch/gpu_base.cpp
@@ -297,7 +297,7 @@ int gpu_reportMemory(const size_t local_cells_capacity, const size_t ghost_cells
       + gpu_allocated_moments*sizeof(vmesh::VelocityBlockContainer*) // gpu_moments dev_VBC
       + gpu_allocated_moments*4*sizeof(Real)  // gpu_moments dev_moments1
       + gpu_allocated_moments*3*sizeof(Real); // gpu_moments dev_moments2
-   // DT reduction buffers are deallocated every step (GPUTODO)
+   // DT reduction buffers are deallocated every step (GPUTODO, make persistent)
 
    size_t vlasovBuffers = 0;
    for (uint i=0; i<allocationCount; ++i) {
@@ -431,8 +431,8 @@ __host__ void gpu_vlasov_allocate_perthread(
    if (gpu_vlasov_allocatedSize[allocID] > blockAllocationCount * BLOCK_ALLOCATION_FACTOR) {
       return;
    }
-   // Potential new allocation with extra padding (including translation multiplier)
-   uint newSize = blockAllocationCount * BLOCK_ALLOCATION_PADDING * TRANSLATION_BUFFER_ALLOCATION_FACTOR;
+   // Potential new allocation with extra padding
+   uint newSize = blockAllocationCount * BLOCK_ALLOCATION_PADDING;
    // Deallocate before new allocation
    gpu_vlasov_deallocate_perthread(allocID);
    gpuStream_t stream = gpu_getStream();

--- a/arch/gpu_base.hpp
+++ b/arch/gpu_base.hpp
@@ -156,6 +156,9 @@ struct ColumnOffsets {
    __device__ size_t dev_sizeCols() const {
       return columnBlockOffsets.size(); // Uses this as an example
    }
+   __device__ size_t dev_sizeColSets() const {
+      return setNumColumns.size(); // Uses this as an example
+   }
    __device__ size_t dev_capacityCols() const {
       return columnBlockOffsets.capacity(); // Uses this as an example
    }
@@ -221,8 +224,8 @@ struct ColumnOffsets {
 };
 
 // Device data variables, to be allocated in good time. Made into an array so that each thread has their own pointer.
-extern Vec **host_blockDataOrdered;
-extern Vec **dev_blockDataOrdered;
+extern Realf **host_blockDataOrdered;
+extern Realf **dev_blockDataOrdered;
 extern uint *gpu_cell_indices_to_id;
 extern uint *gpu_block_indices_to_id;
 extern uint *gpu_block_indices_to_probe;

--- a/arch/gpu_base.hpp
+++ b/arch/gpu_base.hpp
@@ -51,10 +51,6 @@ static const double BLOCK_ALLOCATION_FACTOR = 1.1;
 // probe cube must store (5) counters / offsets, see vlasovsolver/gpu_acc_map.cpp for details.
 static const int GPU_PROBEFLAT_N = 5;
 
-// buffers need to be larger for translation to allow proper parallelism
-// GPUTODO: Get rid of this multiplier and consolidate buffer allocations
-static const int TRANSLATION_BUFFER_ALLOCATION_FACTOR = 5;
-
 #define MAXCPUTHREADS 512 // hypothetical max size for some allocation arrays
 
 void gpu_init_device();

--- a/arch/gpu_base.hpp
+++ b/arch/gpu_base.hpp
@@ -51,6 +51,12 @@ static const double BLOCK_ALLOCATION_FACTOR = 1.1;
 // probe cube must store (5) counters / offsets, see vlasovsolver/gpu_acc_map.cpp for details.
 static const int GPU_PROBEFLAT_N = 5;
 
+// buffers need to be larger for translation to allow proper parallelism
+// GPUTODO: Get rid of this multiplier and consolidate buffer allocations.
+// WARNING: Simply removing this factor led to diffs in Flowthrough_trans_periodic, indicating that
+// there is somethign wrong with the evaluation of buffers! To be investigated.
+static const int TRANSLATION_BUFFER_ALLOCATION_FACTOR = 5;
+
 #define MAXCPUTHREADS 512 // hypothetical max size for some allocation arrays
 
 void gpu_init_device();

--- a/grid.cpp
+++ b/grid.cpp
@@ -683,7 +683,7 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
    }
 
 #ifdef USE_GPU
-   phiprof::Timer gpuMallocTimer("GPU_malloc");
+   phiprof::Timer gpuReservationsTimer("GPU LB set cell reservations");
    uint gpuMaxBlockCount = 0;
    vmesh::LocalID gpuBlockCount = 0;
    // Not parallelized
@@ -710,12 +710,14 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
          SC->dev_upload_population(popID);
       }
    }
-   // Call GPU routines for per-thread memory allocation for Vlasov solvers
+   gpuReservationsTimer.stop();
+   // Call GPU routines for memory allocation for Vlasov solvers
    // deallocates first if necessary
-   //GPUTODO: Also count how many pencils exist
+   //GPUTODO: Also count how many pencils exist?
+   phiprof::Timer gpuAllocationsTimer("GPU LB set buffer allocations");
    gpu_vlasov_allocate(gpuMaxBlockCount,newCellsSize);
    gpu_acc_allocate(gpuMaxBlockCount,newCellsSize);
-   gpuMallocTimer.stop();
+   gpuAllocationsTimer.stop();
 #endif // end USE_GPU
 
 }

--- a/grid.cpp
+++ b/grid.cpp
@@ -713,7 +713,6 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
    gpuReservationsTimer.stop();
    // Call GPU routines for memory allocation for Vlasov solvers
    // deallocates first if necessary
-   //GPUTODO: Also count how many pencils exist?
    phiprof::Timer gpuAllocationsTimer("GPU LB set buffer allocations");
    gpu_vlasov_allocate(gpuMaxBlockCount,newCellsSize);
    gpu_acc_allocate(gpuMaxBlockCount,newCellsSize);

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -237,34 +237,25 @@ namespace projects {
    }
 
    void Project::setVelocitySpace(const uint popID,SpatialCell* cell) const {
-      phiprof::Timer setVSpacetimer {"Set Velocity Space"};
       // Find list of blocks to initialize. The project.cpp version returns
       // all possible blocks, projectTriAxisSearch provides a more educated guess.
 
-      phiprof::Timer findblocksTimer {"find blocks to init"};
       const uint nRequested = this->findBlocksToInitialize(cell,popID);
       // stores in vmesh->getGrid() (localToGlobalMap)
       // with count in cell->get_population(popID).N_blocks
-      findblocksTimer.stop();
 
       // Set and apply the reservation value
       #ifdef USE_GPU
-      phiprof::Timer reservationTimer {"set apply reservation"};
       cell->setReservation(popID,nRequested,true); // Force to this value
       cell->applyReservation(popID);
-      reservationTimer.stop();
       #endif
 
       // Resize and populate mesh
-      phiprof::Timer receiveTimer {"prepare to receive blocks"};
       cell->prepare_to_receive_blocks(popID);
-      receiveTimer.stop();
 
       // Call project-specific fill function, which loops over all requested blocks,
       // fills v-space into target
-      phiprof::Timer fillTimer {"fill phasespace"};
       const Realf nullsum = fillPhaseSpace(cell, popID, nRequested);
-      fillTimer.stop();
       if (rescalesDensity(popID) == true) {
          rescaleDensity(cell,popID);
       }
@@ -453,7 +444,7 @@ namespace projects {
 
       bool shouldRefine {
          (r2 < r_max2) && (
-            alpha1ShouldRefine || 
+            alpha1ShouldRefine ||
             alpha2ShouldRefine ||
             vorticityShouldRefine ||
             anisotropyShouldRefine
@@ -498,7 +489,7 @@ namespace projects {
 
       bool shouldUnrefine {
          (r2 > r_max2) || (
-            alpha1ShouldUnrefine && 
+            alpha1ShouldUnrefine &&
             alpha2ShouldUnrefine &&
             vorticityShouldUnrefine &&
             anisotropyShouldUnrefine
@@ -728,7 +719,7 @@ Project* createProject() {
    if(Parameters::projectName == "LossCone") {
       rvalue = new projects::LossCone;
    }
-   
+
 
    if (rvalue == NULL) {
       cerr << "Unknown project name!" << endl;

--- a/projects/projectTriAxisSearch.cpp
+++ b/projects/projectTriAxisSearch.cpp
@@ -34,7 +34,6 @@ namespace projects {
    uint TriAxisSearch::findBlocksToInitialize(SpatialCell* cell,const uint popID) const {
       vmesh::VelocityMesh *vmesh = cell->get_velocity_mesh(popID);
 
-      phiprof::Timer searchTimer {"v-space search"};
       vmesh::GlobalID *GIDbuffer;
       #ifdef USE_GPU
       // Host-pinned memory buffer, max possible size
@@ -172,10 +171,8 @@ namespace projects {
       } // iteration over V0's
       // Set final size of vmesh
       cell->get_population(popID).N_blocks = LID;
-      searchTimer.stop();
 
       #ifdef USE_GPU
-      phiprof::Timer uploadTimer {"v-space upload"};
       // Copy data from CPU to GPU
       cell->dev_resize_vmesh(popID,LID);
       vmesh::GlobalID *GIDtarget = vmesh->getGrid()->data();
@@ -183,7 +180,6 @@ namespace projects {
       CHK_ERR( gpuMemcpyAsync(GIDtarget, GIDbuffer, LID*sizeof(vmesh::GlobalID), gpuMemcpyHostToDevice, stream));
       CHK_ERR( gpuStreamSynchronize(stream) );
       CHK_ERR( gpuFreeHost(GIDbuffer));
-      uploadTimer.stop();
       #else
       // Resize vmesh down to final size
       vmesh->setNewSize(LID);

--- a/projects/projectTriAxisSearch.cpp
+++ b/projects/projectTriAxisSearch.cpp
@@ -34,6 +34,7 @@ namespace projects {
    uint TriAxisSearch::findBlocksToInitialize(SpatialCell* cell,const uint popID) const {
       vmesh::VelocityMesh *vmesh = cell->get_velocity_mesh(popID);
 
+      phiprof::Timer searchTimer {"v-space search"};
       vmesh::GlobalID *GIDbuffer;
       #ifdef USE_GPU
       // Host-pinned memory buffer, max possible size
@@ -121,7 +122,7 @@ namespace projects {
          counterZ+=buffer;
          vRadiusSquared = max(vRadiusSquared, (Real)counterZ*(Real)counterZ*dvzBlock*dvzBlock);
 
-         #ifndef USE_GPU
+         #ifndef USE_GPU // non-GPU mesh resizing
          // sphere volume is 4/3 pi r^3, approximate that 5*counterX*counterY*counterZ is enough.
          vmesh::LocalID currentMaxSize = LID + 5*counterX*counterY*counterZ;
          vmesh->setNewSize(currentMaxSize);
@@ -144,7 +145,7 @@ namespace projects {
                              + (V_crds[1])*(V_crds[1])
                              + (V_crds[2])*(V_crds[2]));
 
-                  #ifndef USE_GPU
+                  #ifndef USE_GPU // non-GPU mesh resizing
                   if (LID >= currentMaxSize) {
                      currentMaxSize = LID + counterX*counterY*counterZ;
                      vmesh->setNewSize(currentMaxSize);
@@ -169,19 +170,22 @@ namespace projects {
             } // vyblocks_ini
          } // vzblocks_ini
       } // iteration over V0's
-
       // Set final size of vmesh
       cell->get_population(popID).N_blocks = LID;
+      searchTimer.stop();
 
       #ifdef USE_GPU
-      // Copy data into place
+      phiprof::Timer uploadTimer {"v-space upload"};
+      // Copy data from CPU to GPU
       cell->dev_resize_vmesh(popID,LID);
       vmesh::GlobalID *GIDtarget = vmesh->getGrid()->data();
       gpuStream_t stream = gpu_getStream();
       CHK_ERR( gpuMemcpyAsync(GIDtarget, GIDbuffer, LID*sizeof(vmesh::GlobalID), gpuMemcpyHostToDevice, stream));
       CHK_ERR( gpuStreamSynchronize(stream) );
       CHK_ERR( gpuFreeHost(GIDbuffer));
+      uploadTimer.stop();
       #else
+      // Resize vmesh down to final size
       vmesh->setNewSize(LID);
       #endif
 

--- a/spatial_cells/block_adjust_gpu.cpp
+++ b/spatial_cells/block_adjust_gpu.cpp
@@ -346,7 +346,6 @@ void adjust_velocity_blocks_in_cells(
    }
    // Halo of 1 in each direction adds up to 26 velocity neighbors.
 
-   // std::cerr<<" largestContentList "<<largestContentList<<std::endl;
    #ifdef USE_BATCH_WARPACCESSORS
    // For NVIDIA/CUDA, we can do 26 neighbors and 32 threads per warp in a single block.
    // For AMD/HIP, we can do 13 neighbors and 64 threads per warp in a single block, meaning two loops per cell.

--- a/spatial_cells/block_adjust_gpu.cpp
+++ b/spatial_cells/block_adjust_gpu.cpp
@@ -346,6 +346,7 @@ void adjust_velocity_blocks_in_cells(
    }
    // Halo of 1 in each direction adds up to 26 velocity neighbors.
 
+   // std::cerr<<" largestContentList "<<largestContentList<<std::endl;
    #ifdef USE_BATCH_WARPACCESSORS
    // For NVIDIA/CUDA, we can do 26 neighbors and 32 threads per warp in a single block.
    // For AMD/HIP, we can do 13 neighbors and 64 threads per warp in a single block, meaning two loops per cell.

--- a/spatial_cells/block_adjust_gpu_kernels.hpp
+++ b/spatial_cells/block_adjust_gpu_kernels.hpp
@@ -96,7 +96,7 @@ __global__ void __launch_bounds__(WID3,WID3S_PER_MP) batch_update_velocity_block
       has_content[ti] = avgs[ti] >= velocity_block_min_value ? 1 : 0;
       __syncthreads(); // THIS SYNC IS CRUCIAL!
       // Implemented just a simple non-optimized thread OR
-      // GPUTODO reductions via warp voting
+      // GPUTODO reductions via two cycles of warp voting
 
       if (gatherMass) {
          gathered_mass[ti] = avgs[ti];

--- a/spatial_cells/spatial_cell_gpu.cpp
+++ b/spatial_cells/spatial_cell_gpu.cpp
@@ -802,7 +802,8 @@ namespace spatial_cell {
             if (receiving) {
                // Set population size based on mpi_number_of_blocks transferred earlier.
                // Does not need to be cleared. Vmesh map and VBC will be prepared in prepare_to_receive_blocks.
-               populations[activePopID].vmesh->setNewSize(populations[activePopID].N_blocks);
+               // populations[activePopID].vmesh->setNewSize(populations[activePopID].N_blocks);
+               this->dev_resize_vmesh(activePopID,populations[activePopID].N_blocks);
                //populations[activePopID].vmesh->setNewSizeClear(populations[activePopID].N_blocks);
                //setNewSizeClear(activePopID,populations[activePopID].N_blocks);
             } else {

--- a/spatial_cells/velocity_mesh_gpu.h
+++ b/spatial_cells/velocity_mesh_gpu.h
@@ -682,7 +682,7 @@ namespace vmesh {
          gtl_sizepower = globalToLocalMap.getSizePower();
          return blocksSize;
       } else {
-         // GPUTODO: do inside kernel? If ever used.
+         // GPUTODO: do inside kernel? This function is used by SpatialCell::add_velocity_blocks.
          if (ltg_size+blocksSize > ltg_capacity) {
             ltg_capacity = (ltg_size+blocksSize)*BLOCK_ALLOCATION_FACTOR;
             localToGlobalMap.reserve(ltg_capacity,true,stream);

--- a/velocity_mesh_parameters.cpp
+++ b/velocity_mesh_parameters.cpp
@@ -91,7 +91,11 @@ void vmesh::MeshWrapper::uploadMeshWrapper() {
          break;
       }
    }
-   printf("Done setting all %d instances of device mesh wrapper handler!\n",count);
+   int myRank;
+   MPI_Comm_rank(MPI_COMM_WORLD,&myRank);
+   if(myRank == MASTER_RANK) {
+      printf("Done setting all %d instances of device mesh wrapper handler!\n",count);
+   }
 
    // Copy host-side address back
    meshWrapper->velocityMeshes = temp;
@@ -110,8 +114,9 @@ void vmesh::deallocateMeshWrapper() {
 void vmesh::MeshWrapper::initVelocityMeshes(const uint nMeshes) {
    // Verify lengths match?
    if (meshWrapper->velocityMeshesCreation->size() != nMeshes) {
-      printf("Warning! Initializing only %d velocity meshes out of %d created ones.\n",nMeshes,
+      printf("Error! Initialized only %d velocity meshes out of %d created ones.\n",nMeshes,
              (int)meshWrapper->velocityMeshesCreation->size());
+      abort();
    }
    // Create pointer to array of sufficient length
    meshWrapper->velocityMeshes = new std::array<vmesh::MeshParameters,MAX_VMESH_PARAMETERS_COUNT>;

--- a/vlasovsolver/cpu_1d_ppm_nonuniform.hpp
+++ b/vlasovsolver/cpu_1d_ppm_nonuniform.hpp
@@ -89,4 +89,27 @@ ARCH_DEV inline void compute_ppm_coeff_nonuniform(const Realf* __restrict__ cons
    a[2] = (m_face + p_face - 2.0 * values[k][index]);
 }
 
+ARCH_DEV inline void compute_ppm_coeff_nonuniform(const Realf* __restrict__ const dv, const Realf* __restrict__ const values, face_estimate_order order, uint k, Realf a[3], const Realf threshold, const int index, const int stride){
+   Realf m_face; /*left face value*/
+   Realf p_face; /*right face value*/
+   compute_filtered_face_values_nonuniform(dv, values, k, order, m_face, p_face, threshold, index, stride);
+
+   //Coella et al, check for monotonicity
+   m_face = ((p_face - m_face) * (values[k*stride+index] - 0.5 * (m_face + p_face)) >
+             (p_face - m_face)*(p_face - m_face) * (1./6.)) ?
+      3 * values[k*stride+index] - 2 * p_face :
+      m_face;
+   p_face = (-(p_face - m_face) * (p_face - m_face) * (1./6.)) >
+      (p_face - m_face) * (values[k*stride+index] - 0.5 * (m_face + p_face)) ?
+      3 * values[k*stride+index] - 2 * m_face :
+      p_face;
+
+   //Fit a second order polynomial for reconstruction see, e.g., White
+   //2008 (PQM article) (note additional integration factors built in,
+   //contrary to White (2008) eq. 4
+   a[0] = m_face;
+   a[1] = 3.0 * values[k*stride+index] - 2.0 * m_face - p_face;
+   a[2] = (m_face + p_face - 2.0 * values[k*stride+index]);
+}
+
 #endif

--- a/vlasovsolver/cpu_1d_ppm_nonuniform_conserving.hpp
+++ b/vlasovsolver/cpu_1d_ppm_nonuniform_conserving.hpp
@@ -20,15 +20,14 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef HOSTDEV_1D_PPM_H
-#define HOSTDEV_1D_PPM_H
+#ifndef CPU_1D_PPM_H
+#define CPU_1D_PPM_H
 
 #include <iostream>
 #include "vec.h"
 #include "algorithm"
 #include "cmath"
 
-#include "../arch/arch_device_api.h"
 #include "cpu_slope_limiters.hpp"
 #include "cpu_face_estimates.hpp"
 
@@ -60,32 +59,5 @@ inline void compute_ppm_coeff_nonuniform(const Vec * const dv, const Vec * const
    a[2] = (m_face + p_face - 2.0 * values[k]);
 }
 
-
-/****
-      Define functions for Realf instead of Vec
-***/
-
-ARCH_DEV inline void compute_ppm_coeff_nonuniform(const Vec* __restrict__ const dv, const Vec* __restrict__ const values, face_estimate_order order, uint k, Realf a[3], const Realf threshold, const int index){
-   Realf m_face; /*left face value*/
-   Realf p_face; /*right face value*/
-   compute_filtered_face_values_nonuniform_conserving(dv, values, k, order, m_face, p_face, threshold, index);
-
-   //Coella et al, check for monotonicity
-   //  m_face = select((p_face - m_face) * (values[k] - 0.5 * (m_face + p_face)) >
-   //                  (p_face - m_face)*(p_face - m_face) * one_sixth,
-   //                  3 * values[k] - 2 * p_face,
-   //                  m_face);
-   // p_face = select(-(p_face - m_face) * (p_face - m_face) * one_sixth >
-   //                  (p_face - m_face) * (values[k] - 0.5 * (m_face + p_face)),
-   //                 3 * values[k] - 2 * m_face,
-   //                 p_face);
-
-   //Fit a second order polynomial for reconstruction see, e.g., White
-   //2008 (PQM article) (note additional integration factors built in,
-   //contrary to White (2008) eq. 4
-   a[0] = m_face;
-   a[1] = 3.0 * values[k][index] - 2.0 * m_face - p_face;
-   a[2] = (m_face + p_face - 2.0 * values[k][index]);
-}
 
 #endif

--- a/vlasovsolver/cpu_1d_pqm.hpp
+++ b/vlasovsolver/cpu_1d_pqm.hpp
@@ -20,16 +20,15 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef HOSTDEV_1D_PQM_H
-#define HOSTDEV_1D_PQM_H
+#ifndef CPU_1D_PQM_H
+#define CPU_1D_PQM_H
 
 #include "vec.h"
-#include "../arch/arch_device_api.h"
 #include "cpu_slope_limiters.hpp"
 #include "cpu_face_estimates.hpp"
 
 /*make sure quartic polynomial is monotonic*/
-static ARCH_HOSTDEV inline void filter_pqm_monotonicity(const Vec* __restrict__ values, uint k, Vec &fv_l, Vec &fv_r, Vec &fd_l, Vec &fd_r){
+static inline void filter_pqm_monotonicity(const Vec* __restrict__ values, uint k, Vec &fv_l, Vec &fv_r, Vec &fd_l, Vec &fd_r){
    /*second derivative coefficients, eq 23 in white et al.*/
    const Vec b0 =   60.0 * values[k] - 24.0 * fv_r - 36.0 * fv_l + 3.0 * (fd_r - 3.0 * fd_l);
    const Vec b1 = -360.0 * values[k] + 36.0 * fd_l - 24.0 * fd_r + 168.0 * fv_r + 192.0 * fv_l;
@@ -94,9 +93,7 @@ static ARCH_HOSTDEV inline void filter_pqm_monotonicity(const Vec* __restrict__ 
       //todo store and then load data to avoid inserts (is it beneficial...?)
 
 //serialized the handling of inflexion points, these do not happen for smooth regions
-#ifndef USE_GPU
 #pragma omp simd
-#endif
       for(uint i = 0;i < VECL; i++) {
          if(fixInflexion[i]){
             //need to collapse, at least one inflexion point has wrong
@@ -157,7 +154,7 @@ static ARCH_HOSTDEV inline void filter_pqm_monotonicity(const Vec* __restrict__ 
 //   White, Laurent, and Alistair Adcroft. “A High-Order Finite Volume Remapping Scheme for Nonuniform Grids: The Piecewise Quartic Method (PQM).” Journal of Computational Physics 227, no. 15 (July 2008): 7394–7422. doi:10.1016/j.jcp.2008.04.026.
 // */
 
-static ARCH_HOSTDEV inline void compute_pqm_coeff(const Vec* __restrict__ values, face_estimate_order order, uint k, Vec a[5], const Realf threshold)
+static inline void compute_pqm_coeff(const Vec* __restrict__ values, face_estimate_order order, uint k, Vec a[5], const Realf threshold)
 {
    Vec fv_l; /*left face value*/
    Vec fv_r; /*right face value*/
@@ -173,126 +170,6 @@ static ARCH_HOSTDEV inline void compute_pqm_coeff(const Vec* __restrict__ values
    a[2] =  10.0 * values[k] - 4.0 * fv_r - 6.0 * fv_l + 0.5 * (fd_r - 3 * fd_l);
    a[3] = -15.0 * values[k]  + 1.5 * fd_l - fd_r + 7.0 * fv_r + 8 * fv_l;
    a[4] =   6.0 * values[k] +  0.5 * (fd_r - fd_l) - 3.0 * (fv_l + fv_r);
-}
-
-
-/****
-     Define functions for Realf instead of Vec
-***/
-
-/*make sure quartic polynomial is monotonic*/
-static ARCH_DEV inline void filter_pqm_monotonicity(const Vec* __restrict__ values, uint k, Realf &fv_l, Realf &fv_r, Realf &fd_l, Realf &fd_r, const int index) {
-   /*fixed values give to roots clearly outside [0,1], or nonexisting ones*/
-
-   /*second derivative coefficients, eq 23 in white et al.*/
-   const Realf b0 =   60.0 * values[k][index] - 24.0 * fv_r - 36.0 * fv_l + 3.0 * (fd_r - 3.0 * fd_l);
-   const Realf b1 = -360.0 * values[k][index] + 36.0 * fd_l - 24.0 * fd_r + 168.0 * fv_r + 192.0 * fv_l;
-   const Realf b2 =  360.0 * values[k][index] + 30.0 * (fd_r - fd_l) - 180.0 * (fv_l + fv_r);
-   /*let's compute sqrt value to be used for computing roots. If we
-     take sqrt of negaitve numbers, then we instead set a value that
-     will make the root to be +-100 which is well outside range
-     of[0,1]. We do not catch FP exceptions, so sqrt(negative) are okish (add
-     a max(val_to_sqrt,0) if not*/
-   const Realf val_to_sqrt = b1 * b1 - 4 * b0 * b2;
-   const Realf sqrt_val = (val_to_sqrt < 0.0) ?
-      b1 + 200.0 * b2 :
-      sqrt(val_to_sqrt);
-   //compute roots. Division is safe with vectorclass (=inf)
-   const Realf root1 = (b2 != 0) ? (-b1 + sqrt_val) / (2 * b2) : 0;
-   const Realf root2 = (b2 != 0) ? (-b1 - sqrt_val) / (2 * b2) : 0;
-
-   /*PLM slope, MC limiter*/
-   const Realf plm_slope_l = 2.0 * (values[k][index] - values[k - 1][index]);
-   const Realf plm_slope_r = 2.0 * (values[k + 1][index] - values[k][index]);
-   const Realf slope_sign = plm_slope_l + plm_slope_r; //it also has some magnitude, but we will only use its sign.
-   /*first derivative coefficients*/
-   const Realf c0 = fd_l;
-   const Realf c1 = b0;
-   const Realf c2 = b1 / 2.0;
-   const Realf c3 = b2 / 3.0;
-   //compute both slopes at inflexion points, at least one of these
-   //is with [0..1]. If the root is not in this range, we
-   //simplify later if statements by setting it to the plm slope
-   //sign
-   const Realf root1_slope = (root1 >= 0.0 && root1 <= 1.0) ?
-      c0  + root1 * ( c1 + root1 * (c2 + root1 * c3 ) ) :
-      slope_sign;
-   const Realf root2_slope = (root2 >= 0.0 && root2 <= 1.0) ?
-      c0  + root2 * ( c1 + root2 * (c2 + root2 * c3 ) ) :
-      slope_sign;
-   const bool fixInflexion = root1_slope * slope_sign < 0.0 || root2_slope * slope_sign < 0.0;
-
-   if(fixInflexion) {
-      const Realf valuesa = values[k][index];
-      Realf fva_l = fv_l;
-      Realf fva_r = fv_r;
-      Realf fda_l = fd_l;
-      Realf fda_r = fd_r;
-      const Realf slope_signa = slope_sign;
-      //need to collapse, point has wrong sign
-
-      if(fabs(plm_slope_l) <= fabs(plm_slope_r))
-      {
-         //collapse to left edge (eq 21)
-         fda_l =  1.0 / 3.0 * ( 10 * valuesa - 2.0 * fva_r - 8.0 * fva_l);
-         fda_r =  -10.0 * valuesa + 6.0 * fva_r + 4.0 * fva_l;
-         //check if PLM slope is consistent (eq 28 & 29)
-         if (slope_signa * fda_l < 0)
-         {
-            fda_l =  0;
-            fva_r =  5 * valuesa - 4 * fva_l;
-            fda_r =  20 * (valuesa - fva_l);
-         }
-         else if (slope_signa * fda_r < 0)
-         {
-            fda_r =  0;
-            fva_l =  0.5 * (5 * valuesa - 3 * fva_r);
-            fda_l =  10.0 / 3.0 * (-valuesa + fva_r);
-         }
-      }
-      else
-      {
-         //collapse to right edge (eq 21)
-         fda_l =  10.0 * valuesa - 6.0 * fva_l - 4.0 * fva_r;
-         fda_r =  1.0 / 3.0 * ( - 10.0 * valuesa + 2 * fva_l + 8 * fva_r);
-         //check if PLM slope is consistent (eq 28 & 29)
-         if (slope_signa * fda_l < 0)
-         {
-            fda_l =  0;
-            fva_r =  0.5 * ( 5 * valuesa - 3 * fva_l);
-            fda_r =  10.0 / 3.0 * (valuesa - fva_l);
-         }
-         else if (slope_signa * fda_r < 0)
-         {
-            fda_r =  0;
-            fva_l =  5 * valuesa - 4 * fva_r;
-            fda_l =  20.0 * ( - valuesa + fva_r);
-         }
-      }
-      fv_l = (Realf)fva_l;
-      fd_l = (Realf)fda_l;
-      fv_r = (Realf)fva_r;
-      fd_r = (Realf)fda_r;
-   }
-}
-
-static ARCH_DEV inline void compute_pqm_coeff(const Vec* __restrict__ values, face_estimate_order order, uint k, Realf a[5], const Realf threshold, const int index)
-{
-   Realf fv_l; /*left face value*/
-   Realf fv_r; /*right face value*/
-   Realf fd_l; /*left face derivative*/
-   Realf fd_r; /*right face derivative*/
-
-   compute_filtered_face_values_derivatives(values, k, order, fv_l, fv_r, fd_l, fd_r, threshold, index);
-   filter_pqm_monotonicity(values, k, fv_l, fv_r, fd_l, fd_r, index);
-   //Fit a second order polynomial for reconstruction see, e.g., White
-   //2008 (PQM article) (note additional integration factors built in,
-   //contrary to White (2008) eq. 4
-   a[0] = fv_l;
-   a[1] = fd_l/2.0;
-   a[2] =  10.0 * values[k][index] - 4.0 * fv_r - 6.0 * fv_l + 0.5 * (fd_r - 3 * fd_l);
-   a[3] = -15.0 * values[k][index]  + 1.5 * fd_l - fd_r + 7.0 * fv_r + 8 * fv_l;
-   a[4] =   6.0 * values[k][index] +  0.5 * (fd_r - fd_l) - 3.0 * (fv_l + fv_r);
 }
 
 

--- a/vlasovsolver/cpu_acc_intersections.cpp
+++ b/vlasovsolver/cpu_acc_intersections.cpp
@@ -56,7 +56,6 @@ void compute_cell_intersections(
    Transform<Real,3,Affine> bwd_transform= fwd_transform.inverse();
 
    phiprof::Timer intersectionsTimer {intersections_id};
-   // std::cerr<<" intersections map order "<<map_order<<std::endl;
    switch(map_order){
       case 0: {
          //Map order XYZ

--- a/vlasovsolver/cpu_acc_intersections.cpp
+++ b/vlasovsolver/cpu_acc_intersections.cpp
@@ -56,6 +56,7 @@ void compute_cell_intersections(
    Transform<Real,3,Affine> bwd_transform= fwd_transform.inverse();
 
    phiprof::Timer intersectionsTimer {intersections_id};
+   // std::cerr<<" intersections map order "<<map_order<<std::endl;
    switch(map_order){
       case 0: {
          //Map order XYZ

--- a/vlasovsolver/cpu_face_estimates.hpp
+++ b/vlasovsolver/cpu_face_estimates.hpp
@@ -20,8 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef HOSTDEV_FACE_ESTIMATES_H
-#define HOSTDEV_FACE_ESTIMATES_H
+#ifndef CPU_FACE_ESTIMATES_H
+#define CPU_FACE_ESTIMATES_H
 
 #include "vec.h"
 #include "cpu_slope_limiters.hpp"
@@ -42,7 +42,7 @@ enum face_estimate_order {h4, h5, h6, h8};
   \param i Index of cell in values for which the left face is computed
   \param fv_l Face value on left face of cell i
 */
-ARCH_HOSTDEV inline void compute_h8_left_face_value(const Vec * const values, uint k, Vec &fv_l)
+inline void compute_h8_left_face_value(const Vec * const values, uint k, Vec &fv_l)
 {
    fv_l = 1.0/840.0 * (
       - 3.0 * values[k - 4]
@@ -65,7 +65,7 @@ ARCH_HOSTDEV inline void compute_h8_left_face_value(const Vec * const values, ui
   \param i Index of cell in values for which the left face derivativeis computed
   \param fd_l Face derivative on left face of cell i
 */
-ARCH_HOSTDEV inline void compute_h7_left_face_derivative(const Vec * const values, uint k, Vec &fd_l){
+inline void compute_h7_left_face_derivative(const Vec * const values, uint k, Vec &fd_l){
    fd_l = 1.0/5040.0 * (
       + 9.0 * values[k - 4]
       - 119.0 * values[k - 3]
@@ -86,7 +86,7 @@ ARCH_HOSTDEV inline void compute_h7_left_face_derivative(const Vec * const value
   \param i Index of cell in values for which the left face is computed
   \param fv_l Face value on left face of cell i
 */
-ARCH_HOSTDEV inline void compute_h6_left_face_value(const Vec * const values, uint k, Vec &fv_l)
+inline void compute_h6_left_face_value(const Vec * const values, uint k, Vec &fv_l)
 {
    //compute left value
    fv_l = 1.0/60.0 * (values[k - 3]
@@ -106,7 +106,7 @@ ARCH_HOSTDEV inline void compute_h6_left_face_value(const Vec * const values, ui
   \param i Index of cell in values for which the left face derivativeis computed
   \param fd_l Face derivative on left face of cell i
 */
-ARCH_HOSTDEV inline void compute_h5_left_face_derivative(const Vec * const values, uint k, Vec &fd_l)
+inline void compute_h5_left_face_derivative(const Vec * const values, uint k, Vec &fd_l)
 {
    fd_l = 1.0/180.0 * (245 * (values[k] - values[k - 1])
                        - 25 * (values[k + 1] - values[k - 2])
@@ -120,7 +120,7 @@ ARCH_HOSTDEV inline void compute_h5_left_face_derivative(const Vec * const value
   \param i Index of cell in values for which the left face is computed
   \param fv_l Face value on left face of cell i
 */
-ARCH_HOSTDEV inline void compute_h5_face_values(const Vec * const values, uint k, Vec &fv_l, Vec &fv_r)
+inline void compute_h5_face_values(const Vec * const values, uint k, Vec &fv_l, Vec &fv_r)
 {
    //compute left values
    fv_l = 1.0/60.0 * (- 3.0 * values[k - 2]
@@ -143,7 +143,7 @@ ARCH_HOSTDEV inline void compute_h5_face_values(const Vec * const values, uint k
   \param i Index of cell in values for which the left face derivativeis computed
   \param fd_l Face derivative on left face of cell i
 */
-ARCH_HOSTDEV inline void compute_h4_left_face_derivative(const Vec * const values, uint k, Vec &fd_l)
+inline void compute_h4_left_face_derivative(const Vec * const values, uint k, Vec &fd_l)
 {
    fd_l = 1.0/12.0 * (15.0 * (values[k] - values[k - 1]) - (values[k + 1] - values[k - 2]));
 }
@@ -157,7 +157,7 @@ ARCH_HOSTDEV inline void compute_h4_left_face_derivative(const Vec * const value
   \param i Index of cell in values for which the left face is computed
   \param fv_l Face value on left face of cell i
 */
-ARCH_HOSTDEV inline void compute_h4_left_face_value(const Vec * const values, uint k, Vec &fv_l)
+inline void compute_h4_left_face_value(const Vec * const values, uint k, Vec &fv_l)
 {
    //compute left value
    fv_l = 1.0/12.0 * ( - 1.0 * values[k - 2]
@@ -176,7 +176,7 @@ ARCH_HOSTDEV inline void compute_h4_left_face_value(const Vec * const values, ui
   \param fv_l Face value on left face of cell i
   \param h Array with cell widths. Can be in abritrary units since they always cancel. Maybe 1/refinement ratio?
 */
-ARCH_HOSTDEV inline void compute_h4_left_face_value_nonuniform(const Realf * const h, const Vec * const u, uint k, Vec &fv_l) {
+inline void compute_h4_left_face_value_nonuniform(const Realf * const h, const Vec * const u, uint k, Vec &fv_l) {
 
    fv_l = (
       1.0 / ( h[k - 2] + h[k - 1] + h[k] + h[k + 1] )
@@ -201,7 +201,7 @@ ARCH_HOSTDEV inline void compute_h4_left_face_value_nonuniform(const Realf * con
   \param i Index of cell in values for which the left face is computed
   \param fv_l Face value on left face of cell i
 */
-ARCH_HOSTDEV inline void compute_h3_left_face_derivative(const Vec * const values, uint k, Vec &fv_l)
+inline void compute_h3_left_face_derivative(const Vec * const values, uint k, Vec &fv_l)
 {
    /*compute left value*/
    fv_l = 1.0/12.0 * (15 * (values[k] - values[k - 1]) - (values[k + 1] - values[k - 2]));
@@ -212,7 +212,7 @@ ARCH_HOSTDEV inline void compute_h3_left_face_derivative(const Vec * const value
   2) Makes face values bounded
   3) Makes sure face slopes are consistent with PLM slope
 */
-ARCH_HOSTDEV inline void compute_filtered_face_values_derivatives(const Vec * const values, uint k, face_estimate_order order, Vec &fv_l, Vec &fv_r, Vec &fd_l, Vec &fd_r, const Realf threshold)
+inline void compute_filtered_face_values_derivatives(const Vec * const values, uint k, face_estimate_order order, Vec &fv_l, Vec &fv_r, Vec &fd_l, Vec &fd_r, const Realf threshold)
 {
    switch(order)
    {
@@ -275,7 +275,7 @@ ARCH_HOSTDEV inline void compute_filtered_face_values_derivatives(const Vec * co
   2) Makes face values bounded
   3) Makes sure face slopes are consistent with PLM slope
 */
-ARCH_HOSTDEV inline void compute_filtered_face_values(const Vec * const values, uint k, face_estimate_order order, Vec &fv_l, Vec &fv_r, const Realf threshold)
+inline void compute_filtered_face_values(const Vec * const values, uint k, face_estimate_order order, Vec &fv_l, Vec &fv_r, const Realf threshold)
 {
    switch(order)
    {
@@ -324,7 +324,7 @@ ARCH_HOSTDEV inline void compute_filtered_face_values(const Vec * const values, 
 
 
 
-ARCH_HOSTDEV inline void compute_filtered_face_values_nonuniform(const Realf * const dv, const Vec * const values, uint k, face_estimate_order order, Vec &fv_l, Vec &fv_r, const Realf threshold){
+inline void compute_filtered_face_values_nonuniform(const Realf * const dv, const Vec * const values, uint k, face_estimate_order order, Vec &fv_l, Vec &fv_r, const Realf threshold){
    switch(order){
       case h4:
          compute_h4_left_face_value_nonuniform(dv, values, k, fv_l);
@@ -377,7 +377,7 @@ ARCH_HOSTDEV inline void compute_filtered_face_values_nonuniform(const Realf * c
    }
 }
 
-ARCH_HOSTDEV inline Vec get_D2aLim(const Realf * h, const Vec * values, uint k, const Vec C, Vec & fv) {
+inline Vec get_D2aLim(const Realf * h, const Vec * values, uint k, const Vec C, Vec & fv) {
 
    // Colella & Sekora, eq. 18
    Vec invh2 = 1.0 / (h[k] * h[k]);
@@ -394,7 +394,7 @@ ARCH_HOSTDEV inline Vec get_D2aLim(const Realf * h, const Vec * values, uint k, 
    return d2aLim;
 }
 
-ARCH_HOSTDEV inline void constrain_face_values(const Realf * h,const Vec * values,uint k,Vec & fv_l, Vec & fv_r) {
+inline void constrain_face_values(const Realf * h,const Vec * values,uint k,Vec & fv_l, Vec & fv_r) {
 
    const Vec C = 1.25;
    Vec invh2 = 1.0 / (h[k] * h[k]);
@@ -434,7 +434,7 @@ ARCH_HOSTDEV inline void constrain_face_values(const Realf * h,const Vec * value
 
 }
 
-ARCH_HOSTDEV inline void compute_filtered_face_values_nonuniform_conserving(const Realf * const dv, const Vec * const values,uint k, face_estimate_order order, Vec &fv_l, Vec &fv_r, const Realf threshold){
+inline void compute_filtered_face_values_nonuniform_conserving(const Realf * const dv, const Vec * const values,uint k, face_estimate_order order, Vec &fv_l, Vec &fv_r, const Realf threshold){
    switch(order){
       case h4:
          compute_h4_left_face_value_nonuniform(dv, values, k, fv_l);
@@ -510,462 +510,5 @@ ARCH_HOSTDEV inline void compute_filtered_face_values_nonuniform_conserving(cons
    // }
 
 }
-
-
-
-/****
-     Define functions for Realf instead of Vec
-***/
-
-
-
-
-ARCH_DEV inline void compute_h8_left_face_value(const Vec * const values, uint k, Realf &fv_l, const int index)
-{
-   fv_l = 1.0/840.0 * (
-      - 3.0 * values[k - 4][index]
-      + 29.0 * values[k - 3][index]
-      - 139.0 * values[k - 2][index]
-      + 533.0 * values[k - 1][index]
-      + 533.0 * values[k][index]
-      - 139.0 * values[k + 1][index]
-      + 29.0 * values[k + 2][index]
-      - 3.0 * values[k + 3][index]);
-}
-ARCH_DEV inline void compute_h7_left_face_derivative(const Vec * const values, uint k, Realf &fd_l, const int index){
-   fd_l = 1.0/5040.0 * (
-      + 9.0 * values[k - 4][index]
-      - 119.0 * values[k - 3][index]
-      + 889.0 * values[k - 2][index]
-      - 7175.0 * values[k - 1][index]
-      + 7175.0 * values[k][index]
-      - 889.0 * values[k + 1][index]
-      + 119.0 * values[k + 2][index]
-      - 9.0 * values[k + 3][index]);
-}
-ARCH_DEV inline void compute_h6_left_face_value(const Vec * const values, uint k, Realf &fv_l, const int index)
-{
-   //compute left value
-   fv_l = 1.0/60.0 * (values[k - 3][index]
-                      - 8.0 * values[k - 2][index]
-                      + 37.0 * values[k - 1][index]
-                      + 37.0 * values[k ][index]
-                      - 8.0 * values[k + 1][index]
-                      + values[k + 2][index]);
-}
-ARCH_DEV inline void compute_h5_left_face_derivative(const Vec * const values, uint k, Realf &fd_l, const int index)
-{
-   fd_l = 1.0/180.0 * (245 * (values[k][index] - values[k - 1][index])
-                       - 25 * (values[k + 1][index] - values[k - 2][index])
-                       + 2 * (values[k + 2][index] - values[k - 3][index]));
-}
-ARCH_DEV inline void compute_h5_face_values(const Vec * const values, uint k, Realf &fv_l, Realf &fv_r, const int index)
-{
-   //compute left values
-   fv_l = 1.0/60.0 * (- 3.0 * values[k - 2][index]
-                      + 27.0 * values[k - 1][index]
-                      + 47.0 * values[k ][index]
-                      - 13.0 * values[k + 1][index]
-                      + 2.0 * values[k + 2][index]);
-   fv_r = 1.0/60.0 * ( 2.0 * values[k - 2][index]
-                       - 13.0 * values[k - 1][index]
-                       + 47.0 * values[k][index]
-                       + 27.0 * values[k + 1][index]
-                       - 3.0 * values[k + 2][index]);
-}
-ARCH_DEV inline void compute_h4_left_face_derivative(const Vec * const values, uint k, Realf &fd_l, const int index)
-{
-   fd_l = 1.0/12.0 * (15.0 * (values[k][index] - values[k - 1][index]) - (values[k + 1][index] - values[k - 2][index]));
-}
-ARCH_DEV inline void compute_h4_left_face_value(const Vec * const values, uint k, Realf &fv_l, const int index)
-{
-   //compute left value
-   fv_l = 1.0/12.0 * ( - 1.0 * values[k - 2][index]
-                       + 7.0 * values[k - 1][index]
-                       + 7.0 * values[k][index]
-                       - 1.0 * values[k + 1][index]);
-}
-
-ARCH_DEV inline void compute_h4_left_face_value_nonuniform(const Realf * const h, const Vec * const u, uint k, Realf &fv_l, const int index) {
-   fv_l = (
-      1.0 / ( h[k - 2] + h[k - 1] + h[k] + h[k + 1] )
-      * ( ( h[k - 2] + h[k - 1] ) * ( h[k] + h[k + 1] ) / ( h[k - 1] + h[k] )
-          * ( u[k - 1][index] * h[k] + u[k][index] * h[k - 1] )
-          * (1.0 / ( h[k - 2] + h[k - 1] + h[k] ) + 1.0 / ( h[k - 1] + h[k] + h[k + 1] ) )
-          + ( h[k] * ( h[k] + h[k + 1] ) ) / ( ( h[k - 2] + h[k - 1] + h[k] ) * (h[k - 2] + h[k - 1] ) )
-          * ( u[k - 1][index] * (h[k - 2] + 2.0 * h[k - 1] ) - ( u[k - 2][index] * h[k - 1] ) )
-          + h[k - 1] * ( h[k - 2] + h[k - 1] ) / ( ( h[k - 1] + h[k] + h[k + 1] ) * ( h[k] + h[k + 1] ) )
-          * ( u[k][index] * ( 2.0 * h[k] + h[k + 1] ) - u[k + 1][index] * h[k] ) )
-      );
-}
-
-
-
-
-ARCH_DEV inline void compute_h3_left_face_derivative(const Vec * const values, uint k, Realf &fv_l, const int index)
-{
-   /*compute left value*/
-   fv_l = 1.0/12.0 * (15 * (values[k][index] - values[k - 1][index]) - (values[k + 1][index] - values[k - 2][index]));
-}
-
-ARCH_DEV inline void compute_filtered_face_values_derivatives(const Vec * const values, uint k, face_estimate_order order, Realf &fv_l, Realf &fv_r, Realf &fd_l, Realf &fd_r, const Realf threshold, const int index)
-{
-   switch(order)
-   {
-      case h4:
-         compute_h4_left_face_value(values, k, fv_l, index);
-         compute_h4_left_face_value(values, k + 1, fv_r, index);
-         compute_h3_left_face_derivative(values, k, fd_l, index);
-         compute_h3_left_face_derivative(values, k + 1, fd_r, index);
-         break;
-      case h5:
-         compute_h5_face_values(values, k, fv_l, fv_r, index);
-         compute_h4_left_face_derivative(values, k, fd_l, index);
-         compute_h4_left_face_derivative(values, k + 1, fd_r, index);
-         break;
-      default:
-      case h6:
-         compute_h6_left_face_value(values, k, fv_l, index);
-         compute_h6_left_face_value(values, k + 1, fv_r, index);
-         compute_h5_left_face_derivative(values, k, fd_l, index);
-         compute_h5_left_face_derivative(values, k + 1, fd_r, index);
-         break;
-      case h8:
-         compute_h8_left_face_value(values, k, fv_l, index);
-         compute_h8_left_face_value(values, k + 1, fv_r, index);
-         compute_h7_left_face_derivative(values, k, fd_l, index);
-         compute_h7_left_face_derivative(values, k + 1, fd_r, index);
-         break;
-   }
-   Realf slope_abs,slope_sign;
-   // scale values closer to 1 for more accurate slope limiter calculation
-   const Realf scale = 1./threshold;
-   slope_limiter(values[k - 1][index]*scale, values[k][index]*scale, values[k + 1][index]*scale, slope_abs, slope_sign);
-   slope_abs = slope_abs*threshold;
-   //check for extrema, flatten if it is
-   bool is_extrema = (slope_abs == 0.0);
-   if (is_extrema) {
-      fv_r = (is_extrema) ? values[k][index] : fv_r;
-      fv_l = (is_extrema) ? values[k][index] : fv_l;
-      fd_l = (is_extrema) ? 0.0 : fd_l;
-      fd_r = (is_extrema) ? 0.0 : fd_r;
-   }
-   //Fix left face if needed; boundary value is not bounded or slope is not consistent
-   bool filter = (values[k - 1][index] - fv_l) * (fv_l - values[k][index]) < 0 || slope_sign * fd_l < 0.0;
-   if (filter) {
-      //Go to linear (PLM) estimates if not ok (this is always ok!)
-      fv_l= (filter) ? values[k ][index] - slope_sign * 0.5 * slope_abs : fv_l;
-      fd_l= (filter) ? slope_sign * slope_abs : fd_l;
-   }
-   //Fix right face if needed; boundary value is not bounded or slope is not consistent
-   filter = (values[k + 1][index] - fv_r) * (fv_r - values[k][index]) < 0 || slope_sign * fd_r < 0.0;
-   if (filter) {
-      //Go to linear (PLM) estimates if not ok (this is always ok!)
-      fv_r= (filter) ? values[k][index] + slope_sign * 0.5 * slope_abs : fv_r;
-      fd_r= (filter) ? slope_sign * slope_abs : fd_r;
-   }
-}
-
-/*Filters in section 2.6.1 of white et al. to be used for PPM
-  1) Checks for extrema and flattens them
-  2) Makes face values bounded
-  3) Makes sure face slopes are consistent with PLM slope
-*/
-ARCH_DEV inline void compute_filtered_face_values(const Vec * const values, uint k, face_estimate_order order, Realf &fv_l, Realf &fv_r, const Realf threshold, const int index)
-{
-   switch(order)
-   {
-      case h4:
-         compute_h4_left_face_value(values, k, fv_l, index);
-         compute_h4_left_face_value(values, k + 1, fv_r, index);
-         break;
-      case h5:
-         compute_h5_face_values(values, k, fv_l, fv_r, index);
-         break;
-      default:
-      case h6:
-         compute_h6_left_face_value(values, k, fv_l, index);
-         compute_h6_left_face_value(values, k + 1, fv_r, index);
-         break;
-      case h8:
-         compute_h8_left_face_value(values, k, fv_l, index);
-         compute_h8_left_face_value(values, k + 1, fv_r, index);
-         break;
-   }
-   Realf slope_abs, slope_sign;
-   // scale values closer to 1 for more accurate slope limiter calculation
-   const Realf scale = 1./threshold;
-   slope_limiter(values[k -1][index]*scale, values[k][index]*scale, values[k + 1][index]*scale, slope_abs, slope_sign);
-   slope_abs = slope_abs*threshold;
-
-   //check for extrema, flatten if it is
-   bool is_extrema = (slope_abs == 0.0);
-   if (is_extrema) {
-      fv_r = (is_extrema) ? values[k][index] : fv_r;
-      fv_l = (is_extrema) ? values[k][index] : fv_l;
-   }
-   //Fix left face if needed; boundary value is not bounded
-   bool filter = (values[k -1][index] - fv_l) * (fv_l - values[k][index]) < 0 ;
-   if (filter) {
-      //Go to linear (PLM) estimates if not ok (this is always ok!)
-      fv_l = (filter) ? values[k ][index] - slope_sign * 0.5 * slope_abs : fv_l;
-   }
-   //Fix  face if needed; boundary value is not bounded
-   filter = (values[k + 1][index] - fv_r) * (fv_r - values[k][index]) < 0;
-   if (filter) {
-      //Go to linear (PLM) estimates if not ok (this is always ok!)
-      fv_r = (filter) ? values[k][index] + slope_sign * 0.5 * slope_abs : fv_r;
-   }
-}
-
-ARCH_DEV inline void compute_filtered_face_values_nonuniform(const Realf * const dv, const Vec * const values,uint k, face_estimate_order order, Realf &fv_l, Realf &fv_r, const Realf threshold, const int index){
-   switch(order){
-      case h4:
-         compute_h4_left_face_value_nonuniform(dv, values, k, fv_l, index);
-         compute_h4_left_face_value_nonuniform(dv, values, k + 1, fv_r, index);
-         break;
-         // case h5:
-         //   compute_h5_face_values(dv, values, k, fv_l, fv_r, index);
-         //   break;
-         // case h6:
-         //   compute_h6_left_face_value(dv, values, k, fv_l, index);
-         //   compute_h6_left_face_value(dv, values, k + 1, fv_r, index);
-         //   break;
-         // case h8:
-         //   compute_h8_left_face_value(dv, values, k, fv_l, index);
-         //   compute_h8_left_face_value(dv, values, k + 1, fv_r, index);
-         //   break;
-      default:
-         printf("Order %d has not been implemented (yet)\n",order);
-         break;
-   }
-   Realf slope_abs,slope_sign;
-   if (threshold>0) {
-      // scale values closer to 1 for more accurate slope limiter calculation
-      const Realf scale = 1./threshold;
-      slope_limiter(values[k -1][index]*scale, values[k][index]*scale, values[k + 1][index]*scale, slope_abs, slope_sign);
-      slope_abs = slope_abs*threshold;
-   } else {
-      slope_limiter(values[k -1][index], values[k][index], values[k + 1][index], slope_abs, slope_sign);
-   }
-
-   //check for extrema, flatten if it is
-   if (slope_abs == 0) {
-      fv_r = values[k][index];
-      fv_l = values[k][index];
-   }
-
-   //Fix left face if needed; boundary value is not bounded
-   if ((values[k -1][index] - fv_l) * (fv_l - values[k][index]) < 0) {
-      //Go to linear (PLM) estimates if not ok (this is always ok!)
-      fv_l=values[k][index] - slope_sign * 0.5 * slope_abs;
-   }
-
-   //Fix  face if needed; boundary value is not bounded
-   if ((values[k + 1][index] - fv_r) * (fv_r - values[k][index]) < 0) {
-      //Go to linear (PLM) estimates if not ok (this is always ok!)
-      fv_r=values[k][index] + slope_sign * 0.5 * slope_abs;
-   }
-}
-
-ARCH_DEV inline Realf get_D2aLim(const Realf * h, const Vec * values, uint k, const Realf C, Realf & fv, const int index) {
-
-   // Colella & Sekora, eq. 18
-   Realf invh2 = 1.0 / (h[k] * h[k]);
-   Realf d2a =  invh2 * 3.0 * (values[k    ][index] - 2.0 * fv                   + values[k + 1][index]);
-   Realf d2aL = invh2       * (values[k - 1][index] - 2.0 * values[k    ][index] + values[k + 1][index]);
-   Realf d2aR = invh2       * (values[k    ][index] - 2.0 * values[k + 1][index] + values[k + 2][index]);
-   Realf d2aLim;
-   if ( (d2a * d2aL >= 0) && (d2a * d2aR >= 0) && (d2a != 0) ) {
-      d2aLim = d2a / abs(d2a) * min(abs(d2a),min(C*abs(d2aL),C*abs(d2aR)));
-   } else {
-      d2aLim = 0.0;
-   }
-   return d2aLim;
-}
-
-ARCH_DEV inline void constrain_face_values(const Realf * h,const Vec * values,uint k,Realf & fv_l, Realf & fv_r, const int index) {
-
-   const Realf C = 1.25;
-   Realf invh2 = 1.0 / (h[k] * h[k]);
-
-   // Colella & Sekora, eq 19
-   Realf p_face = 0.5 * (values[k][index] + values[k + 1][index])
-      - h[k] * h[k] / 3.0 * get_D2aLim(h,values,k  ,C,fv_r, index);
-   Realf m_face = 0.5 * (values[k-1][index] + values[k][index])
-      - h[k-1] * h[k-1] / 3.0 * get_D2aLim(h,values,k-1,C,fv_l, index);
-
-   // Colella & Sekora, eq 21
-   Realf d2a = -2.0 * invh2 * 6.0 * (values[k][index] - 3.0 * (m_face + p_face)); // a6,j from eq. 7
-   Realf d2aC = invh2 * (values[k - 1][index] - 2.0 * values[k    ][index] + values[k + 1][index]);
-   // Note: Corrected the index of 2nd term in d2aL to k - 1.
-   //       In the paper it is k but that is almost certainly an error.
-   Realf d2aL = invh2 * (values[k - 2][index] - 2.0 * values[k - 1][index] + values[k    ][index]);
-   Realf d2aR = invh2 * (values[k    ][index] - 2.0 * values[k + 1][index] + values[k + 2][index]);
-   Realf d2aLim;
-
-   // Colella & Sekora, eq 22
-   if ( (d2a * d2aL >= 0) && (d2a * d2aR >= 0) &&
-        (d2a * d2aC >= 0) && (d2a != 0) ) {
-
-      d2aLim = d2a / abs(d2a) * min(C * abs(d2aL), min(C * abs(d2aR), min(C * abs(d2aC), abs(d2a))));
-   } else {
-      d2aLim = 0.0;
-      if (d2a == 0.0) {
-         // Set a non-zero value for the denominator in eq. 23.
-         // According to the paper the ratio d2aLim/d2a should be 0
-         d2a = 1.0;
-      }
-   }
-
-   // Colella & Sekora, eq 23
-   fv_r = values[k][index] + (p_face - values[k][index]) * d2aLim / d2a;
-   fv_l = values[k][index] + (m_face - values[k][index]) * d2aLim / d2a;
-
-}
-
-ARCH_DEV inline void compute_filtered_face_values_nonuniform_conserving(const Realf * const dv, const Vec * const values,uint k, face_estimate_order order, Realf &fv_l, Realf &fv_r, const Realf threshold, const int index){
-   switch(order){
-      case h4:
-         compute_h4_left_face_value_nonuniform(dv, values, k, fv_l, index);
-         compute_h4_left_face_value_nonuniform(dv, values, k + 1, fv_r, index);
-         break;
-         // case h5:
-         //   compute_h5_face_values(dv, values, k, fv_l, fv_r);
-         //   break;
-         // case h6:
-         //   compute_h6_left_face_value(dv, values, k, fv_l);
-         //   compute_h6_left_face_value(dv, values, k + 1, fv_r);
-         //   break;
-         // case h8:
-         //   compute_h8_left_face_value(dv, values, k, fv_l);
-         //   compute_h8_left_face_value(dv, values, k + 1, fv_r);
-         //   break;
-      default:
-         printf("Order %d has not been implemented (yet)\n",order);
-         break;
-   }
-
-   Realf slope_abs,slope_sign;
-   if (threshold>0) {
-      // scale values closer to 1 for more accurate slope limiter calculation
-      const Realf scale = 1./threshold;
-      slope_limiter(values[k -1][index]*scale, values[k][index]*scale, values[k + 1][index]*scale, slope_abs, slope_sign);
-      slope_abs = slope_abs*threshold;
-   } else {
-      slope_limiter(values[k -1][index], values[k][index], values[k + 1][index], slope_abs, slope_sign);
-   }
-
-   //check for extrema
-   //bool is_extrema = (slope_abs == 0.0);
-   bool filter_l = (values[k - 1][index] - fv_l) * (fv_l - values[k][index]) < 0 ;
-   bool filter_r = (values[k + 1][index] - fv_r) * (fv_r - values[k][index]) < 0;
-   //  if(horizontal_or(is_extrema) || horizontal_or(filter_l) || horizontal_or(filter_r)) {
-   // Colella & Sekora, eq. 20
-   if (((fv_r - values[k][index]) * (values[k][index] - fv_l) <= 0.0)
-       && ((values[k - 1][index] - values[k][index]) * (values[k][index] - values[k + 1][index]) <= 0.0)) {
-      constrain_face_values(dv, values, k, fv_l, fv_r, index);
-
-      //    fv_r = select(is_extrema, values[k], fv_r);
-      //    fv_l = select(is_extrema, values[k], fv_l);
-   } else {
-
-      //Fix left face if needed; boundary value is not bounded
-      bool filter = (values[k -1][index] - fv_l) * (fv_l - values[k][index]) < 0 ;
-      if (filter) {
-         //Go to linear (PLM) estimates if not ok (this is always ok!)
-         fv_l=values[k ][index] - slope_sign * 0.5 * slope_abs;
-      }
-
-      //Fix  face if needed; boundary value is not bounded
-      filter = (values[k + 1][index] - fv_r) * (fv_r - values[k][index]) < 0;
-      if (filter) {
-         //Go to linear (PLM) estimates if not ok (this is always ok!)
-         fv_r=values[k][index] + slope_sign * 0.5 * slope_abs;
-      }
-   }
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-ARCH_DEV inline void compute_h4_left_face_value_nonuniform(const Realf * const h, const Realf * const u, uint k, Realf &fv_l, const int index, const int stride) {
-   fv_l = (
-      1.0 / ( h[k - 2] + h[k - 1] + h[k] + h[k + 1] )
-      * ( ( h[k - 2] + h[k - 1] ) * ( h[k] + h[k + 1] ) / ( h[k - 1] + h[k] )
-          * ( u[(k-1)*stride+index] * h[k] + u[k*stride+index] * h[k - 1] )
-          * (1.0 / ( h[k - 2] + h[k - 1] + h[k] ) + 1.0 / ( h[k - 1] + h[k] + h[k + 1] ) )
-          + ( h[k] * ( h[k] + h[k + 1] ) ) / ( ( h[k - 2] + h[k - 1] + h[k] ) * (h[k - 2] + h[k - 1] ) )
-          * ( u[(k-1)*stride+index] * (h[k - 2] + 2.0 * h[k - 1] ) - ( u[(k-2)*stride+index] * h[k - 1] ) )
-          + h[k - 1] * ( h[k - 2] + h[k - 1] ) / ( ( h[k - 1] + h[k] + h[k + 1] ) * ( h[k] + h[k + 1] ) )
-          * ( u[k*stride+index] * ( 2.0 * h[k] + h[k + 1] ) - u[(k+1)*stride+index] * h[k] ) )
-      );
-}
-
-
-ARCH_DEV inline void compute_filtered_face_values_nonuniform(const Realf * const dv, const Realf * const values,uint k, face_estimate_order order, Realf &fv_l, Realf &fv_r, const Realf threshold, const int index, const int stride){
-   switch(order){
-      case h4:
-         compute_h4_left_face_value_nonuniform(dv, values, k, fv_l, index, stride);
-         compute_h4_left_face_value_nonuniform(dv, values, k + 1, fv_r, index, stride);
-         break;
-         // case h5:
-         //   compute_h5_face_values(dv, values, k, fv_l, fv_r, index, stride);
-         //   break;
-         // case h6:
-         //   compute_h6_left_face_value(dv, values, k, fv_l, index, stride);
-         //   compute_h6_left_face_value(dv, values, k + 1, fv_r, index, stride);
-         //   break;
-         // case h8:
-         //   compute_h8_left_face_value(dv, values, k, fv_l, index, stride);
-         //   compute_h8_left_face_value(dv, values, k + 1, fv_r, index, stride);
-         //   break;
-      default:
-         printf("Order %d has not been implemented (yet)\n",order);
-         break;
-   }
-   Realf slope_abs,slope_sign;
-   if (threshold>0) {
-      // scale values closer to 1 for more accurate slope limiter calculation
-      const Realf scale = 1./threshold;
-      slope_limiter(values[(k-1)*stride+index]*scale, values[k*stride+index]*scale, values[(k+1)*stride+index]*scale, slope_abs, slope_sign);
-      slope_abs = slope_abs*threshold;
-   } else {
-      slope_limiter(values[(k-1)*stride+index], values[k*stride+index], values[(k+1)*stride+index], slope_abs, slope_sign);
-   }
-
-   //check for extrema, flatten if it is
-   if (slope_abs == 0) {
-      fv_r = values[k*stride+index];
-      fv_l = values[k*stride+index];
-   }
-
-   //Fix left face if needed; boundary value is not bounded
-   if ((values[(k-1)*stride+index] - fv_l) * (fv_l - values[k*stride+index]) < 0) {
-      //Go to linear (PLM) estimates if not ok (this is always ok!)
-      fv_l=values[k*stride+index] - slope_sign * 0.5 * slope_abs;
-   }
-
-   //Fix  face if needed; boundary value is not bounded
-   if ((values[(k+1)*stride+index] - fv_r) * (fv_r - values[k*stride+index]) < 0) {
-      //Go to linear (PLM) estimates if not ok (this is always ok!)
-      fv_r=values[k*stride+index] + slope_sign * 0.5 * slope_abs;
-   }
-}
-
-
 
 #endif

--- a/vlasovsolver/gpu_1d_plm.hpp
+++ b/vlasovsolver/gpu_1d_plm.hpp
@@ -20,11 +20,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef CPU_1D_PLM_H
-#define CPU_1D_PLM_H
+#ifndef GPU_1D_PLM_H
+#define GPU_1D_PLM_H
 
-#include "vec.h"
-#include "cpu_slope_limiters.hpp"
+#include "../arch/arch_device_api.h"
+#include "gpu_slope_limiters.hpp"
 
 using namespace std;
 
@@ -35,17 +35,14 @@ t=(v-v_{i-0.5})/dv where v_{i-0.5} is the left face of a cell
 The factor 2.0 is in the polynom to ease integration, then integral is a[0]*t + a[1]*t**2
 */
 
-static inline void compute_plm_coeff(const Vec * const values, uint k, Vec a[2], const Realf threshold)
+static ARCH_DEV inline void compute_plm_coeff(const Realf* __restrict__ const values, int k, Realf a[2], const Realf threshold, const int index, const int stride)
 {
   // scale values closer to 1 for more accurate slope limiter calculation
   const Realf scale = 1./threshold;
-  //Vec v_1 = values[k - 1] * scale;
-  //Vec v_2 = values[k] * scale;
-  //Vec v_3 = values[k + 1] * scale;
-  //Vec d_cv = slope_limiter(v_1, v_2, v_3) * threshold;
-  const Vec d_cv = slope_limiter( values[k-1]*scale, values[k]*scale, values[k+1]*scale)*threshold;
-  a[0] = values[k] - d_cv * 0.5;
+  const Realf d_cv = slope_limiter( values[(k-1)*stride+index]*scale, values[k*stride+index]*scale, values[(k+1)*stride+index]*scale)*threshold;
+  a[0] = values[k*stride+index] - d_cv * 0.5;
   a[1] = d_cv * 0.5;
 }
+
 
 #endif

--- a/vlasovsolver/gpu_1d_ppm.hpp
+++ b/vlasovsolver/gpu_1d_ppm.hpp
@@ -20,37 +20,38 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef CPU_1D_PPM_H
-#define CPU_1D_PPM_H
+#ifndef GPU_1D_PPM_H
+#define GPU_1D_PPM_H
 
-#include "vec.h"
-#include "cpu_slope_limiters.hpp"
-#include "cpu_face_estimates.hpp"
+#include "../arch/arch_device_api.h"
+#include "gpu_slope_limiters.hpp"
+#include "gpu_face_estimates.hpp"
 
 using namespace std;
 
 /*
   Compute parabolic reconstruction with an explicit scheme
 */
-static inline void compute_ppm_coeff(const Vec * const values, face_estimate_order order, uint k, Vec a[3], const Realf threshold)
+
+static ARCH_DEV inline void compute_ppm_coeff(const Realf* __restrict__ const values, face_estimate_order order, int k, Realf a[3], const Realf threshold, const int index, const int stride)
 {
-   Vec m_face; /*left face value*/
-   Vec p_face; /*right face value*/
-   compute_filtered_face_values(values, k, order, m_face, p_face, threshold);
+   Realf m_face; /*left face value*/
+   Realf p_face; /*right face value*/
+   compute_filtered_face_values(values, k, order, m_face, p_face, threshold, index, stride);
    //Coella et al, check for monotonicity
-   const Vec one_sixth(1.0/6.0);
-   m_face = select((p_face - m_face) * (values[k] - 0.5 * (m_face + p_face)) >
-                   (p_face - m_face) * (p_face - m_face) * one_sixth,
-                   3 * values[k] - 2 * p_face, m_face);
-   p_face = select(-(p_face - m_face) * (p_face - m_face) * one_sixth >
-                   (p_face - m_face) * (values[k] - 0.5 * (m_face + p_face)),
-                   3 * values[k] - 2 * m_face, p_face);
+   const Realf one_sixth(1.0/6.0);
+   m_face = ((p_face - m_face) * (values[k*stride+index] - 0.5 * (m_face + p_face)) >
+             (p_face - m_face) * (p_face - m_face) * one_sixth) ?
+      3 * values[k*stride+index] - 2 * p_face : m_face;
+   p_face = (-(p_face - m_face) * (p_face - m_face) * one_sixth >
+             (p_face - m_face) * (values[k*stride+index] - 0.5 * (m_face + p_face))) ?
+      3 * values[k*stride+index] - 2 * m_face : p_face;
    //Fit a second order polynomial for reconstruction see, e.g., White
    //2008 (PQM article) (note additional integration factors built in,
    //contrary to White (2008) eq. 4
    a[0] = m_face;
-   a[1] = 3.0 * values[k] - 2.0 * m_face - p_face;
-   a[2] = (m_face + p_face - 2.0 * values[k]);
+   a[1] = 3.0 * values[k*stride+index] - 2.0 * m_face - p_face;
+   a[2] = (m_face + p_face - 2.0 * values[k*stride+index]);
 }
 
 #endif

--- a/vlasovsolver/gpu_1d_ppm_nonuniform.hpp
+++ b/vlasovsolver/gpu_1d_ppm_nonuniform.hpp
@@ -20,45 +20,44 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef CPU_1D_PPM_NU_H
-#define CPU_1D_PPM_NU_H
+#ifndef GPU_1D_PPM_NU_H
+#define GPU_1D_PPM_NU_H
 
 #include <iostream>
-#include "vec.h"
 #include "algorithm"
 #include "cmath"
 
-#include "cpu_slope_limiters.hpp"
-#include "cpu_face_estimates.hpp"
+#include "../arch/arch_device_api.h"
+#include "gpu_slope_limiters.hpp"
+#include "gpu_face_estimates.hpp"
 #include "../definitions.h"
 
-using namespace std;
 
-/*
-  Compute parabolic reconstruction with an explicit scheme
-*/
-inline void compute_ppm_coeff_nonuniform(const Realf * const dv, const Vec * const values, face_estimate_order order, uint k, Vec a[3], const Realf threshold){
-   Vec m_face; /*left face value*/
-   Vec p_face; /*right face value*/
-   compute_filtered_face_values_nonuniform(dv, values, k, order, m_face, p_face, threshold);
+/****
+     Define functions for Realf instead of Vec
+***/
+
+ARCH_DEV inline void compute_ppm_coeff_nonuniform(const Realf* __restrict__ const dv, const Realf* __restrict__ const values, face_estimate_order order, int k, Realf a[3], const Realf threshold, const int index, const int stride){
+   Realf m_face; /*left face value*/
+   Realf p_face; /*right face value*/
+   compute_filtered_face_values_nonuniform(dv, values, k, order, m_face, p_face, threshold, index, stride);
 
    //Coella et al, check for monotonicity
-   const Vec one_sixth(1.0/6.0);
-   m_face = select((p_face - m_face) * (values[k] - 0.5 * (m_face + p_face)) >
-                   (p_face - m_face)*(p_face - m_face) * one_sixth,
-                   3 * values[k] - 2 * p_face,
-                   m_face);
-   p_face = select(-(p_face - m_face) * (p_face - m_face) * one_sixth >
-                   (p_face - m_face) * (values[k] - 0.5 * (m_face + p_face)),
-                   3 * values[k] - 2 * m_face,
-                   p_face);
+   m_face = ((p_face - m_face) * (values[k*stride+index] - 0.5 * (m_face + p_face)) >
+             (p_face - m_face)*(p_face - m_face) * (1./6.)) ?
+      3 * values[k*stride+index] - 2 * p_face :
+      m_face;
+   p_face = (-(p_face - m_face) * (p_face - m_face) * (1./6.)) >
+      (p_face - m_face) * (values[k*stride+index] - 0.5 * (m_face + p_face)) ?
+      3 * values[k*stride+index] - 2 * m_face :
+      p_face;
 
    //Fit a second order polynomial for reconstruction see, e.g., White
    //2008 (PQM article) (note additional integration factors built in,
    //contrary to White (2008) eq. 4
    a[0] = m_face;
-   a[1] = 3.0 * values[k] - 2.0 * m_face - p_face;
-   a[2] = (m_face + p_face - 2.0 * values[k]);
+   a[1] = 3.0 * values[k*stride+index] - 2.0 * m_face - p_face;
+   a[2] = (m_face + p_face - 2.0 * values[k*stride+index]);
 }
 
 #endif

--- a/vlasovsolver/gpu_1d_ppm_nonuniform_conserving.hpp
+++ b/vlasovsolver/gpu_1d_ppm_nonuniform_conserving.hpp
@@ -20,45 +20,43 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef CPU_1D_PPM_NU_H
-#define CPU_1D_PPM_NU_H
+#ifndef GPU_1D_PPM_H
+#define GPU_1D_PPM_H
 
 #include <iostream>
-#include "vec.h"
 #include "algorithm"
 #include "cmath"
 
-#include "cpu_slope_limiters.hpp"
-#include "cpu_face_estimates.hpp"
-#include "../definitions.h"
-
-using namespace std;
+#include "../arch/arch_device_api.h"
+#include "gpu_slope_limiters.hpp"
+#include "gpu_face_estimates.hpp"
 
 /*
   Compute parabolic reconstruction with an explicit scheme
+  Define functions for Realf instead of Vec
 */
-inline void compute_ppm_coeff_nonuniform(const Realf * const dv, const Vec * const values, face_estimate_order order, uint k, Vec a[3], const Realf threshold){
-   Vec m_face; /*left face value*/
-   Vec p_face; /*right face value*/
-   compute_filtered_face_values_nonuniform(dv, values, k, order, m_face, p_face, threshold);
 
-   //Coella et al, check for monotonicity
-   const Vec one_sixth(1.0/6.0);
-   m_face = select((p_face - m_face) * (values[k] - 0.5 * (m_face + p_face)) >
-                   (p_face - m_face)*(p_face - m_face) * one_sixth,
-                   3 * values[k] - 2 * p_face,
-                   m_face);
-   p_face = select(-(p_face - m_face) * (p_face - m_face) * one_sixth >
-                   (p_face - m_face) * (values[k] - 0.5 * (m_face + p_face)),
-                   3 * values[k] - 2 * m_face,
-                   p_face);
+ARCH_DEV inline void compute_ppm_coeff_nonuniform(const Realf* __restrict__ const dv, const Realf* __restrict__ const values, face_estimate_order order, int k, Realf a[3], const Realf threshold, const int index, const int stride){
+   Realf m_face; /*left face value*/
+   Realf p_face; /*right face value*/
+   compute_filtered_face_values_nonuniform_conserving(dv, values, k, order, m_face, p_face, threshold, index, stride);
+
+   // //Coella et al, check for monotonicity
+   // m_face = ((p_face - m_face) * (values[k*stride+index] - 0.5 * (m_face + p_face)) >
+   //           (p_face - m_face)*(p_face - m_face) * (1./6.)) ?
+   //    3 * values[k*stride+index] - 2 * p_face :
+   //    m_face;
+   // p_face = (-(p_face - m_face) * (p_face - m_face) * (1./6.)) >
+   //    (p_face - m_face) * (values[k*stride+index] - 0.5 * (m_face + p_face)) ?
+   //    3 * values[k*stride+index] - 2 * m_face :
+   //    p_face;
 
    //Fit a second order polynomial for reconstruction see, e.g., White
    //2008 (PQM article) (note additional integration factors built in,
    //contrary to White (2008) eq. 4
    a[0] = m_face;
-   a[1] = 3.0 * values[k] - 2.0 * m_face - p_face;
-   a[2] = (m_face + p_face - 2.0 * values[k]);
+   a[1] = 3.0 * values[k*stride+index] - 2.0 * m_face - p_face;
+   a[2] = (m_face + p_face - 2.0 * values[k*stride+index]);
 }
 
 #endif

--- a/vlasovsolver/gpu_1d_pqm.hpp
+++ b/vlasovsolver/gpu_1d_pqm.hpp
@@ -1,0 +1,150 @@
+/*
+ * This file is part of Vlasiator.
+ * Copyright 2010-2016 Finnish Meteorological Institute
+ *
+ * For details of usage, see the COPYING file and read the "Rules of the Road"
+ * at http://www.physics.helsinki.fi/vlasiator/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef GPU_1D_PQM_H
+#define GPU_1D_PQM_H
+
+#include "../arch/arch_device_api.h"
+#include "gpu_slope_limiters.hpp"
+#include "gpu_face_estimates.hpp"
+
+/*
+  Define functions for Realf instead of Vec
+*/
+
+/*make sure quartic polynomial is monotonic*/
+static ARCH_DEV inline void filter_pqm_monotonicity(const Realf* __restrict__ values, int k, Realf &fv_l, Realf &fv_r, Realf &fd_l, Realf &fd_r, const int index, const int stride) {
+   /*fixed values give to roots clearly outside [0,1], or nonexisting ones*/
+
+   /*second derivative coefficients, eq 23 in white et al.*/
+   const Realf b0 =   60.0 * values[k*stride+index] - 24.0 * fv_r - 36.0 * fv_l + 3.0 * (fd_r - 3.0 * fd_l);
+   const Realf b1 = -360.0 * values[k*stride+index] + 36.0 * fd_l - 24.0 * fd_r + 168.0 * fv_r + 192.0 * fv_l;
+   const Realf b2 =  360.0 * values[k*stride+index] + 30.0 * (fd_r - fd_l) - 180.0 * (fv_l + fv_r);
+   /*let's compute sqrt value to be used for computing roots. If we
+     take sqrt of negaitve numbers, then we instead set a value that
+     will make the root to be +-100 which is well outside range
+     of[0,1]. We do not catch FP exceptions, so sqrt(negative) are okish (add
+     a max(val_to_sqrt,0) if not*/
+   const Realf val_to_sqrt = b1 * b1 - 4 * b0 * b2;
+   const Realf sqrt_val = (val_to_sqrt < 0.0) ?
+      b1 + 200.0 * b2 :
+      sqrt(val_to_sqrt);
+   //compute roots. Division is safe with vectorclass (=inf)
+   const Realf root1 = (b2 != 0) ? (-b1 + sqrt_val) / (2 * b2) : 0;
+   const Realf root2 = (b2 != 0) ? (-b1 - sqrt_val) / (2 * b2) : 0;
+
+   /*PLM slope, MC limiter*/
+   const Realf plm_slope_l = 2.0 * (values[k*stride+index] - values[(k-1)*stride+index]);
+   const Realf plm_slope_r = 2.0 * (values[(k+1)*stride+index] - values[k*stride+index]);
+   const Realf slope_sign = plm_slope_l + plm_slope_r; //it also has some magnitude, but we will only use its sign.
+   /*first derivative coefficients*/
+   const Realf c0 = fd_l;
+   const Realf c1 = b0;
+   const Realf c2 = b1 / 2.0;
+   const Realf c3 = b2 / 3.0;
+   //compute both slopes at inflexion points, at least one of these
+   //is with [0..1]. If the root is not in this range, we
+   //simplify later if statements by setting it to the plm slope
+   //sign
+   const Realf root1_slope = (root1 >= 0.0 && root1 <= 1.0) ?
+      c0  + root1 * ( c1 + root1 * (c2 + root1 * c3 ) ) :
+      slope_sign;
+   const Realf root2_slope = (root2 >= 0.0 && root2 <= 1.0) ?
+      c0  + root2 * ( c1 + root2 * (c2 + root2 * c3 ) ) :
+      slope_sign;
+   const bool fixInflexion = root1_slope * slope_sign < 0.0 || root2_slope * slope_sign < 0.0;
+
+   if(fixInflexion) {
+      const Realf valuesa = values[k*stride+index];
+      Realf fva_l = fv_l;
+      Realf fva_r = fv_r;
+      Realf fda_l = fd_l;
+      Realf fda_r = fd_r;
+      const Realf slope_signa = slope_sign;
+      //need to collapse, point has wrong sign
+
+      if(fabs(plm_slope_l) <= fabs(plm_slope_r))
+      {
+         //collapse to left edge (eq 21)
+         fda_l =  1.0 / 3.0 * ( 10 * valuesa - 2.0 * fva_r - 8.0 * fva_l);
+         fda_r =  -10.0 * valuesa + 6.0 * fva_r + 4.0 * fva_l;
+         //check if PLM slope is consistent (eq 28 & 29)
+         if (slope_signa * fda_l < 0)
+         {
+            fda_l =  0;
+            fva_r =  5 * valuesa - 4 * fva_l;
+            fda_r =  20 * (valuesa - fva_l);
+         }
+         else if (slope_signa * fda_r < 0)
+         {
+            fda_r =  0;
+            fva_l =  0.5 * (5 * valuesa - 3 * fva_r);
+            fda_l =  10.0 / 3.0 * (-valuesa + fva_r);
+         }
+      }
+      else
+      {
+         //collapse to right edge (eq 21)
+         fda_l =  10.0 * valuesa - 6.0 * fva_l - 4.0 * fva_r;
+         fda_r =  1.0 / 3.0 * ( - 10.0 * valuesa + 2 * fva_l + 8 * fva_r);
+         //check if PLM slope is consistent (eq 28 & 29)
+         if (slope_signa * fda_l < 0)
+         {
+            fda_l =  0;
+            fva_r =  0.5 * ( 5 * valuesa - 3 * fva_l);
+            fda_r =  10.0 / 3.0 * (valuesa - fva_l);
+         }
+         else if (slope_signa * fda_r < 0)
+         {
+            fda_r =  0;
+            fva_l =  5 * valuesa - 4 * fva_r;
+            fda_l =  20.0 * ( - valuesa + fva_r);
+         }
+      }
+      fv_l = (Realf)fva_l;
+      fd_l = (Realf)fda_l;
+      fv_r = (Realf)fva_r;
+      fd_r = (Realf)fda_r;
+   }
+}
+
+static ARCH_DEV inline void compute_pqm_coeff(const Realf* __restrict__ values, face_estimate_order order, int k, Realf a[5], const Realf threshold, const int index, const int stride)
+{
+   Realf fv_l; /*left face value*/
+   Realf fv_r; /*right face value*/
+   Realf fd_l; /*left face derivative*/
+   Realf fd_r; /*right face derivative*/
+
+   compute_filtered_face_values_derivatives(values, k, order, fv_l, fv_r, fd_l, fd_r, threshold, index, stride);
+   filter_pqm_monotonicity(values, k, fv_l, fv_r, fd_l, fd_r, index, stride);
+   //Fit a second order polynomial for reconstruction see, e.g., White
+   //2008 (PQM article) (note additional integration factors built in,
+   //contrary to White (2008) eq. 4
+   a[0] = fv_l;
+   a[1] = fd_l/2.0;
+   a[2] =  10.0 * values[k*stride+index] - 4.0 * fv_r - 6.0 * fv_l + 0.5 * (fd_r - 3 * fd_l);
+   a[3] = -15.0 * values[k*stride+index]  + 1.5 * fd_l - fd_r + 7.0 * fv_r + 8 * fv_l;
+   a[4] =   6.0 * values[k*stride+index] +  0.5 * (fd_r - fd_l) - 3.0 * (fv_l + fv_r);
+}
+
+
+#endif

--- a/vlasovsolver/gpu_acc_map.hpp
+++ b/vlasovsolver/gpu_acc_map.hpp
@@ -28,22 +28,20 @@
    #endif
 #endif
 
-#define i_pcolumnv_gpu(j, k, k_block, num_k_blocks) ( ((j) / ( VECL / WID)) * WID * ( num_k_blocks + 2) + (k) + ( k_block + 1 ) * WID )
-#define i_pcolumnv_gpu_b(planeVectorIndex, k, k_block, num_k_blocks) ( planeVectorIndex * WID * ( num_k_blocks + 2) + (k) + ( k_block + 1 ) * WID )
+// #define i_pcolumnv_gpu(j, k, k_block, num_k_blocks) ( ((j) / ( VECL / WID)) * WID * ( num_k_blocks + 2) + (k) + ( k_block + 1 ) * WID )
+// #define i_pcolumnv_gpu_b(planeVectorIndex, k, k_block, num_k_blocks) ( planeVectorIndex * WID * ( num_k_blocks + 2) + (k) + ( k_block + 1 ) * WID )
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "vec.h"
 #include "../common.h"
 #include "../definitions.h"
 #include "../object_wrapper.h"
 #include "../arch/gpu_base.hpp"
 #include "../spatial_cells/spatial_cell_gpu.hpp"
-#include "cpu_face_estimates.hpp"
-#include "cpu_1d_pqm.hpp"
-#include "cpu_1d_ppm.hpp"
-#include "cpu_1d_plm.hpp"
+#include "gpu_1d_pqm.hpp"
+#include "gpu_1d_ppm.hpp"
+#include "gpu_1d_plm.hpp"
 
 using namespace spatial_cell;
 

--- a/vlasovsolver/gpu_acc_map.hpp
+++ b/vlasovsolver/gpu_acc_map.hpp
@@ -28,9 +28,6 @@
    #endif
 #endif
 
-// #define i_pcolumnv_gpu(j, k, k_block, num_k_blocks) ( ((j) / ( VECL / WID)) * WID * ( num_k_blocks + 2) + (k) + ( k_block + 1 ) * WID )
-// #define i_pcolumnv_gpu_b(planeVectorIndex, k, k_block, num_k_blocks) ( planeVectorIndex * WID * ( num_k_blocks + 2) + (k) + ( k_block + 1 ) * WID )
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/vlasovsolver/gpu_acc_semilag.cpp
+++ b/vlasovsolver/gpu_acc_semilag.cpp
@@ -129,14 +129,17 @@ void gpu_accelerate_cells(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& m
    switch(map_order) {
       case 0: { //Map order XYZ
          dimOrder={0,1,2};
+         // std::cerr<<"dimorder 0,1,2"<<std::endl;
          break;
       }
       case 1: { //Map order YZX
          dimOrder={1,2,0};
+         // std::cerr<<"dimorder 1,2,0"<<std::endl;
          break;
       }
       case 2: { //Map order ZXY
          dimOrder={2,0,1};
+         // std::cerr<<"dimorder 2,0,1"<<std::endl;
          break;
       }
       default:
@@ -149,9 +152,10 @@ void gpu_accelerate_cells(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& m
       and accelerate all cells for that dimension.
    */
    for (int dimIndex = 0; dimIndex<3; ++dimIndex) {
+   // for (int dimIndex = 0; dimIndex<1; ++dimIndex) {
       // Determine intersections for each mapping order
       int dimension = dimOrder[dimIndex];
-
+      
       string profName = "accelerate "+getObjectWrapper().particleSpecies[popID].name;
       phiprof::Timer accTimer {profName};
 
@@ -179,13 +183,13 @@ void gpu_accelerate_cells(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& m
             Dother = D1*D2;
 
             /* set values in array that is used to convert block indices to id using a dot product */
-            cell_indices_to_id[0]=WID2;
-            cell_indices_to_id[1]=WID;
-            cell_indices_to_id[2]=1;
+            cell_indices_to_id[0] = WID2;
+            cell_indices_to_id[1] = WID;
+            cell_indices_to_id[2] = 1;
             break;
          case 1: /* j and k coordinates have been swapped */
             /* set values in array that is used to convert block indices to id using a dot product */
-            block_indices_to_id[0]=1;
+            block_indices_to_id[0] = 1;
             block_indices_to_id[1] = D0*D1;
             block_indices_to_id[2] = D0;
 
@@ -198,13 +202,13 @@ void gpu_accelerate_cells(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& m
             Dother = D0*D2;
 
             /* set values in array that is used to convert block indices to id using a dot product */
-            cell_indices_to_id[0]=1;
-            cell_indices_to_id[1]=WID2;
-            cell_indices_to_id[2]=WID;
+            cell_indices_to_id[0] = 1;
+            cell_indices_to_id[1] = WID2;
+            cell_indices_to_id[2] = WID;
             break;
          case 2:
             /* set values in array that is used to convert block indices to id using a dot product */
-            block_indices_to_id[0]=1;
+            block_indices_to_id[0] = 1;
             block_indices_to_id[1] = D0;
             block_indices_to_id[2] = D0*D1;
 
@@ -217,9 +221,9 @@ void gpu_accelerate_cells(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& m
             Dother = D0*D1;
 
             /* set values in array that is used to convert block indices to id using a dot product. */
-            cell_indices_to_id[0]=1;
-            cell_indices_to_id[1]=WID;
-            cell_indices_to_id[2]=WID2;
+            cell_indices_to_id[0] = 1;
+            cell_indices_to_id[1] = WID;
+            cell_indices_to_id[2] = WID2;
             break;
          default:
             std::cerr<<"Invalid dimension "<<dimension<<"!"<<std::endl;

--- a/vlasovsolver/gpu_acc_semilag.cpp
+++ b/vlasovsolver/gpu_acc_semilag.cpp
@@ -129,17 +129,14 @@ void gpu_accelerate_cells(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& m
    switch(map_order) {
       case 0: { //Map order XYZ
          dimOrder={0,1,2};
-         // std::cerr<<"dimorder 0,1,2"<<std::endl;
          break;
       }
       case 1: { //Map order YZX
          dimOrder={1,2,0};
-         // std::cerr<<"dimorder 1,2,0"<<std::endl;
          break;
       }
       case 2: { //Map order ZXY
          dimOrder={2,0,1};
-         // std::cerr<<"dimorder 2,0,1"<<std::endl;
          break;
       }
       default:
@@ -152,7 +149,6 @@ void gpu_accelerate_cells(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& m
       and accelerate all cells for that dimension.
    */
    for (int dimIndex = 0; dimIndex<3; ++dimIndex) {
-   // for (int dimIndex = 0; dimIndex<1; ++dimIndex) {
       // Determine intersections for each mapping order
       int dimension = dimOrder[dimIndex];
       

--- a/vlasovsolver/gpu_face_estimates.hpp
+++ b/vlasovsolver/gpu_face_estimates.hpp
@@ -1,0 +1,498 @@
+/*
+ * This file is part of Vlasiator.
+ * Copyright 2010-2021 Finnish Meteorological Institute
+ *
+ * For details of usage, see the COPYING file and read the "Rules of the Road"
+ * at http://www.physics.helsinki.fi/vlasiator/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef GPU_FACE_ESTIMATES_H
+#define GPU_FACE_ESTIMATES_H
+
+#include "gpu_slope_limiters.hpp"
+#include "../definitions.h"
+
+#include "../arch/arch_device_api.h"
+
+/*enum for setting face value and derivative estimates. Implicit ones
+  not supported in the solver, so they are now not listed*/
+enum face_estimate_order {h4, h5, h6, h8};
+/**
+   Define functions for Realf instead of Vec
+*/
+
+
+/*!
+  Compute left face value based on the explicit h8 estimate.
+
+  Right face value can be obtained as left face value of cell i + 1.
+
+  \param values Array with volume averages. It is assumed a large enough stencil is defined around i.
+  \param i Index of cell in values for which the left face is computed
+  \param fv_l Face value on left face of cell i
+*/
+ARCH_DEV inline void compute_h8_left_face_value(const Realf* const values, int k, Realf &fv_l, const int index, const int stride)
+{
+   fv_l = 1.0/840.0 * (
+      - 3.0 * values[(k-4)*stride+index]
+      + 29.0 * values[(k-3)*stride+index]
+      - 139.0 * values[(k-2)*stride+index]
+      + 533.0 * values[(k-1)*stride+index]
+      + 533.0 * values[k*stride+index]
+      - 139.0 * values[(k+1)*stride+index]
+      + 29.0 * values[(k+2)*stride+index]
+      - 3.0 * values[(k+3)*stride+index]);
+}
+ARCH_DEV inline void compute_h7_left_face_derivative(const Realf* const values, int k, Realf &fd_l, const int index, const int stride){
+   fd_l = 1.0/5040.0 * (
+      + 9.0 * values[(k-4)*stride+index]
+      - 119.0 * values[(k-3)*stride+index]
+      + 889.0 * values[(k-2)*stride+index]
+      - 7175.0 * values[(k-1)*stride+index]
+      + 7175.0 * values[k*stride+index]
+      - 889.0 * values[(k+1)*stride+index]
+      + 119.0 * values[(k+2)*stride+index]
+      - 9.0 * values[(k+3)*stride+index]);
+}
+ARCH_DEV inline void compute_h6_left_face_value(const Realf* const values, int k, Realf &fv_l, const int index, const int stride)
+{
+   //compute left value
+   fv_l = 1.0/60.0 * (values[(k-3)*stride+index]
+                      - 8.0 * values[(k-2)*stride+index]
+                      + 37.0 * values[(k-1)*stride+index]
+                      + 37.0 * values[k*stride+index]
+                      - 8.0 * values[(k+1)*stride+index]
+                      + values[(k+2)*stride+index]);
+}
+ARCH_DEV inline void compute_h5_left_face_derivative(const Realf* const values, int k, Realf &fd_l, const int index, const int stride)
+{
+   fd_l = 1.0/180.0 * (245 * (values[k*stride+index] - values[(k-1)*stride+index])
+                       - 25 * (values[(k+1)*stride+index] - values[(k-2)*stride+index])
+                       + 2 * (values[(k+2)*stride+index] - values[(k-3)*stride+index]));
+}
+ARCH_DEV inline void compute_h5_face_values(const Realf* const values, int k, Realf &fv_l, Realf &fv_r, const int index, const int stride)
+{
+   //compute left values
+   fv_l = 1.0/60.0 * (- 3.0 * values[(k-2)*stride+index]
+                      + 27.0 * values[(k-1)*stride+index]
+                      + 47.0 * values[k*stride+index]
+                      - 13.0 * values[(k+1)*stride+index]
+                      + 2.0 * values[(k+2)*stride+index]);
+   fv_r = 1.0/60.0 * ( 2.0 * values[(k-2)*stride+index]
+                       - 13.0 * values[(k-1)*stride+index]
+                       + 47.0 * values[k*stride+index]
+                       + 27.0 * values[(k+1)*stride+index]
+                       - 3.0 * values[(k+2)*stride+index]);
+}
+ARCH_DEV inline void compute_h4_left_face_derivative(const Realf* const values, int k, Realf &fd_l, const int index, const int stride)
+{
+   fd_l = 1.0/12.0 * (15.0 * (values[k*stride+index] - values[(k-1)*stride+index]) - (values[(k+1)*stride+index] - values[(k-2)*stride+index]));
+}
+ARCH_DEV inline void compute_h4_left_face_value(const Realf* const values, int k, Realf &fv_l, const int index, const int stride)
+{
+   //compute left value
+   fv_l = 1.0/12.0 * ( - 1.0 * values[(k-2)*stride+index]
+                       + 7.0 * values[(k-1)*stride+index]
+                       + 7.0 * values[k*stride+index]
+                       - 1.0 * values[(k+1)*stride+index]);
+}
+
+// h is bin width (dv or dx)
+// u is values
+ARCH_DEV inline void compute_h4_left_face_value_nonuniform(const Realf* const h, const Realf* const u, int k, Realf &fv_l, const int index, const int stride) {
+   fv_l = (
+      1.0 / ( h[k - 2] + h[k - 1] + h[k] + h[k + 1] )
+      * ( ( h[k - 2] + h[k - 1] ) * ( h[k] + h[k + 1] ) / ( h[k - 1] + h[k] )
+          * ( u[(k-1)*stride+index] * h[k] + u[k*stride+index] * h[k - 1] )
+          * (1.0 / ( h[k - 2] + h[k - 1] + h[k] ) + 1.0 / ( h[k - 1] + h[k] + h[k + 1] ) )
+          + ( h[k] * ( h[k] + h[k + 1] ) ) / ( ( h[k - 2] + h[k - 1] + h[k] ) * (h[k - 2] + h[k - 1] ) )
+          * ( u[(k-1)*stride+index] * (h[k - 2] + 2.0 * h[k - 1] ) - ( u[(k-2)*stride+index] * h[k - 1] ) )
+          + h[k - 1] * ( h[k - 2] + h[k - 1] ) / ( ( h[k - 1] + h[k] + h[k + 1] ) * ( h[k] + h[k + 1] ) )
+          * ( u[k*stride+index] * ( 2.0 * h[k] + h[k + 1] ) - u[(k+1)*stride+index] * h[k] ) )
+      );
+}
+
+
+
+
+ARCH_DEV inline void compute_h3_left_face_derivative(const Realf* const values, int k, Realf &fv_l, const int index, const int stride)
+{
+   /*compute left value*/
+   fv_l = 1.0/12.0 * (15 * (values[k*stride+index] - values[(k-1)*stride+index]) - (values[(k+1)*stride+index] - values[(k-2)*stride+index]));
+}
+
+ARCH_DEV inline void compute_filtered_face_values_derivatives(const Realf* const values, int k, face_estimate_order order, Realf &fv_l, Realf &fv_r, Realf &fd_l, Realf &fd_r, const Realf threshold, const int index,  const int stride)
+{
+   switch(order)
+   {
+      case h4:
+         compute_h4_left_face_value(values, k, fv_l, index, stride);
+         compute_h4_left_face_value(values, k + 1, fv_r, index, stride);
+         compute_h3_left_face_derivative(values, k, fd_l, index, stride);
+         compute_h3_left_face_derivative(values, k + 1, fd_r, index, stride);
+         break;
+      case h5:
+         compute_h5_face_values(values, k, fv_l, fv_r, index, stride);
+         compute_h4_left_face_derivative(values, k, fd_l, index, stride);
+         compute_h4_left_face_derivative(values, k + 1, fd_r, index, stride);
+         break;
+      default:
+      case h6:
+         compute_h6_left_face_value(values, k, fv_l, index, stride);
+         compute_h6_left_face_value(values, k + 1, fv_r, index, stride);
+         compute_h5_left_face_derivative(values, k, fd_l, index, stride);
+         compute_h5_left_face_derivative(values, k + 1, fd_r, index, stride);
+         break;
+      case h8:
+         compute_h8_left_face_value(values, k, fv_l, index, stride);
+         compute_h8_left_face_value(values, k + 1, fv_r, index, stride);
+         compute_h7_left_face_derivative(values, k, fd_l, index, stride);
+         compute_h7_left_face_derivative(values, k + 1, fd_r, index, stride);
+         break;
+   }
+   Realf slope_abs,slope_sign;
+   // scale values closer to 1 for more accurate slope limiter calculation
+   const Realf scale = 1./threshold;
+   slope_limiter(values[(k-1)*stride+index]*scale, values[k*stride+index]*scale, values[(k+1)*stride+index]*scale, slope_abs, slope_sign);
+   slope_abs = slope_abs*threshold;
+   //check for extrema, flatten if it is
+   bool is_extrema = (slope_abs == 0.0);
+   if (is_extrema) {
+      fv_r = (is_extrema) ? values[k*stride+index] : fv_r;
+      fv_l = (is_extrema) ? values[k*stride+index] : fv_l;
+      fd_l = (is_extrema) ? 0.0 : fd_l;
+      fd_r = (is_extrema) ? 0.0 : fd_r;
+   }
+   //Fix left face if needed; boundary value is not bounded or slope is not consistent
+   bool filter = (values[(k-1)*stride+index] - fv_l) * (fv_l - values[k*stride+index]) < 0 || slope_sign * fd_l < 0.0;
+   if (filter) {
+      //Go to linear (PLM) estimates if not ok (this is always ok!)
+      fv_l= (filter) ? values[k*stride+index] - slope_sign * 0.5 * slope_abs : fv_l;
+      fd_l= (filter) ? slope_sign * slope_abs : fd_l;
+   }
+   //Fix right face if needed; boundary value is not bounded or slope is not consistent
+   filter = (values[(k+1)*stride+index] - fv_r) * (fv_r - values[k*stride+index]) < 0 || slope_sign * fd_r < 0.0;
+   if (filter) {
+      //Go to linear (PLM) estimates if not ok (this is always ok!)
+      fv_r= (filter) ? values[k*stride+index] + slope_sign * 0.5 * slope_abs : fv_r;
+      fd_r= (filter) ? slope_sign * slope_abs : fd_r;
+   }
+}
+
+/*Filters in section 2.6.1 of white et al. to be used for PPM
+  1) Checks for extrema and flattens them
+  2) Makes face values bounded
+  3) Makes sure face slopes are consistent with PLM slope
+*/
+ARCH_DEV inline void compute_filtered_face_values(const Realf* const values, int k, face_estimate_order order, Realf &fv_l, Realf &fv_r, const Realf threshold, const int index, const int stride)
+{
+   switch(order)
+   {
+      case h4:
+         compute_h4_left_face_value(values, k, fv_l, index, stride);
+         compute_h4_left_face_value(values, k + 1, fv_r, index, stride);
+         break;
+      case h5:
+         compute_h5_face_values(values, k, fv_l, fv_r, index, stride);
+         break;
+      default:
+      case h6:
+         compute_h6_left_face_value(values, k, fv_l, index, stride);
+         compute_h6_left_face_value(values, k + 1, fv_r, index, stride);
+         break;
+      case h8:
+         compute_h8_left_face_value(values, k, fv_l, index, stride);
+         compute_h8_left_face_value(values, k + 1, fv_r, index, stride);
+         break;
+   }
+   Realf slope_abs, slope_sign;
+   // scale values closer to 1 for more accurate slope limiter calculation
+   const Realf scale = 1./threshold;
+   slope_limiter(values[(k-1)*stride+index]*scale, values[k*stride+index]*scale, values[(k+1)*stride+index]*scale, slope_abs, slope_sign);
+   slope_abs = slope_abs*threshold;
+
+   //check for extrema, flatten if it is
+   bool is_extrema = (slope_abs == 0.0);
+   if (is_extrema) {
+      fv_r = (is_extrema) ? values[k*stride+index] : fv_r;
+      fv_l = (is_extrema) ? values[k*stride+index] : fv_l;
+   }
+   //Fix left face if needed; boundary value is not bounded
+   bool filter = (values[(k-1)*stride+index] - fv_l) * (fv_l - values[k*stride+index]) < 0 ;
+   if (filter) {
+      //Go to linear (PLM) estimates if not ok (this is always ok!)
+      fv_l = (filter) ? values[k*stride+index] - slope_sign * 0.5 * slope_abs : fv_l;
+   }
+   //Fix  face if needed; boundary value is not bounded
+   filter = (values[(k+1)*stride+index] - fv_r) * (fv_r - values[k*stride+index]) < 0;
+   if (filter) {
+      //Go to linear (PLM) estimates if not ok (this is always ok!)
+      fv_r = (filter) ? values[k*stride+index] + slope_sign * 0.5 * slope_abs : fv_r;
+   }
+}
+
+ARCH_DEV inline void compute_filtered_face_values_nonuniform(const Realf * const dv, const Realf* const values,int k, face_estimate_order order, Realf &fv_l, Realf &fv_r, const Realf threshold, const int index, const int stride){
+   switch(order){
+      case h4:
+         compute_h4_left_face_value_nonuniform(dv, values, k, fv_l, index, stride);
+         compute_h4_left_face_value_nonuniform(dv, values, k + 1, fv_r, index, stride);
+         break;
+         // case h5:
+         //   compute_h5_face_values(dv, values, k, fv_l, fv_r, index, stride);
+         //   break;
+         // case h6:
+         //   compute_h6_left_face_value(dv, values, k, fv_l, index, stride);
+         //   compute_h6_left_face_value(dv, values, k + 1, fv_r, index, stride);
+         //   break;
+         // case h8:
+         //   compute_h8_left_face_value(dv, values, k, fv_l, index, stride);
+         //   compute_h8_left_face_value(dv, values, k + 1, fv_r, index, stride);
+         //   break;
+      default:
+         printf("Order %d has not been implemented (yet)\n",order);
+         break;
+   }
+   Realf slope_abs,slope_sign;
+   if (threshold>0) {
+      // scale values closer to 1 for more accurate slope limiter calculation
+      const Realf scale = 1./threshold;
+      slope_limiter(values[(k-1)*stride+index]*scale, values[k*stride+index]*scale, values[(k+1)*stride+index]*scale, slope_abs, slope_sign);
+      slope_abs = slope_abs*threshold;
+   } else {
+      slope_limiter(values[(k-1)*stride+index], values[k*stride+index], values[(k+1)*stride+index], slope_abs, slope_sign);
+   }
+
+   //check for extrema, flatten if it is
+   if (slope_abs == 0) {
+      fv_r = values[k*stride+index];
+      fv_l = values[k*stride+index];
+   }
+
+   //Fix left face if needed; boundary value is not bounded
+   if ((values[(k-1)*stride+index] - fv_l) * (fv_l - values[k*stride+index]) < 0) {
+      //Go to linear (PLM) estimates if not ok (this is always ok!)
+      fv_l=values[k*stride+index] - slope_sign * 0.5 * slope_abs;
+   }
+
+   //Fix  face if needed; boundary value is not bounded
+   if ((values[(k+1)*stride+index] - fv_r) * (fv_r - values[k*stride+index]) < 0) {
+      //Go to linear (PLM) estimates if not ok (this is always ok!)
+      fv_r=values[k*stride+index] + slope_sign * 0.5 * slope_abs;
+   }
+}
+
+ARCH_DEV inline Realf get_D2aLim(const Realf* h, const Realf* values, int k, const Realf C, Realf & fv, const int index, const int stride) {
+
+   // Colella & Sekora, eq. 18
+   Realf invh2 = 1.0 / (h[k] * h[k]);
+   Realf d2a =  invh2 * 3.0 * (values[k*stride    +index] - 2.0 * fv                         + values[(k+1)*stride+index]);
+   Realf d2aL = invh2       * (values[(k-1)*stride+index] - 2.0 * values[k*stride    +index] + values[(k+1)*stride+index]);
+   Realf d2aR = invh2       * (values[k*stride    +index] - 2.0 * values[(k+1)*stride+index] + values[(k+2)*stride+index]);
+   Realf d2aLim;
+   if ( (d2a * d2aL >= 0) && (d2a * d2aR >= 0) && (d2a != 0) ) {
+      d2aLim = d2a / abs(d2a) * min(abs(d2a),min(C*abs(d2aL),C*abs(d2aR)));
+   } else {
+      d2aLim = 0.0;
+   }
+   return d2aLim;
+}
+
+ARCH_DEV inline void constrain_face_values(const Realf* h, const Realf* values,int k,Realf & fv_l, Realf & fv_r, const int index, const int stride) {
+
+   const Realf C = 1.25;
+   Realf invh2 = 1.0 / (h[k] * h[k]);
+
+   // Colella & Sekora, eq 19
+   Realf p_face = 0.5 * (values[k*stride+index] + values[(k+1)*stride+index])
+      - h[k] * h[k] / 3.0 * get_D2aLim(h,values,k  ,C,fv_r, index, stride);
+   Realf m_face = 0.5 * (values[(k-1)*stride+index] + values[k*stride+index])
+      - h[k-1] * h[k-1] / 3.0 * get_D2aLim(h,values,k-1,C,fv_l, index, stride);
+
+   // Colella & Sekora, eq 21
+   Realf d2a = -2.0 * invh2 * 6.0 * (values[k*stride+index] - 3.0 * (m_face + p_face)); // a6,j from eq. 7
+   Realf d2aC = invh2 * (values[(k-1)*stride+index] - 2.0 * values[k*stride+index] + values[(k+1)*stride+index]);
+   // Note: Corrected the index of 2nd term in d2aL to k - 1.
+   //       In the paper it is k but that is almost certainly an error.
+   Realf d2aL = invh2 * (values[(k-2)*stride+index] - 2.0 * values[(k-1)*stride+index] + values[k*stride+index]);
+   Realf d2aR = invh2 * (values[k*stride+index] - 2.0 * values[(k+1)*stride+index] + values[(k+2)*stride+index]);
+   Realf d2aLim;
+
+   // Colella & Sekora, eq 22
+   if ( (d2a * d2aL >= 0) && (d2a * d2aR >= 0) &&
+        (d2a * d2aC >= 0) && (d2a != 0) ) {
+
+      d2aLim = d2a / abs(d2a) * min(C * abs(d2aL), min(C * abs(d2aR), min(C * abs(d2aC), abs(d2a))));
+   } else {
+      d2aLim = 0.0;
+      if (d2a == 0.0) {
+         // Set a non-zero value for the denominator in eq. 23.
+         // According to the paper the ratio d2aLim/d2a should be 0
+         d2a = 1.0;
+      }
+   }
+
+   // Colella & Sekora, eq 23
+   fv_r = values[k*stride+index] + (p_face - values[k*stride+index]) * d2aLim / d2a;
+   fv_l = values[k*stride+index] + (m_face - values[k*stride+index]) * d2aLim / d2a;
+
+}
+
+ARCH_DEV inline void compute_filtered_face_values_nonuniform_conserving(const Realf * const dv, const Realf* const values,int k, face_estimate_order order, Realf &fv_l, Realf &fv_r, const Realf threshold, const int index, const int stride){
+   switch(order){
+      case h4:
+         compute_h4_left_face_value_nonuniform(dv, values, k, fv_l, index, stride);
+         compute_h4_left_face_value_nonuniform(dv, values, k + 1, fv_r, index, stride);
+         break;
+         // case h5:
+         //   compute_h5_face_values(dv, values, k, fv_l, fv_r, index, stride);
+         //   break;
+         // case h6:
+         //   compute_h6_left_face_value(dv, values, k, fv_l, index, stride);
+         //   compute_h6_left_face_value(dv, values, k + 1, fv_r, index, stride);
+         //   break;
+         // case h8:
+         //   compute_h8_left_face_value(dv, values, k, fv_l, index, stride);
+         //   compute_h8_left_face_value(dv, values, k + 1, fv_r, index, stride);
+         //   break;
+      default:
+         printf("Order %d has not been implemented (yet)\n",order);
+         break;
+   }
+
+   Realf slope_abs,slope_sign;
+   if (threshold>0) {
+      // scale values closer to 1 for more accurate slope limiter calculation
+      const Realf scale = 1./threshold;
+      slope_limiter(values[(k-1)*stride+index]*scale, values[k*stride+index]*scale, values[(k+1)*stride+index]*scale, slope_abs, slope_sign);
+      slope_abs = slope_abs*threshold;
+   } else {
+      slope_limiter(values[(k-1)*stride+index], values[k*stride+index], values[(k+1)*stride+index], slope_abs, slope_sign);
+   }
+
+   //check for extrema
+   //bool is_extrema = (slope_abs == 0.0);
+   // bool filter_l = (values[(k-1)*stride+index] - fv_l) * (fv_l - values[k*stride+index]) < 0 ;
+   // bool filter_r = (values[(k+1)*stride+index] - fv_r) * (fv_r - values[k*stride+index]) < 0;
+   //  if(horizontal_or(is_extrema) || horizontal_or(filter_l) || horizontal_or(filter_r)) {
+   // Colella & Sekora, eq. 20
+   if (((fv_r - values[k*stride+index]) * (values[k*stride+index] - fv_l) <= 0.0)
+       && ((values[(k-1)*stride+index] - values[k*stride+index]) * (values[k*stride+index] - values[(k+1)*stride+index]) <= 0.0)) {
+      constrain_face_values(dv, values, k, fv_l, fv_r, index, stride);
+
+      //    fv_r = select(is_extrema, values[k], fv_r);
+      //    fv_l = select(is_extrema, values[k], fv_l);
+   } else {
+
+      //Fix left face if needed; boundary value is not bounded
+      bool filter = (values[(k-1)*stride+index] - fv_l) * (fv_l - values[k*stride+index]) < 0 ;
+      if (filter) {
+         //Go to linear (PLM) estimates if not ok (this is always ok!)
+         fv_l=values[k*stride+index] - slope_sign * 0.5 * slope_abs;
+      }
+
+      //Fix  face if needed; boundary value is not bounded
+      filter = (values[(k+1)*stride+index] - fv_r) * (fv_r - values[k*stride+index]) < 0;
+      if (filter) {
+         //Go to linear (PLM) estimates if not ok (this is always ok!)
+         fv_r=values[k*stride+index] + slope_sign * 0.5 * slope_abs;
+      }
+   }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// ARCH_DEV inline void compute_h4_left_face_value_nonuniform(const Realf * const h, const Realf * const u, int k, Realf &fv_l, const int index, const int stride) {
+//    fv_l = (
+//       1.0 / ( h[k - 2] + h[k - 1] + h[k] + h[k + 1] )
+//       * ( ( h[k - 2] + h[k - 1] ) * ( h[k] + h[k + 1] ) / ( h[k - 1] + h[k] )
+//           * ( u[(k-1)*stride+index] * h[k] + u[k*stride+index] * h[k - 1] )
+//           * (1.0 / ( h[k - 2] + h[k - 1] + h[k] ) + 1.0 / ( h[k - 1] + h[k] + h[k + 1] ) )
+//           + ( h[k] * ( h[k] + h[k + 1] ) ) / ( ( h[k - 2] + h[k - 1] + h[k] ) * (h[k - 2] + h[k - 1] ) )
+//           * ( u[(k-1)*stride+index] * (h[k - 2] + 2.0 * h[k - 1] ) - ( u[(k-2)*stride+index] * h[k - 1] ) )
+//           + h[k - 1] * ( h[k - 2] + h[k - 1] ) / ( ( h[k - 1] + h[k] + h[k + 1] ) * ( h[k] + h[k + 1] ) )
+//           * ( u[k*stride+index] * ( 2.0 * h[k] + h[k + 1] ) - u[(k+1)*stride+index] * h[k] ) )
+//       );
+// }
+
+
+// ARCH_DEV inline void compute_filtered_face_values_nonuniform(const Realf * const dv, const Realf * const values,int k, face_estimate_order order, Realf &fv_l, Realf &fv_r, const Realf threshold, const int index, const int stride){
+//    switch(order){
+//       case h4:
+//          compute_h4_left_face_value_nonuniform(dv, values, k, fv_l, index, stride);
+//          compute_h4_left_face_value_nonuniform(dv, values, k + 1, fv_r, index, stride);
+//          break;
+//          // case h5:
+//          //   compute_h5_face_values(dv, values, k, fv_l, fv_r, index, stride);
+//          //   break;
+//          // case h6:
+//          //   compute_h6_left_face_value(dv, values, k, fv_l, index, stride);
+//          //   compute_h6_left_face_value(dv, values, k + 1, fv_r, index, stride);
+//          //   break;
+//          // case h8:
+//          //   compute_h8_left_face_value(dv, values, k, fv_l, index, stride);
+//          //   compute_h8_left_face_value(dv, values, k + 1, fv_r, index, stride);
+//          //   break;
+//       default:
+//          printf("Order %d has not been implemented (yet)\n",order);
+//          break;
+//    }
+//    Realf slope_abs,slope_sign;
+//    if (threshold>0) {
+//       // scale values closer to 1 for more accurate slope limiter calculation
+//       const Realf scale = 1./threshold;
+//       slope_limiter(values[(k-1)*stride+index]*scale, values[k*stride+index]*scale, values[(k+1)*stride+index]*scale, slope_abs, slope_sign);
+//       slope_abs = slope_abs*threshold;
+//    } else {
+//       slope_limiter(values[(k-1)*stride+index], values[k*stride+index], values[(k+1)*stride+index], slope_abs, slope_sign);
+//    }
+
+//    //check for extrema, flatten if it is
+//    if (slope_abs == 0) {
+//       fv_r = values[k*stride+index];
+//       fv_l = values[k*stride+index];
+//    }
+
+//    //Fix left face if needed; boundary value is not bounded
+//    if ((values[(k-1)*stride+index] - fv_l) * (fv_l - values[k*stride+index]) < 0) {
+//       //Go to linear (PLM) estimates if not ok (this is always ok!)
+//       fv_l=values[k*stride+index] - slope_sign * 0.5 * slope_abs;
+//    }
+
+//    //Fix  face if needed; boundary value is not bounded
+//    if ((values[(k+1)*stride+index] - fv_r) * (fv_r - values[k*stride+index]) < 0) {
+//       //Go to linear (PLM) estimates if not ok (this is always ok!)
+//       fv_r=values[k*stride+index] + slope_sign * 0.5 * slope_abs;
+//    }
+// }
+
+
+
+#endif

--- a/vlasovsolver/gpu_moments.cpp
+++ b/vlasovsolver/gpu_moments.cpp
@@ -182,19 +182,11 @@ __global__ void second_moments_kernel (
    }
 }
 
-/** Calculate zeroth, first, and (possibly) second bulk velocity moments for the
- * given spatial cell. The calculated moments include contributions from
- * all existing particle populations. This function is AMR safe.
- * @param cell Spatial cell.
- * @param computeSecond If true, second velocity moments are calculated.
- * @param doNotSkip If false, DO_NOT_COMPUTE cells are skipped.*/
-// void calculateCellMoments(spatial_cell::SpatialCell* cell,
-//                           const bool& computeSecond,
-//                           const bool& computePopulationMomentsOnly,
-//                           const bool& doNotSkip) {
-// GPUTODO? For a single cell, might as well use ARCH.
-
-
+/** 
+    Note: there is no single-cell GPU-only version of moments calculations,
+    (calculateCellMoments) as that task is achieved through the
+    ARCH-interface with no performance loss.
+*/
 
 /** Calculate zeroth, first, and (possibly) second bulk velocity moments for the
  * given spatial cell. The calculated moments include

--- a/vlasovsolver/gpu_moments.cpp
+++ b/vlasovsolver/gpu_moments.cpp
@@ -182,7 +182,7 @@ __global__ void second_moments_kernel (
    }
 }
 
-/** 
+/**
     Note: there is no single-cell GPU-only version of moments calculations,
     (calculateCellMoments) as that task is achieved through the
     ARCH-interface with no performance loss.
@@ -236,7 +236,7 @@ void gpu_calculateMoments_R(
             host_VBC[celli] = cell->dev_get_velocity_blocks(popID); // GPU-side VBC
             // Evaluate cached vmesh size
             const vmesh::LocalID meshSize = cell->get_velocity_mesh(popID)->size();
-            threadMaxVmeshSize = meshSize > threadMaxVmeshSize ? meshSize : threadMaxVmeshSize; 
+            threadMaxVmeshSize = meshSize > threadMaxVmeshSize ? meshSize : threadMaxVmeshSize;
 
             // Clear old moments to zero value
             if (popID == 0) {
@@ -255,7 +255,7 @@ void gpu_calculateMoments_R(
          }
          #pragma omp critical
          {
-            maxVmeshSizes.at(popID) = maxVmeshSizes.at(popID) > threadMaxVmeshSize ? maxVmeshSizes.at(popID) : threadMaxVmeshSize; 
+            maxVmeshSizes.at(popID) = maxVmeshSizes.at(popID) > threadMaxVmeshSize ? maxVmeshSizes.at(popID) : threadMaxVmeshSize;
          }
       }
       if (maxVmeshSizes.at(popID) == 0) {
@@ -430,7 +430,7 @@ void gpu_calculateMoments_V(
             host_VBC[celli] = cell->dev_get_velocity_blocks(popID); // GPU-side VBC
             // Evaluate cached vmesh size
             const vmesh::LocalID meshSize = cell->get_velocity_mesh(popID)->size();
-            threadMaxVmeshSize = meshSize > threadMaxVmeshSize ? meshSize : threadMaxVmeshSize; 
+            threadMaxVmeshSize = meshSize > threadMaxVmeshSize ? meshSize : threadMaxVmeshSize;
 
             // Clear old moments to zero value
             if (popID == 0) {
@@ -449,7 +449,7 @@ void gpu_calculateMoments_V(
          }
 #pragma omp critical
          {
-            maxVmeshSizes.at(popID) = maxVmeshSizes.at(popID) > threadMaxVmeshSize ? maxVmeshSizes.at(popID) : threadMaxVmeshSize; 
+            maxVmeshSizes.at(popID) = maxVmeshSizes.at(popID) > threadMaxVmeshSize ? maxVmeshSizes.at(popID) : threadMaxVmeshSize;
          }
       }
       if (maxVmeshSizes.at(popID) == 0) {

--- a/vlasovsolver/gpu_slope_limiters.hpp
+++ b/vlasovsolver/gpu_slope_limiters.hpp
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Vlasiator.
+ * Copyright 2010-2016 Finnish Meteorological Institute
+ *
+ * For details of usage, see the COPYING file and read the "Rules of the Road"
+ * at http://www.physics.helsinki.fi/vlasiator/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef GPU_SLOPE_LIMITERS_H
+#define GPU_SLOPE_LIMITERS_H
+
+#include "../arch/arch_device_api.h"
+
+/****
+     Define functions for Realf instead of Vec
+     These functions take direct arguments instead of references for non-const input
+     so that registers and other optimizations are available.
+***/
+
+static ARCH_DEV inline Realf minmod(const Realf slope1, const Realf slope2)
+{
+   const Realf slope = (abs(slope1) < abs(slope2)) ? slope1 : slope2;
+   return (slope1 * slope2 <= 0) ? 0 : slope;
+}
+static ARCH_DEV inline Realf maxmod(const Realf slope1, const Realf slope2)
+{
+   const Realf slope = (abs(slope1) > abs(slope2)) ? slope1 : slope2;
+   return (slope1 * slope2 <= 0) ? 0 : slope;
+}
+
+/*!
+  Superbee slope limiter
+*/
+
+static ARCH_DEV inline Realf slope_limiter_sb(const Realf l, const Realf m, const Realf r)
+{
+   const Realf a = r-m;
+   const Realf b = m-l;
+   const Realf slope1 = minmod(a, 2*b);
+   const Realf slope2 = minmod(2*a, b);
+   return maxmod(slope1, slope2);
+}
+
+/*!
+  Minmod slope limiter
+*/
+
+static ARCH_DEV inline Realf slope_limiter_minmod(const Realf l, const Realf m, const Realf r)
+{
+   const Realf a=r-m;
+   const Realf b=m-l;
+   return minmod(a,b);
+}
+
+/*!
+  MC slope limiter
+*/
+
+static ARCH_DEV inline Realf slope_limiter_mc(const Realf l, const Realf m, const Realf r)
+{
+   const Realf a=r-m;
+   const Realf b=m-l;
+   Realf minval=min(2*abs(a),2*abs(b));
+   minval=min(minval,(Realf)0.5*abs(a+b));
+
+   //check for extrema
+   const Realf output = (a*b < 0) ? 0 : minval;
+   //set sign
+   return (a + b < 0) ? -output : output;
+}
+
+static ARCH_DEV inline Realf slope_limiter_minmod_amr(const Realf l,const Realf m, const Realf r,const Realf a,const Realf b)
+{
+   const Realf J = r-l;
+   Realf f = (m-l)/J;
+   f = min((Realf)1.0,f);
+   return min((Realf)f/(1+a),(Realf)(1.-f)/(1+b))*2*J;
+}
+
+static ARCH_DEV inline Realf slope_limiter(const Realf l, const Realf m, const Realf r)
+{
+   return slope_limiter_sb(l,m,r);
+   //return slope_limiter_minmod(l,m,r);
+}
+
+/*
+ * @param a Cell size fraction dx[i-1]/dx[i] = 1/2, 1, or 2.
+ * @param b Cell size fraction dx[i+1]/dx[i] = 1/2, 1, or 2.
+ * @return Limited value of slope.*/
+static ARCH_DEV inline Realf slope_limiter_amr(const Realf l,const Realf m, const Realf r,const Realf dx_left,const Realf dx_rght)
+{
+   return slope_limiter_minmod_amr(l,m,r,dx_left,dx_rght);
+}
+
+/* Slope limiter with abs and sign separately, uses the currently active slope limiter*/
+static ARCH_DEV inline void slope_limiter(const Realf l,const Realf m, const Realf r, Realf& slope_abs, Realf& slope_sign)
+{
+   const Realf slope = slope_limiter(l,m,r);
+   slope_abs = abs(slope);
+   slope_sign = (slope > 0) ? 1 : -1.0;
+}
+
+
+
+#endif

--- a/vlasovsolver/gpu_trans_map_amr.cpp
+++ b/vlasovsolver/gpu_trans_map_amr.cpp
@@ -916,7 +916,7 @@ void update_remote_mapping_contribution_amr(
       CHK_ERR( gpuDeviceSynchronize() );
 
       // send cell data is set to zero. This is to avoid double copy if
-      // one cell is the neighbor on bot + and - side to the same process
+      // one cell is the neighbor on both + and - side to the same process
       vector<CellID> send_cells_vector(send_cells.begin(), send_cells.end());
       for (uint c = 0; c < send_cells_vector.size(); c++) {
          SpatialCell* send_cell = mpiGrid[send_cells_vector[c]];
@@ -924,6 +924,7 @@ void update_remote_mapping_contribution_amr(
          Realf* blockData = send_cell->get_data(popID);
          CHK_ERR( gpuMemsetAsync(blockData, 0, WID3*send_cell->get_number_of_velocity_blocks(popID)*sizeof(Realf),stream) );
       }
+      CHK_ERR( gpuDeviceSynchronize() );
    }
 
    phiprof::Timer updateRemoteTimerFree {"trans-amr-remotes-free"};

--- a/vlasovsolver/gpu_trans_map_amr.cpp
+++ b/vlasovsolver/gpu_trans_map_amr.cpp
@@ -35,14 +35,10 @@
  #define USE_TRANS_WARPACCESSORS
 #endif
 
-// indices in padded source block, which is of type Vec with VECL
-// elements in each vector.
-#define i_trans_ps_blockv_pencil(planeIndex, blockIndex, lengthOfPencil) ( (blockIndex)  +  ( (planeIndex) * VEC_PER_PLANE ) * ( lengthOfPencil) )
-
-// Skip remapping if whole stencil for all vector elements consists of zeroes
-__host__ __device__ inline bool check_skip_remapping(const Vec* __restrict__ values, const uint vectorindex) {
+// Skip remapping for this stencil, if no blocks exist
+__device__ inline bool check_skip_blocks(const Realf* __restrict__ const *pencilBlockData, const uint centerOffset) {
    for (int index=-VLASOV_STENCIL_WIDTH; index<VLASOV_STENCIL_WIDTH+1; ++index) {
-      if (values[index][vectorindex] > 0) {
+      if (pencilBlockData[centerOffset + index] != NULL) {
          return false;
       }
    }
@@ -58,15 +54,13 @@ __host__ __device__ inline bool check_skip_remapping(const Vec* __restrict__ val
  * @param  pencilStarts  pointer to buffer of indexes of first cells of pencils
  * @param  allBlocks  pointer to list of all GIDs to propagate
  * @param  nAllBlocks  how many blocks exist in total
- * @param  startingBlockIndex  First block index for this kernel invocation
- * @param  blockIndexIncrement  How much each kernel invocation should jump ahead
  * @param  nPencils  Number of total pencils (constant)
  * @param  sumOfLengths  sum of all pencil lengths (constant)
  * @param  threshold  sparsity threshold, used by slope limiters
- * @param  allPencilsMeshes  Pointer to buffer of pointers to velocity meshes
- * @param  allPencilsContainers  Pointer to buffer of pointers to BlockContainers
+ * @param  dev_allPencilsMeshes  Pointer to buffer of pointers to velocity meshes
+ * @param  dev_allPencilsContainers  Pointer to buffer of pointers to BlockContainers
  * @param  pencilBlockData  Pointer to buffer of pointers into cell block data, both written and read
- * @param  pencilOrderedSource  Pointer to Vec-ordered buffer used as interim values
+ * @param  dev_blockDataOrdered  Pointer to aligned buffer used as interim values
  * @param  pencilDZ  Pointer into buffer of pencil cell sizes
  * @param  pencilRatios  Pointer into buffer with pencil target ratios (due to AMR)
  * @param  pencilBlocksCount  Pointer into buffer for storing how many non-empty blocks each pencil has for current GID
@@ -85,33 +79,26 @@ __global__ void __launch_bounds__(WID3) translation_kernel(
    const uint* __restrict__ pencilStarts,
    const vmesh::GlobalID* __restrict__ allBlocks, // List of all blocks
    const uint nAllBlocks, // size of list of blocks which we won't exceed
-   // const uint startingBlockIndex, // First block index for this kernel invocation
-   // const uint blockIndexIncrement, // How much each kernel invocation should jump ahead
    const uint nPencils, // Number of total pencils (constant)
    const uint sumOfLengths, // sum of all pencil lengths (constant)
    const Realf threshold, // used by slope limiters
    const vmesh::VelocityMesh* __restrict__ const *dev_allPencilsMeshes, // Pointers to velocity meshes
    vmesh::VelocityBlockContainer* *dev_allPencilsContainers, // pointers to BlockContainers
    Realf** pencilBlockData, // pointers into cell block data, both written and read
-   Vec** dev_blockDataOrdered, // buffer of pointers to ordered Vector-stored buffer data
-   //Vec* pencilOrderedSource, // Vec-ordered block data values for pencils
+   Realf** dev_blockDataOrdered, // buffer of pointers to mapping input data
    const Realf* __restrict__ pencilDZ,
-   const Realf* __restrict__ pencilRatios, // Vector holding target ratios
+   const Realf* __restrict__ pencilRatios, // buffer holding target ratios
    uint* pencilBlocksCount // store how many non-empty blocks each pencil has for this GID
    ) {
-   // This is launched with grid size (nGpuBlocks,maxCpuThreads,1)
-   // where maxCpuThreads is the number of temp buffers to use
-   // and  nGpuBlocks is the count of blocks which fit in the smallest temp buffer
-   //const int blocki = blockIdx.x;
-   //const int warpSize = blockDim.x*blockDim.y*blockDim.z;
+   // This is launched with grid size (nGpuBlocks,nAllocations,1)
+   // where nGpuBlocks is the count of blocks which fit in the smallest temp buffer at once
+   // and nAllocations is the number of temp GPU buffers to use.
    const uint startingBlockIndex = blockIdx.y*gridDim.x;
    const uint blockIndexIncrement = gridDim.y*gridDim.x;
-   Vec* pencilOrderedSource = dev_blockDataOrdered[blockIdx.y];
+   Realf* pencilOrderedSource = dev_blockDataOrdered[blockIdx.y];
 
-   // This is launched with block size (WID,WID,WID) assuming that VECL==WID2 and VEC_PER_BLOCK=WID
+   // This is launched with block size (WID,WID,WID)
    const vmesh::LocalID ti = threadIdx.z*blockDim.x*blockDim.y + threadIdx.y*blockDim.x + threadIdx.x;
-   const uint vecIndex = threadIdx.y*blockDim.x + threadIdx.x;
-   const uint planeIndex = threadIdx.z;
 
    // Translation direction
    uint vz_index;
@@ -132,7 +119,7 @@ __global__ void __launch_bounds__(WID3) translation_kernel(
 
    // offsets so this block of the kernel uses the correct part of temp arrays
    const uint pencilBlockDataOffset = (blockIdx.x * sumOfLengths) + (blockIdx.y * sumOfLengths * gridDim.x);
-   const uint pencilOrderedSourceOffset = blockIdx.x * sumOfLengths * (WID3/VECL);
+   const uint pencilOrderedSourceOffset = blockIdx.x * sumOfLengths * WID3;
    const uint pencilBlocksCountOffset = (blockIdx.x * nPencils) + (blockIdx.y * nPencils * gridDim.x);
    const vmesh::VelocityMesh* __restrict__ randovmesh = dev_allPencilsMeshes[0]; // just some vmesh
    const Realf dvz = randovmesh->getCellSize()[dimension];
@@ -149,13 +136,12 @@ __global__ void __launch_bounds__(WID3) translation_kernel(
          const uint lengthOfPencil = pencilLengths[pencili];
          const uint start = pencilStarts[pencili];
          // Get pointer to temprary buffer of VEC-ordered data for this kernel
-         Vec* thisPencilOrderedSource = pencilOrderedSource + pencilOrderedSourceOffset + start * WID3/VECL;
+         Realf* thisPencilOrderedSource = pencilOrderedSource + pencilOrderedSourceOffset + start * WID3;
          uint nonEmptyBlocks = 0;
-         // Go over pencil length, gather cellblock data into aligned pencil source data
+         // Go over pencil length, gather cellblock data into pencil source data
          for (uint celli = 0; celli < lengthOfPencil; celli++) {
             const vmesh::VelocityMesh* __restrict__ vmesh = dev_allPencilsMeshes[start + celli];
             vmesh::VelocityBlockContainer* cellContainer = dev_allPencilsContainers[start + celli];
-            // const vmesh::LocalID blockLID = vmesh->getLocalID(blockGID);
             // Now using warp accessor.
             #ifdef USE_TRANS_WARPACCESSORS
             const vmesh::LocalID blockLID = vmesh->warpGetLocalID(blockGID,ti);
@@ -163,14 +149,7 @@ __global__ void __launch_bounds__(WID3) translation_kernel(
             const vmesh::LocalID blockLID = vmesh->getLocalID(blockGID);
             #endif
             // Store block data pointer for both loading of data and writing back to the cell
-            if (blockLID == vmesh->invalidLocalID()) {
-               if (ti==0) {
-                  pencilBlockData[pencilBlockDataOffset + start + celli] = NULL;
-               }
-               __syncthreads();
-               // Non-existing block, push in zeroes
-               thisPencilOrderedSource[i_trans_ps_blockv_pencil(planeIndex, celli, lengthOfPencil)][vecIndex] = 0.0;
-            } else {
+            if (blockLID != vmesh->invalidLocalID()) {
                #ifdef DEBUG_VLASIATOR
                const vmesh::LocalID meshSize = vmesh->size();
                const vmesh::LocalID VBCSize = cellContainer->size();
@@ -185,10 +164,16 @@ __global__ void __launch_bounds__(WID3) translation_kernel(
                   nonEmptyBlocks++;
                }
                __syncthreads();
-               // Valid block, store values in Vec-order for efficient reading in propagation
-               // Transpose block values so that mapping is along k direction.
-               thisPencilOrderedSource[i_trans_ps_blockv_pencil(planeIndex, celli, lengthOfPencil)][vecIndex]
+               // Valid block, store values in contiguous data
+               thisPencilOrderedSource[celli * WID3 + ti]
                   = (pencilBlockData[pencilBlockDataOffset + start + celli])[ti];
+            } else {
+               if (ti==0) {
+                  pencilBlockData[pencilBlockDataOffset + start + celli] = NULL;
+               }
+               __syncthreads();
+               // Non-existing block, push in zeroes
+               thisPencilOrderedSource[celli * WID3 + ti] = 0.0;
             }
          } // End loop over this pencil
          if (ti==0) {
@@ -205,13 +190,6 @@ __global__ void __launch_bounds__(WID3) translation_kernel(
             if (pencilBlockData[pencilBlockDataOffset + celli]) {
                (pencilBlockData[pencilBlockDataOffset + celli])[ti] = 0.0;
             }
-            // vmesh::VelocityMesh* vmesh = dev_allPencilsMeshes[celli];
-            // //const vmesh::LocalID blockLID = vmesh->getLocalID(blockGID);
-            // const vmesh::LocalID blockLID = vmesh->warpGetLocalID(blockGID,ti);
-            // if (blockLID != vmesh->invalidLocalID()) {
-            //    // This block exists for this cell, reset
-            //    (pencilBlockData[pencilBlockDataOffset + celli])[ti] = 0.0;
-            // }
          }
       } // end loop over all cells
 
@@ -237,7 +215,7 @@ __global__ void __launch_bounds__(WID3) translation_kernel(
          }
          const uint lengthOfPencil = pencilLengths[pencili];
          const uint start = pencilStarts[pencili];
-         const Vec* __restrict__ thisPencilOrderedSource = pencilOrderedSource + pencilOrderedSourceOffset + start * WID3/VECL;
+         const Realf* __restrict__ thisPencilOrderedSource = pencilOrderedSource + pencilOrderedSourceOffset + start * WID3;
 
          // Go over length of propagated cells
          for (uint i = VLASOV_STENCIL_WIDTH; i < lengthOfPencil-VLASOV_STENCIL_WIDTH; i++){
@@ -270,25 +248,20 @@ __global__ void __launch_bounds__(WID3) translation_kernel(
             z_2 = positiveTranslationDirection ? 1.0 : - z_translation;
 
             #ifdef DEBUG_VLASIATOR
-            if( horizontal_or(abs(z_1) > Vec(1.0)) || horizontal_or(abs(z_2) > Vec(1.0)) ) {
+            if ( abs(z_1) > 1.0 || abs(z_2) > 1.0 ) {
                assert( 0 && "Error in translation, CFL condition violated.");
             }
             #endif
 
-            // Check if all values are 0:
-            if (!check_skip_remapping(thisPencilOrderedSource
-                                      + i_trans_ps_blockv_pencil(planeIndex, i, lengthOfPencil),vecIndex)) {
-               // Note, you cannot request to sync threads within this code block or you risk deadlock.
-
+            // If no blocks exist for this mapping, skip forward.
+            if (!check_skip_blocks(pencilBlockData,pencilBlockDataOffset + start + i)) {
                // Compute polynomial coefficients
                Realf a[3];
                // Silly indexing into coefficient calculation necessary due to
                // built-in assumptions of unsigned indexing.
                compute_ppm_coeff_nonuniform(pencilDZ + start + i - VLASOV_STENCIL_WIDTH,
-                                            thisPencilOrderedSource
-                                            + i_trans_ps_blockv_pencil(planeIndex, i, lengthOfPencil)
-                                            - VLASOV_STENCIL_WIDTH,
-                                            h4, VLASOV_STENCIL_WIDTH, a, threshold, vecIndex);
+                                            thisPencilOrderedSource + (i - VLASOV_STENCIL_WIDTH) * WID3,
+                                            h4, VLASOV_STENCIL_WIDTH, a, threshold, ti, WID3);
                // Compute integral
                const Realf ngbr_target_density =
                   z_2 * ( a[0] + z_2 * ( a[1] + z_2 * a[2] ) ) -
@@ -300,7 +273,7 @@ __global__ void __launch_bounds__(WID3) translation_kernel(
 
                // NOTE: not using atomic operations causes huge diffs (as if self contribution was neglected)! 11.01.2024 MB
                if (areaRatio && block_data) {
-                  const Realf selfContribution = (thisPencilOrderedSource[i_trans_ps_blockv_pencil(planeIndex, i, lengthOfPencil)][vecIndex] - ngbr_target_density) * areaRatio;
+                  const Realf selfContribution = (thisPencilOrderedSource[i * WID3 + ti] - ngbr_target_density) * areaRatio;
                   //atomicAdd(&block_data[ti],selfContribution);
                   block_data[ti] += selfContribution;
                }
@@ -337,10 +310,6 @@ __global__ void __launch_bounds__(GPUTHREADS*WARPSPERBLOCK) gather_union_of_bloc
    const vmesh::VelocityMesh* __restrict__ const *dev_vmeshes,
    const uint nAllCells)
 {
-   // const uint maxBlocksPerCell =  1 + ((largestFoundMeshSize - 1) / WARPSPERBLOCK); // ceil int division
-   // dim3 gatherdims_blocks(nAllCells,maxBlocksPerCell,1);
-   // dim3 gatherdims_threads(GPUTHREADS,WARPSPERBLOCK,1);
-
    const int ti = threadIdx.x; // [0,GPUTHREADS)
    const int indexInBlock = threadIdx.y; // [0,WARPSPERBLOCK)
    const uint cellIndex = blockIdx.x;
@@ -361,11 +330,6 @@ __global__ void __launch_bounds__(GPUTHREADS*WARPSPERBLOCK) gather_union_of_bloc
    const vmesh::VelocityMesh* __restrict__ const *dev_vmeshes,
    const uint nAllCells)
 {
-   // const uint maxBlocksPerCell =  1 + ((largestFoundMeshSize - 1) / (GPUTHREADS*WARPSPERBLOCK)); // ceil int division
-   // dim3 gatherdims_blocks(nAllCells,maxBlocksPerCell,1);
-   // dim3 gatherdims_threads(GPUTHREADS*WARPSPERBLOCK,1,1);
-
-   //const int ti = threadIdx.x; // [0,GPUTHREADS)
    const int indexInBlock = threadIdx.x; // [0,WARPSPERBLOCK*GPUTHREADS)
    const uint cellIndex = blockIdx.x;
    const uint blockIndexBase = blockIdx.y * WARPSPERBLOCK * GPUTHREADS;
@@ -388,6 +352,7 @@ __global__ void __launch_bounds__(GPUTHREADS*WARPSPERBLOCK) gather_union_of_bloc
  * @param [in] localPropagatedCells List of local cells that get propagated
  * ie. not boundary or DO_NOT_COMPUTE
  * @param [in] remoteTargetCells List of non-local target cells
+ * @param [in] nPencilsLB vector where the number of active pencils for each cell can be stored, to be used by load balance
  * @param [in] dimension Spatial dimension
  * @param [in] dt Time step
  * @param [in] popId Particle population ID
@@ -472,10 +437,8 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
 
    phiprof::Timer buildTimer {"trans-amr-buildBlockList"};
    // Get a unique unsorted list of blockids that are in any of the
-   // propagated cells. We launch this kernel, and do host-side pointer
-   // gathering in parallel with it.
-
-   // And how many block GIDs will we actually manage?
+   // propagated cells. We could do host-side pointer
+   // gathering in parallel with it, but that leads to potentially incorrect phiprof output..
 #ifdef USE_WARPACCESSORS
    const uint maxBlocksPerCell =  1 + ((largestFoundMeshSize - 1) / WARPSPERBLOCK); // ceil int division
    dim3 gatherdims_blocks(nAllCells,maxBlocksPerCell,1);
@@ -492,6 +455,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
       nAllCells
       );
    CHK_ERR( gpuPeekAtLastError() );
+   CHK_ERR( gpuStreamSynchronize(bgStream) ); // So we get phiprof data of this gathering time
    buildTimer.stop();
 
    phiprof::Timer gatherPointerTimer {"trans-amr-gather-meshpointers"};
@@ -521,6 +485,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
    Realf* pencilRatios = DimensionPencils[dimension].gpu_targetRatios;
    gatherPointerTimer.stop();
 
+   // Now we ensure the union of blocks gathering is complete and find the size of it. Use it to ensure allocations.
    allocateTimer.start();
    Hashinator::Info mapInfo;
    unionOfBlocksSet->copyMetadata(&mapInfo, bgStream);
@@ -530,7 +495,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
    allocateTimer.stop();
 
    phiprof::Timer buildTimer2 {"trans-amr-buildBlockList-2"};
-   // Now we ensure the union of blocks gathering is complete and extract the union of blocks into a vector
+   // Extract the union of blocks into a vector
    unionOfBlocksSet->extractAllKeysLoop(*dev_unionOfBlocks,bgStream);
    split::SplitInfo unionInfo;
    unionOfBlocks->copyMetadata(&unionInfo, bgStream);
@@ -541,25 +506,25 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
    Realf threshold = mpiGrid[DimensionPencils[dimension].ids[VLASOV_STENCIL_WIDTH]]->getVelocityBlockMinValue(popID);
    buildTimer2.stop();
 
+   // GPUTODO: make temp buffer allocation a config parameter? Current approach is not necessarily
+   // good if average block count vs grid size are mismatched. Better yet, switch to one large total
+   // buffer which is divvied up between translated blocks / accelerated cells.
+
    // How many blocks worth of pre-allocated buffer do we have for each thread?
    const uint currentAllocation = gpu_vlasov_getSmallestAllocation();
-   // GPUTODO: make temp buffer allocation a config parameter? Current approach is not necessarily
-   // good if average block count vs grid size are mismatcheds
-
    // How many block GIDs could each thread manage in parallel with this existing temp buffer? // floor int division
    // Note: we no longer launch from several threads, but some buffers are still identified via threads.
-   const uint nBlocksPerThread = currentAllocation / sumOfLengths;
-
+   const uint nBlocksPerAllocation = currentAllocation / sumOfLengths;
    // And how many block GIDs will we actually manage at once?
-   //const uint maxThreads = gpu_getMaxThreads();
-   const uint maxThreads = gpu_getAllocationCount();
-   const uint totalPerThread =  1 + ((nAllBlocks - 1) / maxThreads); // ceil int division
-   // no more than this per "thread"
-   const uint nGpuBlocks  = nBlocksPerThread  < totalPerThread ? nBlocksPerThread : totalPerThread;
+   const uint numAllocations = gpu_getAllocationCount();
+   const uint totalPerAllocation =  1 + ((nAllBlocks - 1) / numAllocations); // ceil int division
+   // no more than this per allocation
+   const uint nGpuBlocks = std::min(nBlocksPerAllocation,totalPerAllocation);
    // Limit is either how many blocks exist, or how many fit in buffer.
 
    phiprof::Timer bufferTimer {"trans-amr-buffers"};
    // Two temporary buffers, used in-kernel for both reading and writing
+   // (dev_pencilBlockData and dev_pencilBlocksCount)
    allocateTimer.start();
    gpu_trans_allocate(0,sumOfLengths,0,0,nGpuBlocks,nPencils);
    allocateTimer.stop();
@@ -571,10 +536,11 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
 
    // Loop over velocity space blocks
    phiprof::Timer mappingTimer {"trans-amr-mapping"};
-   dim3 grid(nGpuBlocks,maxThreads,1);
    // Launch 2D grid: First dimension is how many blocks fit in one temp buffer, second one
-   // is "per-thread" so which temp buffer to use.
-   dim3 block(WID,WID,WID); // assumes VECL==WID2
+   // is which temp buffer allocation index to use. (GPUTODO: simplify)
+   dim3 grid(nGpuBlocks,numAllocations,1);
+   dim3 block(WID,WID,WID);
+   Realf** dev_blockDataOrdered_recast = reinterpret_cast<Realf**>(dev_blockDataOrdered);
    translation_kernel<<<grid, block, 0, bgStream>>> (
       dimension,
       dt,
@@ -582,18 +548,15 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
       pencilStarts,
       allBlocks, // List of all block GIDs
       nAllBlocks, // size of list of block GIDs which we won't exceed
-      //startingBlockIndex, // First block index for this kernel invocation // now calculated from launch grid
-      //blockIndexIncrement, // How much each kernel invocation should jump ahead // now calculated from launch grid
       nPencils, // Number of total pencils (constant)
       sumOfLengths, // sum of all pencil lengths (constant)
       threshold,
       dev_allPencilsMeshes, // Pointers to velocity meshes
       dev_allPencilsContainers, // pointers to BlockContainers
       dev_pencilBlockData, // pointers into cell block data, both written and read
-      //pencilOrderedSource, // Vec-ordered block data values for pencils
-      dev_blockDataOrdered, // buffer of pointers to ordered Vector-stored buffer data
+      dev_blockDataOrdered_recast, // buffer of pointers to ordered buffer data
       pencilDZ,
-      pencilRatios, // Vector holding target ratios
+      pencilRatios, // buffer tor holding target ratios
       dev_pencilBlocksCount // store how many non-empty blocks each pencil has for this GID
       );
    CHK_ERR( gpuPeekAtLastError() );

--- a/vlasovsolver/gpu_trans_map_amr.cpp
+++ b/vlasovsolver/gpu_trans_map_amr.cpp
@@ -23,7 +23,7 @@
 #include "../grid.h"
 #include "../object_wrapper.h"
 #include "../memoryallocation.h"
-// #include "vec.h"
+
 #include "gpu_1d_ppm_nonuniform.hpp"
 //#include "gpu_1d_ppm_nonuniform_conserving.hpp"
 

--- a/vlasovsolver/gpu_trans_map_amr.cpp
+++ b/vlasovsolver/gpu_trans_map_amr.cpp
@@ -23,9 +23,9 @@
 #include "../grid.h"
 #include "../object_wrapper.h"
 #include "../memoryallocation.h"
-#include "vec.h"
-#include "cpu_1d_ppm_nonuniform.hpp"
-//#include "cpu_1d_ppm_nonuniform_conserving.hpp"
+// #include "vec.h"
+#include "gpu_1d_ppm_nonuniform.hpp"
+//#include "gpu_1d_ppm_nonuniform_conserving.hpp"
 
 #include "gpu_trans_map_amr.hpp"
 #include "cpu_trans_pencils.hpp"
@@ -540,7 +540,6 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
    // is which temp buffer allocation index to use. (GPUTODO: simplify)
    dim3 grid(nGpuBlocks,numAllocations,1);
    dim3 block(WID,WID,WID);
-   Realf** dev_blockDataOrdered_recast = reinterpret_cast<Realf**>(dev_blockDataOrdered);
    translation_kernel<<<grid, block, 0, bgStream>>> (
       dimension,
       dt,
@@ -554,7 +553,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
       dev_allPencilsMeshes, // Pointers to velocity meshes
       dev_allPencilsContainers, // pointers to BlockContainers
       dev_pencilBlockData, // pointers into cell block data, both written and read
-      dev_blockDataOrdered_recast, // buffer of pointers to ordered buffer data
+      dev_blockDataOrdered, // buffer of pointers to ordered buffer data
       pencilDZ,
       pencilRatios, // buffer tor holding target ratios
       dev_pencilBlocksCount // store how many non-empty blocks each pencil has for this GID

--- a/vlasovsolver/gpu_trans_map_amr.cpp
+++ b/vlasovsolver/gpu_trans_map_amr.cpp
@@ -487,6 +487,7 @@ bool trans_map_1d_amr(const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>&
 
    // Now we ensure the union of blocks gathering is complete and find the size of it. Use it to ensure allocations.
    allocateTimer.start();
+   // Use non-pagefaulting fetching of metadata
    Hashinator::Info mapInfo;
    unionOfBlocksSet->copyMetadata(&mapInfo, bgStream);
    CHK_ERR( gpuStreamSynchronize(bgStream) );

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -421,13 +421,9 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
 
    // set seed, initialise generator and get value. The order is the same
    // for all cells, but varies with timestep.
-   // std::default_random_engine rndState;
-   // std::uniform_int_distribution<uint> distribution(0,299);
-   // rndState.seed(P::tstep);
-   // uint map_order = distribution(rndState) % 3;
-   // std::cerr<<"P::tstep "<<P::tstep<<" map order "<<map_order<<std::endl;
-   // uint map_order = P::tstep % 3;
-   uint map_order = 0;
+   std::default_random_engine rndState;
+   rndState.seed(P::tstep);
+   uint map_order = std::uniform_int_distribution<>(0,2)(rndState);
 
    // Calculate length of step for each cell
    #pragma omp parallel for
@@ -439,7 +435,7 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
          Compute subcycle dt. The length is maxVdt on all steps
          except the (possible) last one. This was to keep neighboring
          spatial cells in sync (with respect to gyration), so that
-         two neighboring cells with different number of subcycles 
+         two neighboring cells with different number of subcycles
          have similar gyration angles, but adjusting the length of the
          last step so all are accelerated for the same amount of time.
          This keeps spatial block neighbors as much in sync as possible
@@ -461,10 +457,7 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
 
    // Semi-Lagrangian acceleration for all cells
 #ifdef USE_GPU
-//    if (dt>9) {
-// //   if (false) {
    gpu_accelerate_cells(mpiGrid,acceleratedCells,popID,map_order);
-   // } else {std::cerr<<" skip first half-acc "<<dt<<std::endl;}
 #else
    cpu_accelerate_cells(mpiGrid,acceleratedCells,popID,map_order);
 #endif

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -421,9 +421,13 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
 
    // set seed, initialise generator and get value. The order is the same
    // for all cells, but varies with timestep.
-   std::default_random_engine rndState;
-   rndState.seed(P::tstep);
-   uint map_order = std::uniform_int_distribution<>(0,2)(rndState);
+   // std::default_random_engine rndState;
+   // std::uniform_int_distribution<uint> distribution(0,299);
+   // rndState.seed(P::tstep);
+   // uint map_order = distribution(rndState) % 3;
+   // std::cerr<<"P::tstep "<<P::tstep<<" map order "<<map_order<<std::endl;
+   // uint map_order = P::tstep % 3;
+   uint map_order = 0;
 
    // Calculate length of step for each cell
    #pragma omp parallel for
@@ -457,7 +461,10 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
 
    // Semi-Lagrangian acceleration for all cells
 #ifdef USE_GPU
+//    if (dt>9) {
+// //   if (false) {
    gpu_accelerate_cells(mpiGrid,acceleratedCells,popID,map_order);
+   // } else {std::cerr<<" skip first half-acc "<<dt<<std::endl;}
 #else
    cpu_accelerate_cells(mpiGrid,acceleratedCells,popID,map_order);
 #endif


### PR DESCRIPTION
To be merged after #1125

This PR changes both the acceleration and translation solvers for GPU mode to act on Realf* buffers, purging any references to vectorclasses (either Agner or other).

The acceleration solver acts on a whole block at once. Care was needed for indexing and thread synchronizations so that writes into blockData do not get race conditions and lead to data corruption. But now it's done!

This also puts all the reconstruction helpers into separate CPU and GPU versions for clarity. This way, if we want specific flexible-vectorclass-versions for the future, they can get their own ones.