### PR TITLE
Change vectordipole dipoleInflow magnetic field split into BGB and PerB

### DIFF
--- a/backgroundfield/vectordipole.cpp
+++ b/backgroundfield/vectordipole.cpp
@@ -73,9 +73,9 @@ double VectorDipole::operator()( double x, double y, double z, coordinate compon
       return 0.0; //set zero field inside dipole
    
    if(r[0]>=xlimit[1]){
-      //set zero or IMF field and derivatives outside "zero x limit"
+      //set zero field and derivatives outside "zero x limit", leaving IMF there
       if(derivative == 0) {
-         return IMF[component]; 
+         return 0.0; 
       } else {
          return 0.0;
       }
@@ -90,8 +90,8 @@ double VectorDipole::operator()( double x, double y, double z, coordinate compon
    const double B=( 3*r[component]*rdotq-q[component]*r2)/r5;
 
    if((derivative == 0) && (r[0] <= xlimit[0])) {
-      // Full dipole field within full xlimit
-      return B;
+      // Full dipole field and IMF removed within full xlimit
+      return B - IMF[component];
    }
 
    if((derivative == 1) && (r[0] <= xlimit[0])){
@@ -138,7 +138,7 @@ double VectorDipole::operator()( double x, double y, double z, coordinate compon
    const double IMFs = (r[0]-xlimit[0])/(xlimit[1]-xlimit[0]);
    const double IMFss = IMFs*IMFs;
    // Smootherstep and its x-directional derivative
-   const double IMFS2 = 6.*IMFss*IMFss*IMFs - 15.*IMFss*IMFss + 10.*IMFss*IMFs;
+   const double IMFS2 = 6.*IMFss*IMFss*IMFs - 15.*IMFss*IMFss + 10.*IMFss*IMFs - 1;
    const double IMFdS2dx = (30.*IMFss*IMFss - 60.*IMFss*IMFs + 30.*IMFss)/(xlimit[1]-xlimit[0]);
 
    // Cartesian derivatives of S2

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -330,7 +330,7 @@ namespace projects {
                setBackgroundField(bgFieldDipole, BgBGrid, true);
                break;
             case 4:  // Vector potential dipole, vanishes or optionally scales to static inflow value after a given x-coordinate
-               // What we in fact do is we place the regular dipole in the background field, and the
+               // What we in fact do is we place the regular dipole and IMF in the background field, and the
                // corrective terms in the perturbed field. This maintains the BGB as curl-free.
                bgFieldDipole.initialize(8e15 *this->dipoleScalingFactor, 0.0, 0.0, 0.0, 0.0 ); //set dipole moment
                setBackgroundField(bgFieldDipole, BgBGrid);
@@ -468,7 +468,13 @@ namespace projects {
 
       phiprof::Timer addConstantTimer {"add-constant-field"};
       // Superimpose constant background field if needed
-      if(this->constBgB[0] != 0.0 || this->constBgB[1] != 0.0 || this->constBgB[2] != 0.0) {
+      if(this->dipoleInflowB[0] != 0.0 || this->dipoleInflowB[1] != 0.0 || this->dipoleInflowB[2] != 0.0) {
+         ConstantField bgConstantField;
+         bgConstantField.initialize(this->dipoleInflowB[0], this->dipoleInflowB[1], this->dipoleInflowB[2]);
+         setBackgroundField(bgConstantField, BgBGrid, true);
+         SBC::ionosphereGrid.setConstantBackgroundField(this->dipoleInflowB);
+      }
+      else if(this->constBgB[0] != 0.0 || this->constBgB[1] != 0.0 || this->constBgB[2] != 0.0) {
          ConstantField bgConstantField;
          bgConstantField.initialize(this->constBgB[0], this->constBgB[1], this->constBgB[2]);
          setBackgroundField(bgConstantField, BgBGrid, true);

--- a/projects/Magnetosphere/Magnetosphere.h
+++ b/projects/Magnetosphere/Magnetosphere.h
@@ -100,7 +100,7 @@ namespace projects {
       Real dipoleTiltTheta;
       Real dipoleXFull;
       Real dipoleXZero;
-      Real dipoleInflowB[3];
+      std::array<Real, 3> dipoleInflowB;
       Real zeroOutComponents[3]; //0->x,1->y,2->z
 
       std::vector<MagnetosphereSpeciesParameters> speciesParams;


### PR DESCRIPTION
This fixes #1188 

Left: Old scheme, Right: New scheme
(Note: Both schemes also remove the use of finite differencing at sysboundaries, but that is not included in this PR)