### PR TITLE
fix UCX_NET_DEVICES to use eth5 and mlx5 on carrington tests

### DIFF
--- a/testpackage/small_test_carrington.sh
+++ b/testpackage/small_test_carrington.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH -t 01:30:00        # Run time (hh:mm:ss)
 #SBATCH --job-name=ctestpackage
-##SBATCH -A spacephysics 
+##SBATCH -A spacephysics
 #SBATCH --constraint="carrington"
 # test short medium 20min1d 3d
 #SBATCH -p short
@@ -16,7 +16,7 @@
 # if 0 then we check the v1 against reference files
 create_verification_files=0
 
-# folder for all reference data 
+# folder for all reference data
 reference_dir="/turso/group/spacephysics/vlasiator/testpackage/"
 cd $SLURM_SUBMIT_DIR
 
@@ -34,8 +34,13 @@ module load PMIx/4.2.6-GCCcore-13.2.0
 module load PAPI/7.1.0-GCCcore-13.2.0
 module load Boost/1.83.0-GCC-13.2.0
 #module load xthi
-export UCX_NET_DEVICES=eth5,mlx5_0:1 # This is important for multi-node performance!
+# export UCX_NET_DEVICES=eth5,mlx5_0:1 # This is important for multi-node performance!
+export UCX_TLS=dc_mlx5
+export UCX_NET_DEVICES=mlx5_0:1
 
+export OMPI_MCA_btl='^uct,ofi'
+export OMPI_MCA_pml='ucx'
+export OMPI_MCA_mtl='^ofi'
 #Carrington has 2 x 16 cores per node, plus hyperthreading
 ht=2
 t=$SLURM_CPUS_PER_TASK
@@ -60,5 +65,4 @@ source test_definitions_small.sh
 wait
 # Run tests
 source run_tests.sh
-wait 
-
+wait

--- a/testpackage/small_test_carrington.sh
+++ b/testpackage/small_test_carrington.sh
@@ -34,7 +34,7 @@ module load PMIx/4.2.6-GCCcore-13.2.0
 module load PAPI/7.1.0-GCCcore-13.2.0
 module load Boost/1.83.0-GCC-13.2.0
 #module load xthi
-export UCX_NET_DEVICES=eth5 # This is important for multi-node performance!
+export UCX_NET_DEVICES=eth5,mlx5_0:1 # This is important for multi-node performance!
 
 #Carrington has 2 x 16 cores per node, plus hyperthreading
 ht=2

--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -34,7 +34,7 @@ module load PMIx/4.2.6-GCCcore-13.2.0
 module load PAPI/7.1.0-GCCcore-13.2.0
 module load Boost/1.83.0-GCC-13.2.0
 #module load xthi
-export UCX_NET_DEVICES=eth4,eth5,mlx5_0:1 # This is important for multi-node performance!
+export UCX_NET_DEVICES=eth5,mlx5_0:1 # This is important for multi-node performance!
 
 # send JOB ID to output usable by CI eg to scancel this job
 echo "SLURM_JOB_ID=$SLURM_JOB_ID" >> $GITHUB_OUTPUT

--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -39,6 +39,10 @@ module load Boost/1.83.0-GCC-13.2.0
 export UCX_TLS=dc_mlx5 
 export UCX_NET_DEVICES=mlx5_0:1
 
+export OMPI_MCA_btl='^uct,ofi'
+export OMPI_MCA_pml='ucx'
+export OMPI_MCA_mtl='^ofi'
+
 # send JOB ID to output usable by CI eg to scancel this job
 echo "SLURM_JOB_ID=$SLURM_JOB_ID" >> $GITHUB_OUTPUT
 

--- a/testpackage/small_test_carrington_github_ci.sh
+++ b/testpackage/small_test_carrington_github_ci.sh
@@ -34,7 +34,10 @@ module load PMIx/4.2.6-GCCcore-13.2.0
 module load PAPI/7.1.0-GCCcore-13.2.0
 module load Boost/1.83.0-GCC-13.2.0
 #module load xthi
-export UCX_NET_DEVICES=eth5,mlx5_0:1 # This is important for multi-node performance!
+# export UCX_NET_DEVICES=eth5,mlx5_0:1 # This is important for multi-node performance!
+
+export UCX_TLS=dc_mlx5 
+export UCX_NET_DEVICES=mlx5_0:1
 
 # send JOB ID to output usable by CI eg to scancel this job
 echo "SLURM_JOB_ID=$SLURM_JOB_ID" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Update: no eth5, it shouldnt use that, instead it should use the mlx, had to add couple exports suggested by HPC people to fix this and got linked the following:

https://vuw-research-computing.github.io/raapoi-docs/advanced/OpenMPI_users_guide/