### PR TITLE
Remove MacOS from CI builds, try building on github arm64 instead.

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -561,7 +561,7 @@ jobs:
         if-no-files-found: error
 
   build_arm64:
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     needs: build_libraries_arm64
 
     steps:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -74,7 +74,7 @@ jobs:
           rm -rf libraries library-build libraries-pioneer.tar.gz
       - name: Submit library job
         run: |
-          srun --interactive -p pioneer -J vlasiator-libs -n 1 -c 64 -t 01:00:00 bash -lc 'module load openmpi; ./fetch_and_build_libraries.sh pioneer'
+          srun --interactive -p pioneer -J vlasiator-libs -n 1 -c 64 -t 01:00:00 bash -lc 'module load llvm openmpi; ./fetch_and_build_libraries.sh pioneer'
           #ssh synth-hca 'source /etc/profile.d/lmod.sh; export PATH=$PATH:$HOME/bin; module load llvm/cross/EPI-0.7-development; cd '$GITHUB_WORKSPACE'; ./fetch_and_build_libraries.sh pioneer'
       - name: Build libraries tar
         run: tar -czvf libraries-pioneer.tar.gz libraries-pioneer/
@@ -551,7 +551,7 @@ jobs:
       run: VLASIATOR_ARCH=pioneer make clean
     - name: Compile vlasiator (RISC-V)
       run: |
-        srun --interactive -p pioneer -J vlasiator_build -n 1 -c 64 --pty -t 01:00:00 bash -lc 'module load boost papi openmpi; export VLASIATOR_ARCH=pioneer; make -j64'
+        srun --interactive -p pioneer -J vlasiator_build -n 1 -c 64 --pty -t 01:00:00 bash -lc 'module load boost papi llvm openmpi; export VLASIATOR_ARCH=pioneer; make -j64'
         #ssh synth-hca 'source /etc/profile.d/lmod.sh; export PATH=$PATH:$HOME/bin; module load llvm/cross/EPI-0.7-development; export VLASIATOR_ARCH=pioneer; cd '$GITHUB_WORKSPACE'; make -j 12'
     - name: Upload riscv binary
       uses: actions/upload-artifact@v4

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -35,36 +35,23 @@ jobs:
           retention-days: 5
           if-no-files-found: error
 
-  build_libraries_appleM1:
+  build_libraries_arm64:
     # Build libraries on macos with M1 hardware, to test both macOS and aarch64 compatibility
-    runs-on: macos-14
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-      - name: Setup MPI
-        uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: 'openmpi'
-      - name: Setup openmp-capable llvm
-        run: |
-          brew install llvm libomp
-          echo "CXX=/opt/homebrew/opt/llvm/bin/clang++" >> "$GITHUB_ENV"
-          echo "OMPI_CXX=/opt/homebrew/opt/llvm/bin/clang++" >> "$GITHUB_ENV"
-          echo "MPI_CXX=mpic++" >> "$GITHUB_ENV"
-          echo "CC=/opt/homebrew/opt/llvm/bin/clang" >> "$GITHUB_ENV"
-          echo "OMPI_CC=/opt/homebrew/opt/llvm/bin/clang" >> "$GITHUB_ENV"
-          echo "MPI_CC=mpicc" >> "$GITHUB_ENV"
       - name: Run library build script
         run: |
-          . ./fetch_and_build_libraries.sh appleM1
+          . ./fetch_and_build_libraries.sh arm64
       - name: Build libraries tar
-        run: tar --zstd -cvf libraries-appleM1.tar.zstd libraries-appleM1
+        run: tar --zstd -cvf libraries-arm64.tar.zstd libraries-arm64
       - name: Upload libraries as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: libraries-appleM1
-          path: libraries-appleM1.tar.zstd
+          name: libraries-arm64
+          path: libraries-arm64.tar.zstd
           retention-days: 5
           if-no-files-found: error
 
@@ -569,42 +556,29 @@ jobs:
         path: vlasiator
         if-no-files-found: error
 
-  build_appleM1:
-    runs-on: macos-14
-    needs: build_libraries_appleM1
+  build_arm64:
+    runs-on: ubuntu-24.04-arm64
+    needs: build_libraries_arm64
 
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Setup MPI
-      uses: mpi4py/setup-mpi@v1
-      with:
-        mpi: 'openmpi'
-    - name: Setup openmp-capable llvm
-      run: |
-        brew install llvm libomp
-        echo "CXX=/opt/homebrew/opt/llvm/bin/clang++" >> "$GITHUB_ENV"
-        echo "OMPI_CXX=/opt/homebrew/opt/llvm/bin/clang++" >> "$GITHUB_ENV"
-        echo "CC=/opt/homebrew/opt/llvm/bin/clang" >> "$GITHUB_ENV"
-        echo "OMPI_CC=/opt/homebrew/opt/llvm/bin/clang" >> "$GITHUB_ENV"
     - name: Install boost
       run: |
-        brew install boost
-        ln -s /opt/homebrew/Cellar/boost/* /opt/homebrew/Cellar/boost/latest
+        sudo apt-get install libboost-program-options-dev
     - name: Download libraries
       uses: actions/download-artifact@v5
       with:
-        name: libraries-appleM1
+        name: libraries-arm64
     - name: Unpack libraries
-      run: tar --zstd -xvf libraries-appleM1.tar.zstd
+      run: tar --zstd -xvf libraries-arm64.tar.zstd
     - name: Make clean
-      run: VLASIATOR_ARCH=appleM1 make clean
+      run: VLASIATOR_ARCH=github_actions_arm64 make clean
     - name: Compile vlasiator (Release build)
       run: |
-        VLASIATOR_ARCH=appleM1 make clean
-        VLASIATOR_ARCH=appleM1 make -j 3
+        VLASIATOR_ARCH=github_actions_arm64 make -j 4
 
   build_tools:
     # Build vlsvdiff, vlsvextract, and fluxfunction for testpackage use

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y g++ build-essential cmake make libopenmpi-dev openmpi-bin libboost-program-options-dev
+          sudo apt-get install -y g++ build-essential cmake make libopenmpi-dev openmpi-bin libboost-program-options-dev zstd
       - name: Run library build script
         run: |
           . ./fetch_and_build_libraries.sh arm64
@@ -572,7 +572,7 @@ jobs:
     - name: Install boost
       run: |
        sudo apt-get update
-       sudo apt-get install -y g++ build-essential cmake make libopenmpi-dev openmpi-bin libboost-program-options-dev
+       sudo apt-get install -y g++ build-essential cmake make libopenmpi-dev openmpi-bin libboost-program-options-dev zstd
     - name: Download libraries
       uses: actions/download-artifact@v5
       with:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -42,6 +42,10 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++ build-essential cmake make libopenmpi-dev openmpi-bin libboost-program-options-dev
       - name: Run library build script
         run: |
           . ./fetch_and_build_libraries.sh arm64
@@ -567,7 +571,8 @@ jobs:
         submodules: true
     - name: Install boost
       run: |
-        sudo apt-get install libboost-program-options-dev
+       sudo apt-get update
+       sudo apt-get install -y g++ build-essential cmake make libopenmpi-dev openmpi-bin libboost-program-options-dev
     - name: Download libraries
       uses: actions/download-artifact@v5
       with:

--- a/MAKE/Makefile.github_actions_arm64
+++ b/MAKE/Makefile.github_actions_arm64
@@ -45,7 +45,7 @@ CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 #                         mpi.h in c++ on Cray
 
 FLAGS =
-CXXFLAGS += -I ${GITHUB_WORKSPACE}/libraries/include -L ${GITHUB_WORKSPACE}/libraries/lib -march=native -O3 -std=c++20 -fopenmp -Wall -Wno-unused -fabi-version=0 -mavx -g -Wno-cast-function-type
+CXXFLAGS += -I ${GITHUB_WORKSPACE}/libraries/include -L ${GITHUB_WORKSPACE}/libraries/lib -march=native -O3 -std=c++20 -fopenmp -Wall -Wno-unused -fabi-version=0 -g -Wno-cast-function-type
 MATHFLAGS = # -ffast-math -fno-finite-math-only
 testpackage: MATHFLAGS = # -fno-unsafe-math-optimizations
 LDFLAGS = -L ${GITHUB_WORKSPACE}/libraries/lib -Wl,-rpath=${GITHUB_WORKSPACE}/libraries/lib -g

--- a/MAKE/Makefile.github_actions_arm64
+++ b/MAKE/Makefile.github_actions_arm64
@@ -45,16 +45,16 @@ CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 #                         mpi.h in c++ on Cray
 
 FLAGS =
-CXXFLAGS += -I ${GITHUB_WORKSPACE}/libraries/include -L ${GITHUB_WORKSPACE}/libraries/lib -march=native -O3 -std=c++20 -fopenmp -Wall -Wno-unused -fabi-version=0 -g -Wno-cast-function-type
+CXXFLAGS += -I ${GITHUB_WORKSPACE}/libraries-arm64/include -L ${GITHUB_WORKSPACE}/libraries-arm64/lib -march=native -O3 -std=c++20 -fopenmp -Wall -Wno-unused -fabi-version=0 -g -Wno-cast-function-type
 MATHFLAGS = # -ffast-math -fno-finite-math-only
 testpackage: MATHFLAGS = # -fno-unsafe-math-optimizations
-LDFLAGS = -L ${GITHUB_WORKSPACE}/libraries/lib -Wl,-rpath=${GITHUB_WORKSPACE}/libraries/lib -g
+LDFLAGS = -L ${GITHUB_WORKSPACE}/libraries-arm64/lib -Wl,-rpath=${GITHUB_WORKSPACE}/libraries-arm64/lib -g
 LIB_MPI = -lgomp 
 
 
 #======== Libraries ===========
 
-LIBRARY_PREFIX = ${GITHUB_WORKSPACE}/libraries
+LIBRARY_PREFIX = ${GITHUB_WORKSPACE}/libraries-arm64
 
 INC_BOOST =
 LIB_BOOST = -lboost_program_options
@@ -74,7 +74,7 @@ LIB_SILO = -lsiloh5
 INC_PAPI =
 LIB_PAPI = -lpapi
 
-LIB_PROFILE = -I $(LIBRARY_PREFIX)/include ${GITHUB_WORKSPACE}/libraries/lib/libphiprof.a
+LIB_PROFILE = -I $(LIBRARY_PREFIX)/include ${GITHUB_WORKSPACE}/libraries-arm64/lib/libphiprof.a
 INC_PROFILE =
 INC_TOPO =
 

--- a/MAKE/Makefile.github_actions_arm64
+++ b/MAKE/Makefile.github_actions_arm64
@@ -1,0 +1,85 @@
+CMP = mpic++
+LNK = mpic++
+#CMP = tau_cxx.sh
+#LNK = tau_cxx.sh
+
+#======== Vectorization ==========
+#Set vector backend type for vlasov solvers, sets precision and length. 
+#NOTE this has to have the same precision as the distribution function define (DISTRIBUTION_FP_PRECISION)
+#Options: 
+# AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
+# AVX512:   VEC8D_AGNER, VEC16F_AGNER
+# Fallback: VEC_FALLBACK_GENERIC
+
+ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
+#Single-precision        
+	VECTORCLASS = VEC_FALLBACK_GENERIC
+	#VECTORCLASS = VEC8F_AGNER
+else
+#Double-precision
+	#VECTORCLASS = VEC4D_AGNER
+	VECTORCLASS = VEC_FALLBACK_GENERIC
+endif
+
+#======== PAPI ==========
+#Add PAPI_MEM define to use papi to report memory consumption?
+CXXFLAGS +=  -DPAPI_MEM
+
+
+#======== Allocator =========
+#Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
+#Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
+CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+
+
+#======= Compiler and compilation flags =========
+# NOTES on compiler flags:
+# CXXFLAGS is for compiler flags, they are always used
+# MATHFLAGS are for special math etc. flags, these are only applied on solver functions
+# LDFLAGS flags for linker
+
+#-DNO_WRITE_AT_ALL:  Define to disable write at all to 
+#                    avoid memleak (much slower IO)
+#-DMPICH_IGNORE_CXX_SEEK: Ignores some multiple definition 
+#                         errors that come up when using 
+#                         mpi.h in c++ on Cray
+
+FLAGS =
+CXXFLAGS += -I ${GITHUB_WORKSPACE}/libraries/include -L ${GITHUB_WORKSPACE}/libraries/lib -march=native -O3 -std=c++20 -fopenmp -Wall -Wno-unused -fabi-version=0 -mavx -g -Wno-cast-function-type
+MATHFLAGS = # -ffast-math -fno-finite-math-only
+testpackage: MATHFLAGS = # -fno-unsafe-math-optimizations
+LDFLAGS = -L ${GITHUB_WORKSPACE}/libraries/lib -Wl,-rpath=${GITHUB_WORKSPACE}/libraries/lib -g
+LIB_MPI = -lgomp 
+
+
+#======== Libraries ===========
+
+LIBRARY_PREFIX = ${GITHUB_WORKSPACE}/libraries
+
+INC_BOOST =
+LIB_BOOST = -lboost_program_options
+
+INC_JEMALLOC = -I $(LIBRARY_PREFIX)/include
+LIB_JEMALLOC = $(LIBRARY_PREFIX)/lib/libjemalloc.a
+
+INC_ZOLTAN =
+LIB_ZOLTAN = -lzoltan
+
+INC_VLSV = -I $(LIBRARY_PREFIX)/include
+LIB_VLSV = -L $(LIBRARY_PREFIX)/lib -lvlsv
+
+INC_SILO =
+LIB_SILO = -lsiloh5
+
+INC_PAPI =
+LIB_PAPI = -lpapi
+
+LIB_PROFILE = -I $(LIBRARY_PREFIX)/include ${GITHUB_WORKSPACE}/libraries/lib/libphiprof.a
+INC_PROFILE =
+INC_TOPO =
+
+# Works without but as an example: arch-specific INCLUDE paths be like this:
+INC_DCCRG = -I${GITHUB_WORKSPACE}/submodules/dccrg
+INC_FSGRID = -I${GITHUB_WORKSPACE}/submodules/fsgrid
+INC_VECTORCLASS = -isystem ${GITHUB_WORKSPACE}/submodules/vectorclass/ -isystem ${GITHUB_WORKSPACE}/submodules/vectorclass-addon/vector3d/
+INC_EIGEN = -isystem ${GITHUB_WORKSPACE}/submodules/eigen/

--- a/build_fetched_libraries.sh
+++ b/build_fetched_libraries.sh
@@ -121,6 +121,8 @@ mkdir zoltan-build
 cd zoltan-build
 if [[ $PLATFORM == "-pioneer" ]]; then
     ../Zoltan/configure --prefix=$WORKSPACE/libraries${PLATFORM} --enable-mpi --with-mpi-compilers --with-gnumake --with-id-type=ullong --host=riscv64-unknown-linux-gnu --build=arm-linux-gnu
+elif [[ $PLATFORM == "-arm64" ]]; then
+    ../Zoltan/configure --prefix=$WORKSPACE/libraries${PLATFORM} --enable-mpi --with-mpi-compilers --with-gnumake --with-id-type=ullong --build=arm-linux-gnu --host=arm-linux-gnu CC=mpicc CXX=mpic++
 elif [[ $PLATFORM == "-appleM1" || $PLATFORM == "-meluxina" ]]; then
     ../Zoltan/configure --prefix=$WORKSPACE/libraries${PLATFORM} --enable-mpi --with-mpi-compilers --with-gnumake --with-id-type=ullong CC=mpicc CXX=mpic++
 elif [[ $PLATFORM == "-leonardo_dcgp_intel" ]]; then


### PR DESCRIPTION
The MacOS runners were only added in the first place because it was the only cloud-hosted arm64 architecture at the time. Now that Github offers proper arm64-based Ubuntu machines, lets use those instead.

Also macOS building is broken and nobody bothers to fix it.