### PR TITLE
Fix ionosphere solver abusing openFieldLine instead of ZPARAM

### DIFF
--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -86,6 +86,7 @@ namespace SBC {
    Real Ionosphere::couplingInterval; /*!< Ionosphere update interval */
    int Ionosphere::solveCount; /*!< Counter of the number of solvings */
    Real Ionosphere::backgroundIonisation; /*!< Background ionisation due to stellar UV and cosmic rays */
+   bool Ionosphere::useEigenSolver;
    int  Ionosphere::solverMaxIterations;
    Real Ionosphere::solverRelativeL2ConvergenceThreshold;
    int Ionosphere::solverMaxFailureCount;
@@ -2559,106 +2560,70 @@ namespace SBC {
       }
       initSolver(false);
 
-
-
       nIterations = 0;
-
       nRestarts = 0;
-
       for(uint n=0; n<nodes.size(); n++) {
-
          SphericalTriGrid::Node& N = ionosphereGrid.nodes[n];
-
          if(fabs(N.x[2]) < Ionosphere::innerRadius * sin(Ionosphere::shieldingLatitude * M_PI / 180.0)) {
-
             N.parameters[ionosphereParameters::SOLUTION] = 0;
+         }
+      }
+
+
+      if(Ionosphere::useEigenSolver) {
+         // BiCGSTAB solver from Eigen
+         Eigen::SparseMatrix<Real> potentialSolverMatrix(nodes.size(), nodes.size());
+         Eigen::VectorXd vRightHand(nodes.size()), vPhi(nodes.size());
+         for(uint n=0; n<nodes.size(); n++) {
+
+            for(uint m=0; m<nodes[n].numDepNodes; m++) {
+               potentialSolverMatrix.insert(n, nodes[n].dependingNodes[m]) = nodes[n].dependingCoeffs[m];
+            }
+
+            vRightHand[n] = nodes[n].parameters[ionosphereParameters::SOURCE];
 
          }
 
-      }
-
-
-      Eigen::SparseMatrix<Real> potentialSolverMatrix(nodes.size(), nodes.size());
-
-      Eigen::VectorXd vRightHand(nodes.size()), vPhi(nodes.size());
-
-      for(uint n=0; n<nodes.size(); n++) {
-
-
-
-         for(uint m=0; m<nodes[n].numDepNodes; m++) {
-
-            potentialSolverMatrix.insert(n, nodes[n].dependingNodes[m]) = nodes[n].dependingCoeffs[m];
-
+         // gettimeofday(&tStart, NULL);
+         potentialSolverMatrix.makeCompressed();
+         Eigen::BiCGSTAB<Eigen::SparseMatrix<Real> > solver;
+         solver.compute(potentialSolverMatrix);
+         vPhi = solver.solve(vRightHand);
+         for(uint n=0; n<nodes.size(); n++) {
+            nodes[n].parameters[ionosphereParameters::SOLUTION] = vPhi[n];
          }
 
+         nIterations = solver.iterations();
+         residual = solver.error();
 
-
-         vRightHand[n] = nodes[n].parameters[ionosphereParameters::SOURCE];
-
-      }
-
-      // gettimeofday(&tStart, NULL);
-
-      potentialSolverMatrix.makeCompressed();
-
-      Eigen::BiCGSTAB<Eigen::SparseMatrix<Real> > solver;
-
-      solver.compute(potentialSolverMatrix);
-
-      vPhi = solver.solve(vRightHand);
-
-      for(uint n=0; n<nodes.size(); n++) {
-
-         nodes[n].parameters[ionosphereParameters::SOLUTION] = vPhi[n];
-
-      }
-
-
-
-      nIterations = solver.iterations();
-
-      residual = solver.error();
-
-
-
-      for(uint n=0; n<nodes.size(); n++) {
-
-         Node& N=nodes[n];
-
-         if(N.x[2] >= 0) {
-
-            if(N.parameters.at(ionosphereParameters::SOLUTION) < minPotentialN) {
-
-               minPotentialN = N.parameters.at(ionosphereParameters::SOLUTION);
-
+         for(uint n=0; n<nodes.size(); n++) {
+            Node& N=nodes[n];
+            if(N.x[2] >= 0) {
+               if(N.parameters.at(ionosphereParameters::SOLUTION) < minPotentialN) {
+                  minPotentialN = N.parameters.at(ionosphereParameters::SOLUTION);
+               }
+               if(N.parameters.at(ionosphereParameters::SOLUTION) > maxPotentialN) {
+                  maxPotentialN = N.parameters.at(ionosphereParameters::SOLUTION);
+               }
+            } else {
+               if(N.parameters.at(ionosphereParameters::SOLUTION) < minPotentialS) {
+                  minPotentialS = N.parameters.at(ionosphereParameters::SOLUTION);
+               }
+               if(N.parameters.at(ionosphereParameters::SOLUTION) > maxPotentialS) {
+                  maxPotentialS = N.parameters.at(ionosphereParameters::SOLUTION);
+               }
             }
-
-            if(N.parameters.at(ionosphereParameters::SOLUTION) > maxPotentialN) {
-
-               maxPotentialN = N.parameters.at(ionosphereParameters::SOLUTION);
-
-            }
-
-         } else {
-
-            if(N.parameters.at(ionosphereParameters::SOLUTION) < minPotentialS) {
-
-               minPotentialS = N.parameters.at(ionosphereParameters::SOLUTION);
-
-            }
-
-            if(N.parameters.at(ionosphereParameters::SOLUTION) > maxPotentialS) {
-
-               maxPotentialS = N.parameters.at(ionosphereParameters::SOLUTION);
-
-            }
-
          }
-
+      } else {
+         // Our own BiCG implementation in solveInternal, like in GUMICS' implementation.
+         do {
+            solveInternal(nIterations, nRestarts, residual, minPotentialN, maxPotentialN, minPotentialS, maxPotentialS);
+            if(Ionosphere::solverToggleMinimumResidualVariant) {
+               Ionosphere::solverUseMinimumResidualVariant = !Ionosphere::solverUseMinimumResidualVariant;
+            }
+         } while (residual > Ionosphere::solverRelativeL2ConvergenceThreshold && nIterations < Ionosphere::solverMaxIterations);
       }
-
-     }
+   }
 
    void SphericalTriGrid::solveInternal(
       int & iteration,
@@ -3109,6 +3074,7 @@ namespace SBC {
       Readparameters::add("ionosphere.backgroundIonisation", "Background ionoisation due to cosmic rays (mho)", 0.5);
       Readparameters::add("ionosphere.fixedSigmaP", "Fixed Pedersen conductivity value for the whole shell, if ionizationModel is 'fixedSigma'", 10.);
       Readparameters::add("ionosphere.fixedSigmaH", "Fixed Hall conductivity value for the whole shell, if ionizationModel is 'fixedSigma'", 0.);
+      Readparameters::add("ionosphere.useEigenSolver", "Whether to use Eigen's BiCGSTAB solver over our home-grown BiCG implementation", false);
       Readparameters::add("ionosphere.solverMaxIterations", "Maximum number of iterations for the conjugate gradient solver", 2000);
       Readparameters::add("ionosphere.solverRelativeL2ConvergenceThreshold", "Convergence threshold for the relative L2 metric", 1e-6);
       Readparameters::add("ionosphere.solverMaxFailureCount", "Maximum number of iterations allowed to diverge before restarting the ionosphere solver", 5);
@@ -3178,6 +3144,7 @@ namespace SBC {
       Readparameters::get("ionosphere.ridleyParallelConductivity", ridleyParallelConductivity);
       Readparameters::get("ionosphere.fibonacciNodeNum",fibonacciNodeNum);
       Readparameters::get("ionosphere.gridFilePath",path);
+      Readparameters::get("ionosphere.useEigenSolver", useEigenSolver);
       Readparameters::get("ionosphere.solverMaxIterations", solverMaxIterations);
       Readparameters::get("ionosphere.solverRelativeL2ConvergenceThreshold", solverRelativeL2ConvergenceThreshold);
       Readparameters::get("ionosphere.solverMaxFailureCount", solverMaxFailureCount);

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -367,7 +367,7 @@ namespace SBC {
    }
 
    // Read an arbitrary ionosphere grid, in either Wavefront OBJ
-   // or VTK ASCII format. 
+   // or VTK ASCII format.
    // The file should contain only a single triangle grid (and be otherwise
    // reasonable for use as an ionosphere mesh)
    void SphericalTriGrid::initializeGridFromFile(string pathString) {
@@ -1554,7 +1554,7 @@ namespace SBC {
                            continue;
                         }
 
-                        if(nodes[i].openFieldLine  == FieldTracing::TracingLineEndType::CLOSED) {
+                        if(nodes[i].openFieldLine == FieldTracing::TracingLineEndType::CLOSED) {
                            // Closed nodes can be probed directly
                            Eigen::Vector3d ox(nodes[i].x.data());
                            Real distance = (ox - x).norm();
@@ -2795,7 +2795,7 @@ namespace SBC {
 #endif
          for(uint n=0; n<nodes.size(); n++) {
             Node& N=nodes[n];
-            const iSolverReal incr = N.openFieldLine * N.parameters[ionosphereParameters::RRESIDUAL];
+            const iSolverReal incr = N.parameters[ionosphereParameters::ZPARAM] * N.parameters[ionosphereParameters::RRESIDUAL];
 #ifdef IONOSPHERE_SORTED_SUMS
             if(incr < 0) {
                thread_set_neg.insert(incr);
@@ -2834,7 +2834,7 @@ namespace SBC {
             #pragma omp for
             for(uint n=0; n<nodes.size(); n++) {
                Node& N=nodes[n];
-               N.parameters[ionosphereParameters::PPARAM] = N.openFieldLine;
+               N.parameters[ionosphereParameters::PPARAM] = N.parameters[ionosphereParameters::ZPARAM];
                N.parameters[ionosphereParameters::PPPARAM] = N.parameters[ionosphereParameters::ZZPARAM];
             }
          } else {
@@ -2844,7 +2844,7 @@ namespace SBC {
             for(uint n=0; n<nodes.size(); n++) {
                Node& N=nodes[n];
                N.parameters[ionosphereParameters::PPARAM] *= bk;
-               N.parameters[ionosphereParameters::PPARAM] += N.openFieldLine;
+               N.parameters[ionosphereParameters::PPARAM] += N.parameters[ionosphereParameters::ZPARAM];
                N.parameters[ionosphereParameters::PPPARAM] *= bk;
                N.parameters[ionosphereParameters::PPPARAM] += N.parameters[ionosphereParameters::ZZPARAM];
             }
@@ -2874,7 +2874,7 @@ namespace SBC {
          for(uint n=0; n<nodes.size(); n++) {
             Node& N=nodes[n];
             iSolverReal zparam = Atimes(n, ionosphereParameters::PPARAM, false);
-            N.openFieldLine = zparam;
+            N.parameters[ionosphereParameters::ZPARAM] = zparam;
             iSolverReal incr = zparam * N.parameters[ionosphereParameters::PPPARAM];
 #ifdef IONOSPHERE_SORTED_SUMS
             if(incr < 0) {
@@ -2968,7 +2968,7 @@ namespace SBC {
             Node& N=nodes[n];
             // Calculate residual of the new solution. The faster way to do this would be
             //
-            // iSolverReal newresid = N.parameters[ionosphereParameters::RESIDUAL] - ak * N.openFieldLine;
+            // iSolverReal newresid = N.parameters[ionosphereParameters::RESIDUAL] - ak * N.parameters[ionosphereParameters::ZPARAM]
             // and
             // N.parameters[ionosphereParameters::RRESIDUAL] -= ak * N.parameters[ionosphereParameters::ZZPARAM];
             //
@@ -3008,7 +3008,7 @@ namespace SBC {
          #pragma omp for
          for(uint n=0; n<nodes.size(); n++) {
             Node& N=nodes[n];
-            N.openFieldLine = Asolve(n, ionosphereParameters::RESIDUAL, false);
+            N.parameters[ionosphereParameters::ZPARAM] = Asolve(n, ionosphereParameters::RESIDUAL, false);
          }
 
          // See if this solved the potential better than before

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -2445,7 +2445,7 @@ namespace SBC {
      // Zero out parameters
      if(zeroOut) {
         for(uint n=0; n<nodes.size(); n++) {
-           for(uint p=ionosphereParameters::SOLUTION; p<ionosphereParameters::N_IONOSPHERE_PARAMETERS-1; p++) {
+           for(uint p=ionosphereParameters::SOLUTION; p<ionosphereParameters::N_IONOSPHERE_PARAMETERS; p++) {
               Node& N=nodes[n];
               N.parameters[p] = 0;
            }
@@ -2456,7 +2456,7 @@ namespace SBC {
         for(uint n=0; n<nodes.size(); n++) {
            Node& N=nodes[n];
            potentialSum += N.parameters[ionosphereParameters::SOLUTION];
-           for(uint p=ionosphereParameters::ZPARAM; p<ionosphereParameters::N_IONOSPHERE_PARAMETERS-1; p++) {
+           for(uint p=ionosphereParameters::ZPARAM; p<ionosphereParameters::N_IONOSPHERE_PARAMETERS; p++) {
               N.parameters[p] = 0;
            }
         }

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -1232,9 +1232,6 @@ namespace SBC {
             }
          } else if(ionosphereGrid.ionizationModel == Juusola2025) {
 
-            const static int NODE_CONSTRAINT_REDUCTION = 1;
-            const static int ELEMENT_CONSTRAINT_REDUCTION =1;
-
             // Ionosoheric Sigma calculation functions from
             // Juusola et al. 2025.
             // Coefficients are in ionosphere_tables.h
@@ -1393,7 +1390,6 @@ namespace SBC {
                   int localC=0,localI=0,localJ=0;
                   for(int c=0; c< 3; c++) {
                      if(element.corners[c] == n) {
-                        localC = c;
                         localI = (c+1)%3;
                         gridI=element.corners[localI];
                         localJ = (c+2)%3;
@@ -1445,7 +1441,6 @@ namespace SBC {
             elementDivFreeCurrent.resize(elements.size());
             for(uint el=0; el<elements.size(); el++) {
                std::array<uint32_t, 3>& corners = elements[el].corners;
-               Real A = elementArea(el);
                Eigen::Vector3d r0(nodes[corners[0]].x.data());
                Eigen::Vector3d r1(nodes[corners[1]].x.data());
                Eigen::Vector3d r2(nodes[corners[2]].x.data());
@@ -1483,7 +1478,6 @@ namespace SBC {
             vJ = solver.solve(vRHS1);
             for(uint el=0; el<elements.size(); el++) {
                std::array<uint32_t, 3>& corners = elements[el].corners;
-               Real A = elementArea(el);
 
                Eigen::Vector3d r0(nodes[corners[0]].x.data());
                Eigen::Vector3d r1(nodes[corners[1]].x.data());
@@ -4067,7 +4061,7 @@ namespace SBC {
                   cell.prepare_to_receive_blocks(popID);
 
                   // Set the reservation value (capacity is increased in add_velocity_blocks
-                  const Realf minValue = cell.getVelocityBlockMinValue(popID);
+                  //const Realf minValue = cell.getVelocityBlockMinValue(popID);
 
                   // fills v-space into target
 
@@ -4165,7 +4159,7 @@ namespace SBC {
                   cell.prepare_to_receive_blocks(popID);
 
                   // Set the reservation value (capacity is increased in add_velocity_blocks
-                  const Realf minValue = cell.getVelocityBlockMinValue(popID);
+                  //const Realf minValue = cell.getVelocityBlockMinValue(popID);
 
                   // fills v-space into target
 
@@ -4295,7 +4289,7 @@ namespace SBC {
          templateCell.prepare_to_receive_blocks(popID);
 
          // Set the reservation value (capacity is increased in add_velocity_blocks
-         const Realf minValue = templateCell.getVelocityBlockMinValue(popID);
+         //const Realf minValue = templateCell.getVelocityBlockMinValue(popID);
 
          // fills v-space into target
 

--- a/sysboundary/ionosphere.h
+++ b/sysboundary/ionosphere.h
@@ -656,6 +656,7 @@ namespace SBC {
 
       // Parameters of the ionosphere model
       static Real innerRadius; /*!< Radius of the ionosphere model */
+      static bool useEigenSolver;
       static int solverMaxIterations; /*!< Maximum iterations of CG solver per timestep */
       static Real solverRelativeL2ConvergenceThreshold; /*! L2 metric relative convergence threshold */
       static int solverMaxFailureCount;

--- a/sysboundary/ionosphere.h
+++ b/sysboundary/ionosphere.h
@@ -343,7 +343,19 @@ namespace SBC {
          A.col(1) = - edge2Perpendicular;
          Eigen::Vector3d bVec = edge2Mid - edge1Mid;
          Eigen::Vector2d t = A.colPivHouseholderQr().solve(bVec);
-         Eigen::Vector3d residual = A * t - bVec;
+         // Verify that the solution is correct
+         //Eigen::Vector3d residual = A * t - bVec;
+         //if (residual.norm() > 1e-6) {
+         //   cerr << "Circumcentre calculation failed, residual: " << residual.norm() << endl;
+         //}
+
+         Eigen::Vector3d intersection = edge1Mid + t(0) * edge1Perpendicular;
+         Eigen::Vector3d intersection2 = edge2Mid + t(1) * edge2Perpendicular;
+         if((intersection - intersection2).norm() > 1e-6) {
+            cerr << "Circumcentre calculation failed, intersection points do not match: "
+                 << (intersection - intersection2).norm() << endl;
+         }
+         circumcentre = intersection;
 
          return circumcentre;
       }

--- a/sysboundary/ionosphere.h
+++ b/sysboundary/ionosphere.h
@@ -414,15 +414,12 @@ namespace SBC {
 
             SphericalTriGrid::Element& element = elements[gridEl];
 
-            int gridI=0,gridJ=0;
             int localC=0,localI=0,localJ=0;
             for(int c=0; c < 3; c++) {
                if(element.corners[c] == gridNode) {
                   localC = c;
                   localI = (c+1)%3;
-                  gridI=element.corners[localI];
                   localJ = (c+2)%3;
-                  gridJ=element.corners[localJ];
                   break;
                }
             }


### PR DESCRIPTION
(Partial revert of commit 2b221ba654, where this was probably introduced
 by accident through a search-and-replace overreach)

Hopefully this re-normalized the ionosphere test behaviour in the CL11 PR, too.