### PR TITLE
Logparser

### DIFF
--- a/tools/logparser.py
+++ b/tools/logparser.py
@@ -1,0 +1,39 @@
+import re
+import os
+
+logdict = {}
+with open("/home/lassejsc/Downloads/logfile.txt", "r") as logfile:
+    loglines = logfile.readlines()
+    iterator = iter(loglines)
+    n = 0
+    line = iterator.__next__()
+    logdict[-1] = []
+    while n < len(loglines):
+        try:
+            regex = re.search(r"^-{10}\Wtstep\W=\W(\d+).+?-{10}", line)
+            if regex:
+                tstep = regex.group(1)
+
+                logdict[tstep] = [line]
+                line = iterator.__next__()
+                n += 1
+                while not re.search(r"^-{10}\Wtstep\W=\W(\d+).+?-{10}", line):
+                    logdict[tstep].append(line)
+                    # we dont want to do this at last step
+                    try:
+                        line = iterator.__next__()
+                    except StopIteration:
+                        break
+                    n += 1
+            else:
+                logdict[-1].append(line)
+                line = iterator.__next__()
+
+        except StopIteration:
+            break
+    logfile.close()
+
+with open("./test.txt", "w") as fileoutput:
+    for lines in logdict.values():
+        for line in lines:
+            fileoutput.write(line)

--- a/tools/logparser.py
+++ b/tools/logparser.py
@@ -1,8 +1,20 @@
 import re
 import os
+import argparse
+
+
+parser = argparse.ArgumentParser(
+    prog="Logparser",
+    description="For pruning restarts from the logfile such that the latest successful timestep is left in the log",
+)
+parser.add_argument("logfile", type=str)
+parser.add_argument("outputfile", type=str)
+args = parser.parse_args()
+input = args.logfile
+output = args.outputfile
 
 logdict = {}
-with open("/home/lassejsc/Downloads/logfile.txt", "r") as logfile:
+with open(input, "r") as logfile:
     loglines = logfile.readlines()
     iterator = iter(loglines)
     n = 0
@@ -33,7 +45,7 @@ with open("/home/lassejsc/Downloads/logfile.txt", "r") as logfile:
             break
     logfile.close()
 
-with open("./test.txt", "w") as fileoutput:
+with open(output, "w") as fileoutput:
     for lines in logdict.values():
         for line in lines:
             fileoutput.write(line)


### PR DESCRIPTION
Parses vlasiator log files with the lines like `---------- tstep = 69474 t = 853.169 dt = 0.0122804 FS cycles = 3 ----------` and outputs only the latest successful time steps into a new log file such that for example if the run was restarted at say `tstep=100` back to `tstep=50` the log file wont include the time steps 50-100 that happened before the restart.

Usage:
```python logparser.py [INPUT] [OUTPUT]```