### PR TITLE
Do not reapply solved B components in boundary cells except at simulation start

### DIFF
--- a/sysboundary/copysphere.cpp
+++ b/sysboundary/copysphere.cpp
@@ -863,6 +863,7 @@ namespace SBC {
    void Copysphere::getFaces(bool *faces) {}
 
    void Copysphere::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
+                                FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
                                 FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                 FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                 creal t) {}

--- a/sysboundary/copysphere.h
+++ b/sysboundary/copysphere.h
@@ -75,6 +75,7 @@ namespace SBC {
       ) override;
       virtual void updateState(
          dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry> &mpiGrid,
+         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
          FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> &perBGrid,
          FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH> &BgBGrid,
          creal t

--- a/sysboundary/donotcompute.cpp
+++ b/sysboundary/donotcompute.cpp
@@ -80,6 +80,7 @@ namespace SBC {
    }
    
    void DoNotCompute::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry> &mpiGrid,
+                                  FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
                                   FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> &perBGrid,
                                   FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                   creal t) {}

--- a/sysboundary/donotcompute.h
+++ b/sysboundary/donotcompute.h
@@ -59,6 +59,7 @@ namespace SBC {
       ) override;
       void updateState(
          dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry> &mpiGrid,
+         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
          FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> &perBGrid,
          FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
          creal t

--- a/sysboundary/inflow.h
+++ b/sysboundary/inflow.h
@@ -68,6 +68,7 @@ public:
                                   FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                   Project& project) override;
    virtual void updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
+                            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
                             FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                             creal t) override;
@@ -122,8 +123,10 @@ protected:
                                      creal t) = 0;
    void setCellsFromTemplate(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid, const uint popID);
    void setBFromTemplate(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
+                         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
                          FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
-                         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid);
+                         FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
+                         const bool resetSolved);
 
 };
 } // namespace SBC

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -3505,6 +3505,7 @@ namespace SBC {
    void Ionosphere::getFaces(bool *faces) {}
 
    void Ionosphere::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
+                                FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
                                 FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                                 FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                                 creal t) {}

--- a/sysboundary/ionosphere.h
+++ b/sysboundary/ionosphere.h
@@ -396,6 +396,7 @@ namespace SBC {
       ) override;
       virtual void updateState(
          dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
+         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
          FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
          FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
          creal t

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -286,6 +286,7 @@ namespace SBC {
    }
 
    void Outflow::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
+                             FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
                              FsGrid<array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                              FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                              creal t) {}

--- a/sysboundary/outflow.h
+++ b/sysboundary/outflow.h
@@ -74,6 +74,7 @@ namespace SBC {
       ) override;
       virtual void updateState(
          dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
+         FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
          FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
          FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
          creal t

--- a/sysboundary/sysboundary.cpp
+++ b/sysboundary/sysboundary.cpp
@@ -627,13 +627,14 @@ void SysBoundary::applyInitialState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_G
 }
 
 void SysBoundary::updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
+                              FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
                               FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH>& perBGrid,
                               FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                               creal t) {
    if (isAnyDynamic()) {
       for(auto& b : sysBoundaries) {
          if (b->isDynamic()) {
-            b->updateState(mpiGrid, perBGrid, BgBGrid, t);
+            b->updateState(mpiGrid, technicalGrid, perBGrid, BgBGrid, t);
          }
       }
    }

--- a/sysboundary/sysboundary.h
+++ b/sysboundary/sysboundary.h
@@ -80,6 +80,7 @@ class SysBoundary {
                           Project& project
                          );
    void updateState(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry> &mpiGrid,
+                    FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
                     FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> &perBGrid,
                     FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
                     creal t);

--- a/sysboundary/sysboundarycondition.h
+++ b/sysboundary/sysboundarycondition.h
@@ -77,6 +77,7 @@ namespace SBC {
          )=0;
          virtual void updateState(
             dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry> &mpiGrid,
+            FsGrid< fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid,
             FsGrid<std::array<Real, fsgrids::bfield::N_BFIELD>, FS_STENCIL_WIDTH> &perBGrid,
             FsGrid<std::array<Real, fsgrids::bgbfield::N_BGB>, FS_STENCIL_WIDTH>& BgBGrid,
             creal t

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -1211,7 +1211,7 @@ int simulate(int argn,char* args[]) {
       // Update boundary condition states (time-varying)
       if (P::propagateVlasovTranslation || P::propagateVlasovAcceleration) {
          phiprof::Timer timer {"Update system boundaries (Vlasov pre-translation)"};
-         sysBoundaryContainer.updateState(mpiGrid, perBGrid, BgBGrid, P::t + 0.5 * P::dt);
+         sysBoundaryContainer.updateState(mpiGrid, technicalGrid, perBGrid, BgBGrid, P::t + 0.5 * P::dt);
          timer.stop();
          addTimedBarrier("barrier-boundary-conditions");
       }


### PR DESCRIPTION
The argument being that B evolves in these cells and thus resetting B during runtime is suspect.