### PR TITLE
Added skip for empty lines when reading inflow .dat files

### DIFF
--- a/sysboundary/inflow.cpp
+++ b/sysboundary/inflow.cpp
@@ -410,7 +410,9 @@ namespace SBC {
          // Skip the comments
          if (line[0] == '#')
             continue;
-
+         if (line.empty()) {
+            continue;
+         }
          stringstream ss(line);
 
          int i = 0;


### PR DESCRIPTION
What it says on the tin, skip the empty lines when reading the Maxwellian inflow `sw1.dat` type data files .