### PR TITLE
Schedule CI runs for master weekly...

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -6,6 +6,8 @@ on:
     branches : ["dev","master"]
   pull_request:
     branches: ["dev","master"]
+  schedule:
+    - cron: '0 0 * * TUE'
   # ... or when the workflow is started manually
   workflow_dispatch:
 

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -8,6 +8,7 @@ on:
     branches: ["dev","master"]
   schedule:
     - cron: '0 0 * * TUE'
+      timezone: "Europe/Helsinki"
   # ... or when the workflow is started manually
   workflow_dispatch:
 


### PR DESCRIPTION
... to 1) make use of the Carrington reservation and 2) ensure CI keeps functioning.

Noting that the scheduled jobs _only_ run on the default branch, i.e. `master` for now. Should the default be `dev` instead, even in general?