### PR TITLE
Enable precommit CI auto-stage on PRs to format source code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,7 +8,9 @@ PointerAlignment: Left
 AlignAfterOpenBracket: true
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false
-ColumnLimit: 120
+ColumnLimit: 200
 AccessModifierOffset: -3
-...
-
+LambdaBodyIndentation: OuterScope
+NamespaceIndentation: All
+BinPackArguments: true
+OneLineFormatOffRegex: pragma

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+      - name: Install clang-format 22
+        run: |
+          sudo echo "deb http://ftp.fi.debian.org/debian/ experimental main contrib non-free" >> /etc/apt/sources.list
+          sudo apt-get update
+          sudo apt-get install -y clang-format-22
       - name: Run precommit
       - uses: pre-commit/action@v3.0.1
       - uses: pre-commit-ci/lite-action@v1.1.0

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,0 +1,22 @@
+name: Run precommit to automatically format and fix PRs
+
+on:
+  pull_request:
+    branches: [ master, dev ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    container: ursg/vlasiator_ci:20250909_1
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Run precommit
+      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit-ci/lite-action@v1.1.0
+        if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,11 @@ repos:
     hooks:
     -   id: remove-tabs
         args: [--whitespaces-count, '8']
-#-   repo: https://github.com/pocc/pre-commit-hooks
-#    rev: v1.3.5
-#    hooks:
-#    -   id: clang-format
-#        args: [-i]
+-   repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+    -   id: clang-format
+        args: [-i]
 
 ci:
     autofix_commit_msg: |


### PR DESCRIPTION
This will now (hopefully) autoformat in a reasonable way, without messing up omp pragmas.