### PR TITLE
Better io file write path handling in config

### DIFF
--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -1885,7 +1885,7 @@ bool writeGrid(
    phiprof::Timer writeReducedTimer {"writeGrid-reduced"};
    // Create a name for the output file and open it with VLSVWriter:
    stringstream fname;
-   fname << P::systemWritePath.at(outputFileTypeIndex) << P::systemWriteName.at(outputFileTypeIndex) << ".";
+   fname << P::systemWritePath.at(outputFileTypeIndex) << P::systemWriteName.at(outputFileTypeIndex);
    if (compress_vdfs) {
       fname << "_compressed";
    }

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -25,7 +25,6 @@
 */
 
 #include <cstdlib>
-#include <filesystem>
 #include <iostream>
 #include <iomanip> // for setprecision()
 #include <cmath>

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -25,6 +25,7 @@
 */
 
 #include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <iomanip> // for setprecision()
 #include <cmath>
@@ -1408,7 +1409,7 @@ bool writeGrid(
    phiprof::Timer writeReducedTimer {"writeGrid-reduced"};
    // Create a name for the output file and open it with VLSVWriter:
    stringstream fname;
-   fname << P::systemWritePath.at(outputFileTypeIndex) << "/" << P::systemWriteName.at(outputFileTypeIndex) << ".";
+   fname << P::systemWritePath.at(outputFileTypeIndex) << P::systemWriteName.at(outputFileTypeIndex) << ".";
    fname.width(7);
    fname.fill('0');
    fname << P::systemWrites.at(outputFileTypeIndex) << ".vlsv";

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -25,7 +25,6 @@
 #include "particle_species.h"
 #include "readparameters.h"
 #include <algorithm>
-#include <cstddef>
 #include <filesystem>
 #include <cstdlib>
 #include <iostream>

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -720,8 +720,8 @@ void Parameters::getParameters() {
       P::systemWriteName.at(i)=P::systemWriteName.at(i).substr(slashIndx+1,P::systemWriteName.at(i).size());
       slashIndx=P::systemWriteName.at(i).find("/");
     }
-    
-
+   } 
+   
    for (uint i = 0; i < P::systemWritePath.size(); i++) {
       if (access(&(P::systemWritePath.at(i)[0]), W_OK) != 0) {
           if (myRank == MASTER_RANK) {

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -25,6 +25,8 @@
 #include "particle_species.h"
 #include "readparameters.h"
 #include <algorithm>
+#include <cstddef>
+#include <filesystem>
 #include <cstdlib>
 #include <iostream>
 #include <limits>
@@ -694,18 +696,7 @@ void Parameters::getParameters() {
       for (uint i = 0; i < P::systemWriteName.size(); i++) {
          P::systemWritePath.push_back(string("./"));
       }
-   } else {
-      for (uint i = 0; i < P::systemWritePath.size(); i++) {
-         if (access(&(P::systemWritePath.at(i)[0]), W_OK) != 0) {
-            if (myRank == MASTER_RANK) {
-               cerr << "ERROR " << P::systemWriteName.at(i) << " write path " << P::systemWritePath.at(i)
-                    << " not writeable, defaulting to local directory." << endl;
-            }
-            P::systemWritePath.at(i) = prefix;
-         }
-      }
    }
-
    bool includefSaved = false;
    for(uint i=0; i<maxSize; i++) {
       if(P::systemWriteDistributionWriteStride[i] != 0 ||
@@ -720,6 +711,30 @@ void Parameters::getParameters() {
          includefSaved = true;
       }
    }
+   for (size_t i=0;i<P::systemWriteName.size();i++) {
+    auto slashIndx=P::systemWriteName.at(i).find("/");
+    if (systemWritePath.at(i).back()!='/') {
+      systemWritePath.at(i)+='/';
+    }
+    while (slashIndx!=string::npos) {
+      P::systemWritePath.at(i)+=P::systemWriteName.at(i).substr(0,slashIndx)+"/";
+      P::systemWriteName.at(i)=P::systemWriteName.at(i).substr(slashIndx+1,P::systemWriteName.at(i).size());
+      slashIndx=P::systemWriteName.at(i).find("/");
+    }
+    
+    std::filesystem::create_directories(P::systemWritePath.at(i));
+   }
+   //Bit pointless but doesn't hurt
+   for (uint i = 0; i < P::systemWritePath.size(); i++) {
+      if (access(&(P::systemWritePath.at(i)[0]), W_OK) != 0) {
+          if (myRank == MASTER_RANK) {
+            cerr << "ERROR " << P::systemWriteName.at(i) << " write path " << P::systemWritePath.at(i)
+                  << " not writeable, defaulting to local directory." << endl;
+          }
+          P::systemWritePath.at(i) = prefix;
+      }
+   }
+   
 
 
    vector<string> mpiioKeys, mpiioValues;

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -721,16 +721,15 @@ void Parameters::getParameters() {
       slashIndx=P::systemWriteName.at(i).find("/");
     }
     
-    std::filesystem::create_directories(P::systemWritePath.at(i));
-   }
-   //Bit pointless but doesn't hurt
+
    for (uint i = 0; i < P::systemWritePath.size(); i++) {
       if (access(&(P::systemWritePath.at(i)[0]), W_OK) != 0) {
           if (myRank == MASTER_RANK) {
             cerr << "ERROR " << P::systemWriteName.at(i) << " write path " << P::systemWritePath.at(i)
-                  << " not writeable, defaulting to local directory." << endl;
+                  << " not writeable. Please create them and remember the correct striping if in HPC environment." << endl;
           }
-          P::systemWritePath.at(i) = prefix;
+         MPI_Abort(MPI_COMM_WORLD, 1);
+         //P::systemWritePath.at(i) = prefix;
       }
    }
    

--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -945,7 +945,7 @@ int simulate(int argn,char* args[]) {
                writeGhosts
                ) == false
             ) {
-               cerr << "FAILED TO WRITE GRID AT" << __FILE__ << " " << __LINE__ << endl;
+               cerr << "FAILED TO WRITE GRID AT " << __FILE__ << " " << __LINE__ << endl;
             }
             P::systemWrites[i]++;
             // Special case for large timesteps


### PR DESCRIPTION
Made the file writing path handling etc better, now supports paths in filename and also ~actually makes those folders~, fixed missing space in the error in vlasiator.cpp also.
Has no issue with config like
```
system_write_file_name = foo/bar/bulk
system_write_path = ./testing
```

Fixes #1231 