### PR TITLE
Robuster git tag finding and version sorting for main release tags

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -60,7 +60,7 @@ jobs:
           
           git checkout dev
           PREV_TAG=$(git describe --tags --abbrev=0)||echo Error in git-describe
-          PREV_TAG_FIRST=$(git describe --tags --abbrev=0 --first-parent)||echo Error in git-describe
+          PREV_TAG_FIRST=$(git tag --list 'v*.*' --sort=-v:refname | head -n1)||echo Error in git-describe
           if [[ -z "$PREV_TAG_FIRST" ]]; then
             PREV_TAG_FIRST=unknown
             HIST=


### PR DESCRIPTION
Find preceding version tag for doxygen instead of using janky `--first-parent` things.