### PR TITLE
Refine report improvements

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -1290,8 +1290,8 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
    uint64_t coarsens {mpiGrid.get_cells_to_unrefine_count()};
    ratio_refines = static_cast<double>(refines) / static_cast<double>(cells);
    double ratio_coarsens = static_cast<double>(coarsens) / static_cast<double>(cells);
-   logFile << "(AMR) Refining " << refines << " cells after induces, " << 100.0 * ratio_refines << "% of grid" << std::endl;
-   logFile << "(AMR) Coarsening " << coarsens << " cells after induces, " << 100.0 * ratio_coarsens << "% of grid" << std::endl;
+   logFile << "(AMR) Refining " << refines << " cells to " << refines*8 << " children after induces, " << 100.0 * ratio_refines << "% of grid" << std::endl;
+   logFile << "(AMR) Coarsening " << coarsens << " cells to " << coarsens/8 <<  " parents after induces, " << 100.0 * ratio_coarsens << "% of grid" << std::endl;
 
    double newBytes{0};
    phiprof::Timer estimateMemoryTimer {"Estimate memory usage"};

--- a/memory_report.cpp
+++ b/memory_report.cpp
@@ -166,7 +166,7 @@ void report_memory_consumption(
       double max_mem_papi[4];
       /*PAPI returns memory in KB units, transform to bytes*/
       mem_papi[0] = dmem.high_water_mark * 1024;
-      mem_papi[1] = dmem.high_water_mark * 1024 + extra_bytes;
+      mem_papi[1] = dmem.resident * 1024 + extra_bytes;
       mem_papi[2] = dmem.resident * 1024;
       mem_papi[3] = extra_bytes;
       //sum node mem
@@ -188,12 +188,13 @@ void report_memory_consumption(
          logFile << reportstring;
          if (max_mem_papi[3] != 0.0) {
             snprintf(reportstring,512, "(MEM) tstep %i t %.3g %-21s (GiB/node; avg, min, max, sum): %-8.3g %-8.3g %-8.3g %-8.3g on %i nodes\n",
-               P::tstep, P::t, "HWM with refines", sum_mem_papi[1]/nNodes/GiB, min_mem_papi[1]/GiB, max_mem_papi[1]/GiB, sum_mem_papi[1]/GiB, nNodes);
+               P::tstep, P::t, "Resident with refines", sum_mem_papi[1]/nNodes/GiB, min_mem_papi[1]/GiB, max_mem_papi[1]/GiB, sum_mem_papi[1]/GiB, nNodes);
             logFile << reportstring;
          }
       }
       if(rank == MASTER_RANK) {
-         bailout(max_mem_papi[1]/GiB > P::bailout_max_memory, "Memory high water mark per node exceeds bailout threshold", __FILE__, __LINE__);
+         bailout(max_mem_papi[0]/GiB > P::bailout_max_memory, "Memory high water mark per node exceeds bailout threshold", __FILE__, __LINE__);
+         bailout(max_mem_papi[1]/GiB > P::bailout_max_memory, "Estimated resident per node exceeds bailout threshold", __FILE__, __LINE__);
       }
    }
 #endif


### PR DESCRIPTION
- Clarify counts of refined and coarsened cells
- Use resident memory for refinement estimates, as we're trying to measure the transient memory overhead of refinement