### PR TITLE
Split refinement transfers

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -482,7 +482,7 @@ void setFaceNeighborRanks( dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
 }
 
 // TODO bool here is kinda stupid but less janky than function pointer
-void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, std::vector<CellID> incoming_cells_list, std::vector<CellID> outgoing_cells_list, bool refinement = false)
+void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, std::vector<CellID>& incoming_cells_list, std::vector<CellID>& outgoing_cells_list, bool refinement = false)
 {
    phiprof::Timer transfersTimer {"Data transfers"};
    const vector<CellID>& cells = getLocalCells();
@@ -539,8 +539,7 @@ void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
 
    for (uint64_t transfer_part=0; transfer_part<num_part_transfers; transfer_part++) {
       //Set transfers on/off for the incoming cells in this transfer set and prepare for receive
-      for (unsigned int i=0;i<incoming_cells_list.size();i++){
-         CellID cell_id=incoming_cells_list[i];
+      for (const CellID& cell_id : incoming_cells_list) {
          SpatialCell* cell = mpiGrid[cell_id];
          if (cell_id%num_part_transfers!=transfer_part) {
             cell->set_mpi_transfer_enabled(false);
@@ -550,8 +549,7 @@ void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
       }
 
       //Set transfers on/off for the outgoing cells in this transfer set
-      for (unsigned int i=0; i<outgoing_cells_list.size(); i++) {
-         CellID cell_id=outgoing_cells_list[i];
+      for (const CellID cell_id : outgoing_cells_list) {
          SpatialCell* cell = mpiGrid[cell_id];
          if (cell_id%num_part_transfers!=transfer_part) {
             cell->set_mpi_transfer_enabled(false);
@@ -588,8 +586,7 @@ void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
          int prepareReceives {phiprof::initializeTimer("Preparing receives")};
          int receives = 0;
          #pragma omp parallel for schedule(guided)
-         for (unsigned int i=0; i<incoming_cells_list.size(); i++) {
-            CellID cell_id=incoming_cells_list[i];
+         for (const CellID cell_id : incoming_cells_list) {
             SpatialCell* cell = mpiGrid[cell_id];
             if (cell_id % num_part_transfers == transfer_part) {
                receives++;
@@ -617,21 +614,25 @@ void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
          transferTimer.stop();
 
          // Free memory for cells that have been sent (the block data)
-         for (unsigned int i=0;i<outgoing_cells_list.size();i++){
-            CellID cell_id=outgoing_cells_list[i];
+         for (const CellID cell_id : outgoing_cells_list){
             SpatialCell* cell = mpiGrid[cell_id];
 
             // Free memory of this cell as it has already been transferred,
             // it will not be used anymore. NOTE: Only clears memory allocated
             // to the active population.
-            if (cell_id % num_part_transfers == transfer_part) cell->clear(popID,true);
+            if (cell_id % num_part_transfers == transfer_part) {
+               cell->clear(popID,true);
+            }
          }
 
          memory_purge(); // Purge jemalloc allocator to actually release memory
       } // for-loop over populations
    } // for-loop over transfer parts
-   transfersTimer.stop();
 
+   // Re-enable transfer for received cells
+   for (const CellID cell_id : incoming_cells_list) {
+      mpiGrid[cell_id]->set_mpi_transfer_enabled(true);
+   }
 }
 
 void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, SysBoundary& sysBoundaries, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, bool doTranslationLists){
@@ -674,6 +675,7 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
    mpiGrid.finish_balance_load();
    finishLBTimer.stop();
 
+   // TODO might not be required with transferInParts changes
    //Make sure transfers are enabled for all cells
    recalculateLocalCellsCache(mpiGrid);
    #pragma omp parallel for

--- a/grid.cpp
+++ b/grid.cpp
@@ -1384,7 +1384,7 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
       }
    }
 
-   transferInParts(mpiGrid, incoming_cells_list, outgoing_cells_list);
+   transferInParts(mpiGrid, incoming_cells_list, outgoing_cells_list, true);
 
    phiprof::Timer copyChildrenTimer {"copy to children"};
    for (CellID id : newChildren) {

--- a/grid.cpp
+++ b/grid.cpp
@@ -1369,48 +1369,22 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
    auto newChildren = mpiGrid.execute_refines();
    executeTimer.stop();
 
-   std::vector<CellID> receives;
+   // TODO surely this doesn't need a for loop
+   std::vector<CellID> incoming_cells_list;
    for (auto const& [key, val] : mpiGrid.get_cells_to_receive()) {
       for (auto i : val) {
-         receives.push_back(i.first);
+         incoming_cells_list.push_back(i.first);
       }
    }
 
-   phiprof::Timer transfersTimer {"transfers"};
-   for (size_t popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
-      // Set active population
-      SpatialCell::setCommunicatedSpecies(popID);
-
-      //Transfer velocity block list
-      SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_LIST_STAGE1);
-      mpiGrid.continue_refining();
-      SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_LIST_STAGE2);
-      mpiGrid.continue_refining();
-
-      int prepareReceives {phiprof::initializeTimer("Preparing receives")};
-      for (CellID id : receives) {
-         // reserve space for velocity block data in arriving remote cells
-         phiprof::Timer timer {prepareReceives};
-         mpiGrid[id]->prepare_to_receive_blocks(popID);
-         timer.stop(1, "Spatial cells");
+   std::vector<CellID> outgoing_cells_list;
+   for (auto const& [key, val] : mpiGrid.get_cells_to_send()) {
+      for (auto i : val) {
+         outgoing_cells_list.push_back(i.first);
       }
-
-      if(receives.empty()) {
-         //empty phiprof timer, to avoid unneccessary divergence in unique
-         //profiles (keep order same)
-         phiprof::Timer timer {prepareReceives};
-         timer.stop(0, "Spatial cells");
-      }
-
-      //do the actual transfer of data for the set of cells to be transferred
-      phiprof::Timer transferTimer {"transfer_all_data"};
-      SpatialCell::set_mpi_transfer_type(Transfer::ALL_DATA);
-      mpiGrid.continue_refining();
-      transferTimer.stop();
-
-      memory_purge(); // Purge jemalloc allocator to actually release memory
    }
-   transfersTimer.stop();
+
+   transferInParts(mpiGrid, incoming_cells_list, outgoing_cells_list);
 
    phiprof::Timer copyChildrenTimer {"copy to children"};
    for (CellID id : newChildren) {

--- a/grid.cpp
+++ b/grid.cpp
@@ -481,40 +481,11 @@ void setFaceNeighborRanks( dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
    }
 }
 
-void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, SysBoundary& sysBoundaries, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, bool doTranslationLists){
-   // Invalidate cached cell lists
-   Parameters::meshRepartitioned = true;
-
-   // tell other processes which velocity blocks exist in remote spatial cells
-   phiprof::Timer balanceLoadTimer {"Balancing load", {"Load balance"}};
-
-   phiprof::Timer deallocTimer {"deallocate boundary data"};
-   //deallocate blocks in remote cells to decrease memory load
-   deallocateRemoteCellBlocks(mpiGrid);
-   deallocTimer.stop();
-
-   //set weights based on each cells LB weight counter
-   const vector<CellID>& cells = getLocalCells();
-   for (size_t i=0; i<cells.size(); ++i){
-      // Set cell weight. We could use different counters or number of blocks if different solvers are active.
-      // if (P::propagateVlasovAcceleration)
-      // When using the FS-SPLIT functionality, Jaro Hokkanen reported issues with using the regular
-      // CellParams::LBWEIGHTCOUNTER, so use of blockscounts + 1 might be required.
-      mpiGrid.set_cell_weight(cells[i], (Real)1 + mpiGrid[cells[i]]->parameters[CellParams::LBWEIGHTCOUNTER]);
-   }
-
-   phiprof::Timer initLBTimer {"dccrg.initialize_balance_load"};
-   mpiGrid.initialize_balance_load(true);
-   initLBTimer.stop();
-
-   const std::unordered_set<CellID>& incoming_cells = mpiGrid.get_cells_added_by_balance_load();
-   std::vector<CellID> incoming_cells_list (incoming_cells.begin(),incoming_cells.end());
-
-   const std::unordered_set<CellID>& outgoing_cells = mpiGrid.get_cells_removed_by_balance_load();
-   std::vector<CellID> outgoing_cells_list (outgoing_cells.begin(),outgoing_cells.end());
-
-   /*transfer cells in parts to preserve memory*/
+// TODO bool here is kinda stupid but less janky than function pointer
+void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, std::vector<CellID> incoming_cells_list, std::vector<CellID> outgoing_cells_list, bool refinement = false)
+{
    phiprof::Timer transfersTimer {"Data transfers"};
+   const vector<CellID>& cells = getLocalCells();
 
    // Idea: do as many cell sending passes hereafter so that there's not more than transfer_block_fraction_limit
    // blocks of this task's total block count that gets sent. Helps in reducing memory peaks during load balancing.
@@ -596,12 +567,20 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
          // Transfer velocity block lists. On-device GPU mesh preparation tasks require
          // device synchronization between transfer phases.
          SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_LIST_STAGE1);
-         mpiGrid.continue_balance_load();
+         if (!refinement) {
+            mpiGrid.continue_balance_load();
+         } else {
+            mpiGrid.continue_refining();
+         }
          #ifdef USE_GPU
          CHK_ERR( gpuDeviceSynchronize() );
          #endif
          SpatialCell::set_mpi_transfer_type(Transfer::VEL_BLOCK_LIST_STAGE2);
-         mpiGrid.continue_balance_load();
+         if (!refinement) {
+            mpiGrid.continue_balance_load();
+         } else {
+            mpiGrid.continue_refining();
+         }
          #ifdef USE_GPU
          CHK_ERR( gpuDeviceSynchronize() );
          #endif
@@ -630,7 +609,11 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
          //do the actual transfer of data for the set of cells to be transferred
          phiprof::Timer transferTimer {"transfer_all_data"};
          SpatialCell::set_mpi_transfer_type(Transfer::ALL_DATA);
-         mpiGrid.continue_balance_load();
+         if (!refinement) {
+            mpiGrid.continue_balance_load();
+         } else {
+            mpiGrid.continue_refining();
+         }
          transferTimer.stop();
 
          // Free memory for cells that have been sent (the block data)
@@ -648,6 +631,43 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
       } // for-loop over populations
    } // for-loop over transfer parts
    transfersTimer.stop();
+
+}
+
+void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, SysBoundary& sysBoundaries, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, bool doTranslationLists){
+   // Invalidate cached cell lists
+   Parameters::meshRepartitioned = true;
+
+   // tell other processes which velocity blocks exist in remote spatial cells
+   phiprof::Timer balanceLoadTimer {"Balancing load", {"Load balance"}};
+
+   phiprof::Timer deallocTimer {"deallocate boundary data"};
+   //deallocate blocks in remote cells to decrease memory load
+   deallocateRemoteCellBlocks(mpiGrid);
+   deallocTimer.stop();
+
+   //set weights based on each cells LB weight counter
+   const vector<CellID>& cells = getLocalCells();
+   for (size_t i=0; i<cells.size(); ++i){
+      // Set cell weight. We could use different counters or number of blocks if different solvers are active.
+      // if (P::propagateVlasovAcceleration)
+      // When using the FS-SPLIT functionality, Jaro Hokkanen reported issues with using the regular
+      // CellParams::LBWEIGHTCOUNTER, so use of blockscounts + 1 might be required.
+      mpiGrid.set_cell_weight(cells[i], (Real)1 + mpiGrid[cells[i]]->parameters[CellParams::LBWEIGHTCOUNTER]);
+   }
+
+   phiprof::Timer initLBTimer {"dccrg.initialize_balance_load"};
+   mpiGrid.initialize_balance_load(true);
+   initLBTimer.stop();
+
+   const std::unordered_set<CellID>& incoming_cells = mpiGrid.get_cells_added_by_balance_load();
+   std::vector<CellID> incoming_cells_list (incoming_cells.begin(),incoming_cells.end());
+
+   const std::unordered_set<CellID>& outgoing_cells = mpiGrid.get_cells_removed_by_balance_load();
+   std::vector<CellID> outgoing_cells_list (outgoing_cells.begin(),outgoing_cells.end());
+
+   /*transfer cells in parts to preserve memory*/
+   transferInParts(mpiGrid, incoming_cells_list, outgoing_cells_list);
 
    //finish up load balancing
    phiprof::Timer finishLBTimer {"dccrg.finish_balance_load"};

--- a/grid.cpp
+++ b/grid.cpp
@@ -481,6 +481,12 @@ void setFaceNeighborRanks( dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
    }
 }
 
+inline int get_transfer_part(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, uint64_t num_part_transfers, CellID cell)
+{
+   // Siblings transfer in same part
+   return (mpiGrid.mapping.get_refinement_level(cell) ? mpiGrid.mapping.get_parent(cell) : cell) % num_part_transfers;
+}
+
 // TODO bool here is kinda stupid but less janky than function pointer
 void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, std::vector<CellID>& incoming_cells_list, std::vector<CellID>& outgoing_cells_list, bool refinement = false)
 {
@@ -517,7 +523,7 @@ void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
          uint64_t transfer_part_block_count=0;
          for (unsigned int i=0;i<outgoing_cells_list.size();i++){
             CellID cell_id=outgoing_cells_list[i];
-            if (cell_id%num_part_transfers_local==transfer_part) {
+            if (get_transfer_part(mpiGrid, num_part_transfers_local, cell_id) == transfer_part) {
                transfer_part_block_count += mpiGrid[cell_id]->get_number_of_all_velocity_blocks();
             }
          }
@@ -541,7 +547,7 @@ void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
       //Set transfers on/off for the incoming cells in this transfer set and prepare for receive
       for (const CellID& cell_id : incoming_cells_list) {
          SpatialCell* cell = mpiGrid[cell_id];
-         if (cell_id%num_part_transfers!=transfer_part) {
+         if (get_transfer_part(mpiGrid, num_part_transfers, cell_id) != transfer_part) {
             cell->set_mpi_transfer_enabled(false);
          } else {
             cell->set_mpi_transfer_enabled(true);
@@ -551,7 +557,7 @@ void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
       //Set transfers on/off for the outgoing cells in this transfer set
       for (const CellID cell_id : outgoing_cells_list) {
          SpatialCell* cell = mpiGrid[cell_id];
-         if (cell_id%num_part_transfers!=transfer_part) {
+         if (get_transfer_part(mpiGrid, num_part_transfers, cell_id) != transfer_part) {
             cell->set_mpi_transfer_enabled(false);
          } else {
             cell->set_mpi_transfer_enabled(true);
@@ -588,7 +594,7 @@ void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
          #pragma omp parallel for schedule(guided)
          for (const CellID cell_id : incoming_cells_list) {
             SpatialCell* cell = mpiGrid[cell_id];
-            if (cell_id % num_part_transfers == transfer_part) {
+            if (get_transfer_part(mpiGrid, num_part_transfers, cell_id) == transfer_part) {
                receives++;
                // reserve space for velocity block data in arriving remote cells
                phiprof::Timer timer {prepareReceives};
@@ -620,9 +626,39 @@ void transferInParts(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
             // Free memory of this cell as it has already been transferred,
             // it will not be used anymore. NOTE: Only clears memory allocated
             // to the active population.
-            if (cell_id % num_part_transfers == transfer_part) {
+            if (get_transfer_part(mpiGrid, num_part_transfers, cell_id) == transfer_part) {
                cell->clear(popID,true);
             }
+         }
+
+         if (refinement) {
+            // Old cells removed by refinement
+            phiprof::Timer copyParentsTimer {"copy to parents"};
+            std::set<CellID> processed;
+            for (CellID id : mpiGrid.get_removed_cells()) {
+               if (get_transfer_part(mpiGrid, num_part_transfers, id) == transfer_part) {
+                  CellID parent = mpiGrid.get_existing_cell(mpiGrid.get_center(id));
+                  if (!processed.count(parent)) {
+                     std::vector<CellID> children = mpiGrid.get_all_children(parent);
+                     // Make sure cell contents aren't garbage
+                     *mpiGrid[parent] = *mpiGrid[id];
+
+                     for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
+                        SBC::averageCellData(mpiGrid, children, mpiGrid[parent], popID, 1);
+                     }
+
+                     // Averaging moments
+                     calculateCellMoments(mpiGrid[parent], true, false);
+
+                     processed.insert(parent);
+
+                     for (const CellID child : children) {
+                        mpiGrid[child]->clear(popID, true);
+                     }
+                  }
+               }
+            }
+            copyParentsTimer.stop(processed.size(), "Spatial cells");
          }
 
          memory_purge(); // Purge jemalloc allocator to actually release memory
@@ -1407,28 +1443,6 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
       #endif
    }
    copyChildrenTimer.stop(newChildren.size(), "Spatial cells");
-
-   // Old cells removed by refinement
-   phiprof::Timer copyParentsTimer {"copy to parents"};
-   std::set<CellID> processed;
-   for (CellID id : mpiGrid.get_removed_cells()) {
-      CellID parent = mpiGrid.get_existing_cell(mpiGrid.get_center(id));
-      if (!processed.count(parent)) {
-         std::vector<CellID> children = mpiGrid.get_all_children(parent);
-         // Make sure cell contents aren't garbage
-         *mpiGrid[parent] = *mpiGrid[id];
-
-         for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
-            SBC::averageCellData(mpiGrid, children, mpiGrid[parent], popID, 1);
-         }
-
-         // Averaging moments
-         calculateCellMoments(mpiGrid[parent], true, false);
-
-         processed.insert(parent);
-      }
-   }
-   copyParentsTimer.stop(processed.size(), "Spatial cells");
 
    phiprof::Timer finishTimer {"finish refining"};
    mpiGrid.finish_refining();

--- a/grid.cpp
+++ b/grid.cpp
@@ -1339,7 +1339,8 @@ void mapRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    timer.stop();
 }
 
-bool initializeRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, SysBoundary& sysBoundaries, Project& project, int useStatic) {
+bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, SysBoundary& sysBoundaries, Project& project, int useStatic) {
+   phiprof::Timer amrTimer {"Re-refine spatial cells"};
    uint64_t refines {0};
    if (useStatic > -1) {
       project.forceRefinement(mpiGrid, useStatic);
@@ -1397,12 +1398,7 @@ bool initializeRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& m
    MPI_Allreduce(&(globalflags::bailingOut), &bailout, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
    bailoutAllreduceTimer.stop();
 
-   return !bailout;
-}
-
-bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, SysBoundary& sysBoundaries, Project& project, int useStatic) {
-   phiprof::Timer amrTimer {"Re-refine spatial cells"};
-   if (!initializeRefinement(mpiGrid, technicalGrid, sysBoundaries, project, useStatic)) {
+   if (bailout) {
       return false;
    }
 
@@ -1447,6 +1443,7 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
    phiprof::Timer finishTimer {"finish refining"};
    mpiGrid.finish_refining();
    finishTimer.stop();
+   dccrgTimer.stop();
 
    memory_purge(); // Purge jemalloc allocator to actually release memory
 

--- a/grid.cpp
+++ b/grid.cpp
@@ -481,7 +481,7 @@ void setFaceNeighborRanks( dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
    }
 }
 
-inline int get_transfer_part(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, uint64_t num_part_transfers, CellID cell)
+inline uint64_t get_transfer_part(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, uint64_t num_part_transfers, CellID cell)
 {
    // Siblings transfer in same part
    return (mpiGrid.mapping.get_refinement_level(cell) ? mpiGrid.mapping.get_parent(cell) : cell) % num_part_transfers;

--- a/grid.cpp
+++ b/grid.cpp
@@ -1303,8 +1303,7 @@ void mapRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    timer.stop();
 }
 
-bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, SysBoundary& sysBoundaries, Project& project, int useStatic) {
-   phiprof::Timer amrTimer {"Re-refine spatial cells"};
+bool initializeRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, SysBoundary& sysBoundaries, Project& project, int useStatic) {
    uint64_t refines {0};
    if (useStatic > -1) {
       project.forceRefinement(mpiGrid, useStatic);
@@ -1362,7 +1361,12 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
    MPI_Allreduce(&(globalflags::bailingOut), &bailout, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
    bailoutAllreduceTimer.stop();
 
-   if (bailout) {
+   return !bailout;
+}
+
+bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, SysBoundary& sysBoundaries, Project& project, int useStatic) {
+   phiprof::Timer amrTimer {"Re-refine spatial cells"};
+   if (!initializeRefinement(mpiGrid, technicalGrid, sysBoundaries, project, useStatic)) {
       return false;
    }
 
@@ -1429,7 +1433,6 @@ bool adaptRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGri
    phiprof::Timer finishTimer {"finish refining"};
    mpiGrid.finish_refining();
    finishTimer.stop();
-   dccrgTimer.stop();
 
    memory_purge(); // Purge jemalloc allocator to actually release memory
 

--- a/grid.h
+++ b/grid.h
@@ -114,8 +114,6 @@ void setFaceNeighborRanks( dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
  */
 void mapRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid);
 
-bool initializeRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, SysBoundary& sysBoundaries, Project& project, int useStatic = -1);
-
 /*! Refine spatial cells and update necessary information
  * \param mpiGrid Spatial grid
  * \param technicalGrid Technical grid

--- a/grid.h
+++ b/grid.h
@@ -114,6 +114,8 @@ void setFaceNeighborRanks( dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
  */
 void mapRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid);
 
+bool initializeRefinement(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, FsGrid<fsgrids::technical, FS_STENCIL_WIDTH> & technicalGrid, SysBoundary& sysBoundaries, Project& project, int useStatic = -1);
+
 /*! Refine spatial cells and update necessary information
  * \param mpiGrid Spatial grid
  * \param technicalGrid Technical grid

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -1110,11 +1110,7 @@ int simulate(int argn,char* args[]) {
          if (refineNow || (!dtIsChanged && P::adaptRefinement && P::tstep % (P::rebalanceInterval * P::refineCadence) == 0 && P::t > P::refineAfter)) { 
             logFile << "(AMR): Adapting refinement!"  << endl << writeVerbose;
             refineNow = false;
-
-            initializeRefinement(mpiGrid, technicalGrid, sysBoundaryContainer, *project);
-
-            // Check dummied out since we never seem to hit it
-            if (true) {
+            if (!adaptRefinement(mpiGrid, technicalGrid, sysBoundaryContainer, *project)) {
                // OOM, rebalance and try again
                logFile << "(LB) AMR rebalancing with heavier refinement weights." << endl;
                globalflags::bailingOut = false; // Reset this
@@ -1124,11 +1120,9 @@ int simulate(int argn,char* args[]) {
                balanceLoad(mpiGrid, sysBoundaryContainer, technicalGrid);
                // We can /= 8.0 now as cells have potentially migrated. Go back to block-based count for now.
                for (auto id : mpiGrid.get_local_cells_to_refine()) {
-                  SpatialCell* cell = mpiGrid[id];
-                  cell->parameters[CellParams::LBWEIGHTCOUNTER] = 0;
+                  mpiGrid[id]->parameters[CellParams::LBWEIGHTCOUNTER] = 0;
                   for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
-                     // TODO define weighting of non/sysboundary cells in one place and replace this stupid ternary
-                     cell->parameters[CellParams::LBWEIGHTCOUNTER] += (cell->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ? 3.0 : 0.5) * mpiGrid[id]->get_number_of_velocity_blocks(popID);
+                     mpiGrid[id]->parameters[CellParams::LBWEIGHTCOUNTER] += mpiGrid[id]->get_number_of_velocity_blocks(popID);
                   }
                }
 

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -1110,7 +1110,11 @@ int simulate(int argn,char* args[]) {
          if (refineNow || (!dtIsChanged && P::adaptRefinement && P::tstep % (P::rebalanceInterval * P::refineCadence) == 0 && P::t > P::refineAfter)) { 
             logFile << "(AMR): Adapting refinement!"  << endl << writeVerbose;
             refineNow = false;
-            if (!adaptRefinement(mpiGrid, technicalGrid, sysBoundaryContainer, *project)) {
+
+            initializeRefinement(mpiGrid, technicalGrid, sysBoundaryContainer, *project);
+
+            // Check dummied out since we never seem to hit it
+            if (true) {
                // OOM, rebalance and try again
                logFile << "(LB) AMR rebalancing with heavier refinement weights." << endl;
                globalflags::bailingOut = false; // Reset this
@@ -1120,9 +1124,11 @@ int simulate(int argn,char* args[]) {
                balanceLoad(mpiGrid, sysBoundaryContainer, technicalGrid);
                // We can /= 8.0 now as cells have potentially migrated. Go back to block-based count for now.
                for (auto id : mpiGrid.get_local_cells_to_refine()) {
-                  mpiGrid[id]->parameters[CellParams::LBWEIGHTCOUNTER] = 0;
+                  SpatialCell* cell = mpiGrid[id];
+                  cell->parameters[CellParams::LBWEIGHTCOUNTER] = 0;
                   for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
-                     mpiGrid[id]->parameters[CellParams::LBWEIGHTCOUNTER] += mpiGrid[id]->get_number_of_velocity_blocks(popID);
+                     // TODO define weighting of non/sysboundary cells in one place and replace this stupid ternary
+                     cell->parameters[CellParams::LBWEIGHTCOUNTER] += (cell->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ? 3.0 : 0.5) * mpiGrid[id]->get_number_of_velocity_blocks(popID);
                   }
                }
 


### PR DESCRIPTION
Attempt to split transfers when refining. This reduces the memory overhead of coarsening specifically.