### PR TITLE
Warn when field line tracing is enabled and not in a Magnetosphere project

### DIFF
--- a/MAKE/Makefile.kstppd
+++ b/MAKE/Makefile.kstppd
@@ -68,8 +68,8 @@ LIB_PAPI = -L$(LIBRARY_PREFIX)/lib/ -lpapi
 INC_JEMALLOC = -I$(LIBRARY_PREFIX)/jemalloc/include
 LIB_JEMALLOC = -L$(LIBRARY_PREFIX)/jemalloc/lib -ljemalloc
 
-LIB_PROFILE = -L$(LIBRARY_PREFIX)/lib -lphiprof
-INC_PROFILE = -I$(LIBRARY_PREFIX)/include
+LIB_PROFILE = -L$(LIBRARY_PREFIX)/phiprof/lib -lphiprof
+INC_PROFILE = -I$(LIBRARY_PREFIX)/phiprof/include
 
 INC_VECTORCLASS = -isystem ./submodules/vectorclass/ -isystem ./submodules/vectorclass-addon/vector3d/
 INC_EIGEN = -isystem ./submodules/eigen/

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -37,6 +37,12 @@
 #define NAN 0
 #endif
 
+#define WARN(MSG) do {                                         \
+    fprintf(stderr, "************************************\n"); \
+    fprintf(stderr, "WARNING: %s\n", (MSG));                   \
+    fprintf(stderr, "************************************\n"); \
+} while (0)
+
 using namespace std;
 
 typedef Parameters P;
@@ -1154,6 +1160,15 @@ void Parameters::getParameters() {
    } else {
       cerr << __FILE__ << ":" << __LINE__ << " ERROR: Unknown value for fieldtracing.fieldLineTracer: " << tracerString << endl;
       abort();
+   }
+
+   //Sanity check on MASTER RANK only. If we have field trcing enabled and not in a
+   // Magnetosphere project issue a warning. The run will probably crash
+   // soon
+   if (myRank == MASTER_RANK){
+      if (RP::field_exists("fieldtracing") && P::projectName != "Magnetosphere" ) {
+         WARN("WARNING: You have enabled Field Line Tracing in a non Magnetosphere project. The code will likely crash soon!");
+      }
    }
 }
 

--- a/readparameters.h
+++ b/readparameters.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <typeinfo>
 #include <vector>
+#include <string_view>
 
 #include "common.h"
 #include "version.h"
@@ -111,6 +112,48 @@ public:
             MPI_Abort(MPI_COMM_WORLD, 1);
          }
       }
+   }
+
+   /** Boolean methods to check whether a field exists in the cfg file 
+    * @param target: The field we look for ie: fieldtracing.
+    */
+   static bool field_exists(const std::string_view target) {
+      auto exists = [](const std::string_view  target, const std::string& filename)->bool{
+         //Trim white space
+         auto trim = [](std::string& s)->void {
+            auto is_ws = [](unsigned char c) { return std::isspace(c); };
+            auto a = std::find_if_not(s.begin(), s.end(), is_ws);
+            auto b = std::find_if_not(s.rbegin(), s.rend(), is_ws).base();
+            s = (a < b) ? std::string(a, b) : std::string();
+         };
+
+         std::ifstream f(run_config_file_name);
+         if (!f) {
+            return false;
+         }
+
+         std::string curr_line;
+         while (std::getline(f, curr_line)) {
+            trim(curr_line);
+            //Ignore commetns for cfg file
+            if (curr_line.empty() || curr_line[0] == '#') {
+               continue;
+            }
+            //In vlasiator cfg fields are specified in [] brackets
+            if (curr_line.size() >= 2 && curr_line.front() == '[' && curr_line.back() == ']') {
+               auto inner = curr_line.substr(1, curr_line.size() - 2);
+               trim(inner);
+               if (inner == target)
+                  return true;
+            }
+         }
+         return false;
+      };
+
+      const bool retval = exists(target, user_config_file_name) ||
+                          exists(target, run_config_file_name)  ||
+                          exists(target, global_config_file_name);
+      return retval;
    }
 
    template <typename T> static void get(const std::string& name, T& value) {


### PR DESCRIPTION
This PR tries to resolve #1185 . 
I could actually not figure out any way to do the same using Boost's program options so I had to do some manual parsing. In any case this will now wart on ```stderr``` when field tracing is enabled and we are not running a Magnetosphere. The user can still however specify datareducers which will trigger field line tracing. Should we guard that too?