### PR TITLE
Accelerate Maxwellian boundaries in Flowthrough_amr

### DIFF
--- a/testpackage/tests/Flowthrough_amr/Flowthrough_amr.cfg
+++ b/testpackage/tests/Flowthrough_amr/Flowthrough_amr.cfg
@@ -113,3 +113,6 @@ algorithm = RCB
 [bailout]
 velocity_space_wall_block_margin = 0
 
+[vlasovsolver]
+accelerateMaxwellianBoundaries = 1
+


### PR DESCRIPTION
During investigations of diffs in #1099 I was baffled again by our diffs in the testpackage Flowthrough_amr test. What struck me today is that diffs were jumping up by factors of 2 to 6 at every change in dt step-by-step when the "normal" changes are diffs growing by about 10% per step or thereabout.

I tested activating
```
[vlasovsolver]
accelerateMaxwellianBoundaries = 1
```
which is well-established in production.

In #1099 at today's state https://github.com/fmihpc/vlasiator/actions/runs/16967516987/job/48291190426 the diffs in Flowthrough_amr are (Carrington CI), but this has been known to be a bit instable and sometimes be 100x larger:
```
 variable                                     | absolute diff | relative diff |
----------
Comparing file Flowthrough_amr/bulk.0000001.vlsv against reference
 proton/vg_rho_0                                0.0193          9.01e-09
 proton/vg_v_0                                  0.00259         1.19e-08
 proton/vg_v_1                                  0.0081          8.01e-07
 proton/vg_v_2                                  0.00564         3.89e-07
 fg_b_0                                         1.07e-17        9.11e-09
 fg_b_1                                         2.04e-17        9.92e-09
 fg_b_2                                         9.98e-18        4.66e-09
 fg_e_0                                         2.05e-12        8.67e-08
 fg_e_1                                         4.96e-12        1.14e-08
 fg_e_2                                         7.56e-12        1.83e-08
```

Running manually dev vs the branch on LUMI-C, on a single task and single thread, I get
```
proton/vg_rho 0          5.18    2.41e-06
proton/vg_v 0          0.945   4.35e-06
fg_b 0                     1.03e-15        8.81e-07
fg_e 0                      4.99e-10        2.08e-05
```


If I activate the Maxwellian boundary acceleration, still single task, single thread, I get
```
proton/vg_rho 0         0.226   1.05e-07
proton/vg_v 0         0.0522  2.39e-07
fg_b 0                       1.08e-16        9.19e-08
fg_e 0                        8.76e-11        3.69e-06
```

If I activate the Maxwellian boundary acceleration on 16 tasks x 16 threads I get
```
proton/vg_rho 0       0.0174  8.07e-09
proton/vg_v 0           0.00789 3.61e-08
fg_b 0                         1.89e-18        1.61e-09
fg_e 0                          2.4e-12 1.01e-07
```

In the latter two cases, the diffs don't increase monotonically any more for all variables, so this doesn't rid us of all diffs. I'm also a bit surprised the 16 x 16 diverges less than the serial version. But well.


Note that dt changes "macroscopically" of course, and new reference data will be needed after this, but it seems to make Flowthrough_amr less diffy.