### PR TITLE
Workflow check for whether to run testpackage

### DIFF
--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -1,7 +1,7 @@
 
 #!/bin/bash 
 
-git_diff=$(git diff --name-only upstream/vlasiator_gpu...)
+git_diff=$(git diff --name-only origin/dev...)
 declare -i full_count=$(echo $git_diff | wc -w)
 declare -a unallowed_strings=(".cpp\b" ".hpp\b" ".c\b" ".sh\b" )
 for unallowed_string in ${unallowed_strings[@]}

--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -22,4 +22,3 @@ done
 if [[ $allowed_count == $full_count ]]; then
   echo "run_test"
 fi
-#if [[ $(./r.sh) = "run_test"  ]]; then echo "test"; fi

--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -1,0 +1,25 @@
+
+#!/bin/bash 
+
+git_diff=$(git diff --name-only upstream/vlasiator_gpu...)
+declare -i full_count=$(echo $git_diff | wc -w)
+declare -a unallowed_strings=(".cpp\b" ".hpp\b" ".c\b" ".sh\b" )
+for unallowed_string in ${unallowed_strings[@]}
+do
+  if [[ $(echo $git_diff | grep -Po $unallowed_string) ]]; then
+    exit 0
+  fi
+done
+
+declare -a file_check=("\w+.md" "INSTALL" "CITATION.cff" "Doxyfile*" "\bdoc/")
+declare -i allowed_count=0
+
+for allowed_string in ${file_check[@]}
+do
+  diff="$(echo $git_diff | grep -Po $allowed_string | wc -w)"
+  allowed_count=$(( $allowed_count + $diff ))
+done
+if [[ $allowed_count == $full_count ]]; then
+  echo "run_test"
+fi
+#if [[ $(./r.sh) = "run_test"  ]]; then echo "test"; fi

--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -11,7 +11,7 @@ do
   fi
 done
 
-declare -a file_check=("\w+.md" "INSTALL" "CITATION.cff" "Doxyfile*" "\bdoc/")
+declare -a file_check=("\w+.md" "INSTALL" "CITATION.cff" "Doxyfile." "\bdoc/")
 declare -i allowed_count=0
 
 for allowed_string in ${file_check[@]}
@@ -22,3 +22,4 @@ done
 if [[ $allowed_count == $full_count ]]; then
   echo "run_test"
 fi
+

--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -1,7 +1,6 @@
 
 #!/bin/bash 
 git_diff=$(git diff --name-only origin/$@...)
-echo $git_diff
 declare -i full_count=$(echo $git_diff | wc -w)
 declare -a unallowed_strings=(".cpp\b" ".hpp\b" ".c\b" ".sh\b" )
 for unallowed_string in ${unallowed_strings[@]}

--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -3,6 +3,8 @@
 git_diff=$(git diff --name-only origin/$@...)
 declare -i full_count=$(echo $git_diff | wc -w)
 declare -a unallowed_strings=(".cpp\b" ".hpp\b" ".c\b" ".sh\b" )
+
+#Check if git diff contains any changes to the actual code
 for unallowed_string in ${unallowed_strings[@]}
 do
   if [[ $(echo $git_diff | grep -Po $unallowed_string) ]]; then
@@ -13,6 +15,7 @@ done
 declare -a file_check=("\w+.md" "INSTALL" "CITATION.cff" "Doxyfile." "\bdoc/")
 declare -i allowed_count=0
 
+#checking if only allowed files are changed. 
 for allowed_string in ${file_check[@]}
 do
   diff="$(echo $git_diff | grep -Po $allowed_string | wc -w)"

--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -1,7 +1,6 @@
 
 #!/bin/bash 
-echo $@
-git_diff=$(git diff --name-only origin/dev...)
+git_diff=$(git diff --name-only origin/$@...)
 declare -i full_count=$(echo $git_diff | wc -w)
 declare -a unallowed_strings=(".cpp\b" ".hpp\b" ".c\b" ".sh\b" )
 for unallowed_string in ${unallowed_strings[@]}

--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -1,6 +1,6 @@
 
 #!/bin/bash 
-
+echo $@
 git_diff=$(git diff --name-only origin/dev...)
 declare -i full_count=$(echo $git_diff | wc -w)
 declare -a unallowed_strings=(".cpp\b" ".hpp\b" ".c\b" ".sh\b" )

--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -1,5 +1,5 @@
 
-#!/bin/bash 
+#!/usr/bin/env bash
 git_diff=$(git diff --name-only origin/$@...)
 declare -i full_count=$(echo $git_diff | wc -w)
 declare -a unallowed_strings=(".cpp\b" ".hpp\b" ".c\b" ".sh\b" )

--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -12,7 +12,7 @@ do
   fi
 done
 
-declare -a file_check=("\w+.md" "INSTALL" "CITATION.cff" "Doxyfile." "\bdoc/")
+declare -a file_check=("\w+.md" "INSTALL" "CITATION.cff" "Doxyfile." "\bdoc/" "\b.vscode/" "\bdoxytmp/" "\bscaling/" "\bvisit_variables/")
 declare -i allowed_count=0
 
 #checking if only allowed files are changed. 

--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -1,6 +1,7 @@
 
 #!/bin/bash 
 git_diff=$(git diff --name-only origin/$@...)
+echo $git_diff
 declare -i full_count=$(echo $git_diff | wc -w)
 declare -a unallowed_strings=(".cpp\b" ".hpp\b" ".c\b" ".sh\b" )
 for unallowed_string in ${unallowed_strings[@]}

--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -19,6 +19,6 @@ do
   allowed_count=$(( $allowed_count + $diff ))
 done
 if [[ $allowed_count == $full_count ]]; then
-  echo "run_test"
+  echo "no_test"
 fi
 

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -24,6 +24,8 @@ jobs:
         id: gitdiff
         run: |
           cd $GITHUB_WORKSPACE
+          echo $PWD
+          ls -lh
           chmod +x ./.github/workflows/CI_git_diff.sh
           if [[ $(./.github/workflows/CI_git_diff.sh) = "run_test" ]]; then
             echo "RUN_TP=True" >> $GITHUB_OUTPUT

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Get git diff 
         id: gitdiff
         run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get git diff 
         id: gitdiff
         run: |
-          if [[ $(./.github/CI_git_diff.sh) = "run_test" ]]; then
+          if [[ $(./.github/workflows/CI_git_diff.sh) = "run_test" ]]; then
             echo "RUN_TP=True" >> $GITHUB_OUTPUT
           fi
   get_git_diff_check:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -30,16 +30,16 @@ jobs:
           cd $GITHUB_WORKSPACE
           #chmod +x ./.github/workflows/CI_git_diff.sh
           if [[ $(./.github/workflows/CI_git_diff.sh) = "run_test" ]]; then
-            echo "RUN_TP=True" >> $GITHUB_OUTPUT
+            echo "RUN_TP=False" >> $GITHUB_OUTPUT
           fi
   get_git_diff_check:
     runs-on: ubuntu-latest
     needs: get_git_diff
-    if: ${{ needs.get_git_diff.outputs.RUN_TP != 'True' }}
+    if: ${{ needs.get_git_diff.outputs.RUN_TP != 'False' }}
     steps:
       - name: Checking whether to run tests
         run: |
-          echo "Running tests"
+          echo "Running testpackage test runs"
 
 
   build_libraries:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -35,7 +35,7 @@ jobs:
   get_git_diff_check:
     runs-on: ubuntu-latest
     needs: get_git_diff
-    if: ${{ needs.get_git_diff.outputs.RUN_TP == 'True' }}
+    if: ${{ needs.get_git_diff.outputs.RUN_TP != 'True' }}
     steps:
       - name: Checking whether to run tests
         run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Get git diff 
         id: gitdiff
         run: |
+          cd $GITHUB_WORKSPACE
           if [[ $(./.github/workflows/CI_git_diff.sh) = "run_test" ]]; then
             echo "RUN_TP=True" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -14,6 +14,28 @@ concurrency:
    cancel-in-progress: true
 
 jobs:
+ 
+  get_git_diff:
+    runs-on: ubuntu-latest
+    outputs:
+       RUN_TP: ${{ steps.gitdiff.outputs.RUN_TP }}
+    steps:
+      - name: Get git diff 
+        id: gitdiff
+        run: |
+          if [[ $(./.github/CI_git_diff.sh) = "run_test" ]]; then
+            echo "RUN_TP=True" >> $GITHUB_OUTPUT
+          fi
+  get_git_diff_check:
+    runs-on: ubuntu-latest
+    needs: get_git_diff
+    if: ${{ needs.get_git_diff.outputs.RUN_TP == 'True' }}
+    steps:
+      - name: Checking whether to run tests
+        run: |
+          echo "Running tests"
+
+
   build_libraries:
     # Build libraries for the current version of the docker image
     # (to be used in any subsequent compilation and run jobs on said image)
@@ -691,7 +713,7 @@ jobs:
   run_TP:
     # Run the testpackage on the carrington cluster
     runs-on: carrington
-    needs: [build_TP, build_tools]
+    needs: [build_TP, build_tools, get_git_diff_check]
     continue-on-error: true
 
     steps:
@@ -762,7 +784,7 @@ jobs:
   run_TP_HILE-C:
     # Run the testpackage on the HILE-C cluster
     runs-on: hile
-    needs: [build_TP_HILE-C, build_tools_HILE-C]
+    needs: [build_TP_HILE-C, build_tools_HILE-C, get_git_diff_check]
     continue-on-error: true
 
     steps:
@@ -932,7 +954,7 @@ jobs:
   run_ionosphere_LFMtest:
     runs-on: ubuntu-latest
     container: ursg/vlasiator_ci:20250909_1
-    needs: build_ionosphereTests
+    needs: [build_ionosphereTests, get_git_diff_check]
     steps:
     - name: Checkout source
       uses: actions/checkout@v4

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -24,6 +24,7 @@ jobs:
         id: gitdiff
         run: |
           cd $GITHUB_WORKSPACE
+          chmod +x ./.github/workflows/CI_git_diff.sh
           if [[ $(./.github/workflows/CI_git_diff.sh) = "run_test" ]]; then
             echo "RUN_TP=True" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -20,13 +20,13 @@ jobs:
     outputs:
        RUN_TP: ${{ steps.gitdiff.outputs.RUN_TP }}
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
       - name: Get git diff 
         id: gitdiff
         run: |
           cd $GITHUB_WORKSPACE
-          echo $PWD
-          ls -lh
-          chmod +x ./.github/workflows/CI_git_diff.sh
+          #chmod +x ./.github/workflows/CI_git_diff.sh
           if [[ $(./.github/workflows/CI_git_diff.sh) = "run_test" ]]; then
             echo "RUN_TP=True" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Checking whether to run tests
         run: |
-          echo "Running testpackage test runs"
+          echo "Running testpackage"
 
 
   build_libraries:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -30,7 +30,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           #chmod +x ./.github/workflows/CI_git_diff.sh
           echo Comparing PR branch against ${{ github.base_ref }}
-          if [[ $(./.github/workflows/CI_git_diff.sh ${{ github.base_ref }} ) = "run_test" ]]; then
+          if [[ $(./.github/workflows/CI_git_diff.sh ${{ github.base_ref }} ) = "no_test" ]]; then
             echo "RUN_TP=False" >> $GITHUB_OUTPUT
           fi
   get_git_diff_check:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           #chmod +x ./.github/workflows/CI_git_diff.sh
-          if [[ $(./.github/workflows/CI_git_diff.sh) = "run_test" ]]; then
+          if [[ $(./.github/workflows/CI_git_diff.sh ${{ github.ref }} ) = "run_test" ]]; then
             echo "RUN_TP=False" >> $GITHUB_OUTPUT
           fi
   get_git_diff_check:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           #chmod +x ./.github/workflows/CI_git_diff.sh
-          if [[ $(./.github/workflows/CI_git_diff.sh ${{ github.ref }} ) = "run_test" ]]; then
+          if [[ $(./.github/workflows/CI_git_diff.sh ${{ github.base.ref }} ) = "run_test" ]]; then
             echo "RUN_TP=False" >> $GITHUB_OUTPUT
           fi
   get_git_diff_check:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -29,9 +29,8 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           #chmod +x ./.github/workflows/CI_git_diff.sh
-          echo ${{ github.base }} ${{ github.head_ref }} ${{ github.head }}
-          echo ${{ github.base_ref }} ${{ github.ref }} ${{ github.base.ref}} 
-          if [[ $(./.github/workflows/CI_git_diff.sh ${{ github.base.ref }} ) = "run_test" ]]; then
+          ./.github/workflows/CI_git_diff.sh ${{ github.base_ref }}
+          if [[ $(./.github/workflows/CI_git_diff.sh ${{ github.base_ref }} ) = "run_test" ]]; then
             echo "RUN_TP=False" >> $GITHUB_OUTPUT
           fi
   get_git_diff_check:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           #chmod +x ./.github/workflows/CI_git_diff.sh
+          echo ${{ github.base }} ${{ github.head_ref }} ${{ github.head }}
+          echo ${{ github.base_ref }} ${{ github.ref }} ${{ github.base.ref}} 
           if [[ $(./.github/workflows/CI_git_diff.sh ${{ github.base.ref }} ) = "run_test" ]]; then
             echo "RUN_TP=False" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -32,7 +32,10 @@ jobs:
           echo Comparing PR branch against ${{ github.base_ref }}
           if [[ $(./.github/workflows/CI_git_diff.sh ${{ github.base_ref }} ) = "no_test" ]]; then
             echo "RUN_TP=False" >> $GITHUB_OUTPUT
+            echo "Not running testpackage"
+            exit 0
           fi
+          echo "Running testpackage"
   get_git_diff_check:
     runs-on: ubuntu-latest
     needs: get_git_diff

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           #chmod +x ./.github/workflows/CI_git_diff.sh
-          ./.github/workflows/CI_git_diff.sh ${{ github.base_ref }}
+          echo Comparing PR branch against ${{ github.base_ref }}
           if [[ $(./.github/workflows/CI_git_diff.sh ${{ github.base_ref }} ) = "run_test" ]]; then
             echo "RUN_TP=False" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
The workflow will now skip the testpackage runs if only documentation has changed.

This adds two new steps for the workflow: `get_git_diff` and `get_git_diff_check`. During first one the new script `CI_git_diff.sh` is run to get the git diff between the PR branch and its target.  The script uses grep with regex to check whether only documentation files have changed. If it is so, then running of the testpackage is skipped. 

`get_git_diff_check` acts merely as an if statement that checks if the `get_git_diff` tells to run the tests. 



