### PR TITLE
Update vlasovmover.cpp

### DIFF
--- a/ioread.cpp
+++ b/ioread.cpp
@@ -388,7 +388,10 @@ bool _readBlockData(
    uint64_t byteSize;
    list<pair<string,string> > avgAttribs;
    bool success=true;
-   const string popName = getObjectWrapper().particleSpecies[popID].name;
+   string popName = getObjectWrapper().particleSpecies[popID].name;
+   if (P::activateVamr) {
+     popName += std::to_string(getObjectWrapper().particleSpecies[popID].RefinementLevel);
+   }
    const string tagName = "BLOCKIDS";
 
    avgAttribs.push_back(make_pair("mesh",spatMeshName));
@@ -506,7 +509,10 @@ bool readBlockData(
    uint64_t* offsetArray = new uint64_t[N_processes];
 
    for (uint popID=0; popID<getObjectWrapper().particleSpecies.size(); ++popID) {
-      const string& popName = getObjectWrapper().particleSpecies[popID].name;
+      string popName = getObjectWrapper().particleSpecies[popID].name;
+      if (P::activateVamr) {
+	popName += std::to_string(getObjectWrapper().particleSpecies[popID].RefinementLevel);
+      }
 
       // Create a cellID remapping lambda that can renumber our velocity space, should it's size have changed.
       // By default, this is a no-op that keeps the blockIDs untouched.

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -469,7 +469,7 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
       The last subcycle adjustment is performed in a higher level function, and it
       performs a full neighbour block list update, and is called for all accelerated cells.
    **/
-   if (step < (globalMaxSubcycles - 1)) {
+   if (step > 0 && step < (globalMaxSubcycles - 1)) {
       adjustVelocityBlocks(mpiGrid, acceleratedCells, false, popID);
    }
 }
@@ -558,6 +558,9 @@ void calculateAcceleration(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
             }
             // Accelerate population over one subcycle step
             calculateAcceleration(popID,(uint)globalMaxSubcycles,step,mpiGrid,acceleratedCells,dt);
+            if(step==0 && (uint)globalMaxSubcycles > 1){
+	            adjustVelocityBlocks(mpiGrid, cells, false, popID);
+	         }
          } // for-loop over acceleration substeps
 
          // final adjust for all cells, also updating full remote block lists


### PR DESCRIPTION
The way in which the velocity blocks are adjusted in the acceleration part has been modified to ensure that they are always updated for all cells in the first step. 

Before we were adjusting the velocity blocks only for the cells that need to be accelerated in a more than one step process (i.e. at least 2 subcycles), so that means not all the cells. And when we adjust the cells, the first step is to update its velocity block information. And then we share this information between neighbouring spatial cells. BUT if the neighbour cells are not in the cells that need to do a two step process, it is not updated, and if we have 2 species with different velocity grids, the shared value will be the one of the old species. Meaning that we share false and out of bound information.