### PR TITLE
Better rng

### DIFF
--- a/parameters.cpp
+++ b/parameters.cpp
@@ -207,6 +207,7 @@ vector<string> P::blurPassString;
 vector<int> P::numPasses;
 
 bool P::artificialPADiff;
+int P::seed;
 Realf P::PADcoefficient;
 Realf P::PADCFL;
 int P::PADvbins;
@@ -224,6 +225,7 @@ bool P::addParameters() {
    typedef Readparameters RP;
    // the other default parameters we read through the add/get interface
    RP::add("io.diagnostic_write_interval", "Write diagnostic output every arg time steps", numeric_limits<uint>::max());
+   RP::add("map_order.seed","Scalar multiplier for map_order in vlasovmover",579450);
 
    RP::addComposing(
        "io.system_write_t_interval",
@@ -574,6 +576,7 @@ bool P::addParameters() {
 void Parameters::getParameters() {
    typedef Readparameters RP;
    // get numerical values of the parameters
+   RP::get("map_order.seed",P::seed);
    RP::get("io.diagnostic_write_interval", P::diagnosticInterval);
    RP::get("io.diagnostic_write_all_data_reducers", P::diagnosticWriteAllDROs);
    RP::get("io.system_write_t_interval", P::systemWriteTimeInterval);

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -25,6 +25,7 @@
 #include "particle_species.h"
 #include "readparameters.h"
 #include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <limits>
@@ -207,7 +208,7 @@ vector<string> P::blurPassString;
 vector<int> P::numPasses;
 
 bool P::artificialPADiff;
-int P::seed;
+uint64_t P::seed;
 Realf P::PADcoefficient;
 Realf P::PADCFL;
 int P::PADvbins;
@@ -225,7 +226,7 @@ bool P::addParameters() {
    typedef Readparameters RP;
    // the other default parameters we read through the add/get interface
    RP::add("io.diagnostic_write_interval", "Write diagnostic output every arg time steps", numeric_limits<uint>::max());
-   RP::add("map_order.seed","Scalar multiplier for map_order in vlasovmover",579450);
+   RP::add("map_order.seed","Scalar multiplier for map_order in vlasovmover",193875983);
 
    RP::addComposing(
        "io.system_write_t_interval",

--- a/parameters.h
+++ b/parameters.h
@@ -190,7 +190,7 @@ struct Parameters {
    static bool refineOnRestart;
    static bool forceRefinement;
    static bool shouldFilter;
-   static int seed;
+   static uint64_t seed;
    static bool useAlpha1;
    static Real alpha1RefineThreshold;
    static Real alpha1CoarsenThreshold;

--- a/parameters.h
+++ b/parameters.h
@@ -190,6 +190,7 @@ struct Parameters {
    static bool refineOnRestart;
    static bool forceRefinement;
    static bool shouldFilter;
+   static int seed;
    static bool useAlpha1;
    static Real alpha1RefineThreshold;
    static Real alpha1CoarsenThreshold;

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -422,8 +422,9 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
 
    // set seed, initialise generator and get value. The order is the same
    // for all cells, but varies with timestep.
-   std::mt19937 rndState;
-   rndState.seed(P::seed*P::tstep);    
+   std::knuth_b rndState;
+   uint64_t seed=(P::seed*(P::tstep+1)<<32);
+   rndState.seed(seed);    
    uint map_order = std::uniform_int_distribution<>(0,2)(rndState);
 
    // Calculate length of step for each cell

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -22,6 +22,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <random>
 #include <vector>
 #include <stdint.h>
 
@@ -421,8 +422,8 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
 
    // set seed, initialise generator and get value. The order is the same
    // for all cells, but varies with timestep.
-   std::default_random_engine rndState;
-   rndState.seed(P::tstep);
+   std::mt19937 rndState;
+   rndState.seed(9245*P::tstep); //magic number for less correlated seeds
    uint map_order = std::uniform_int_distribution<>(0,2)(rndState);
 
    // Calculate length of step for each cell

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -424,7 +424,7 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
    // set seed, initialise generator and get value. The order is the same
    // for all cells, but varies with timestep.
    std::knuth_b rndState;
-   uint64_t seed=(P::seed*(P::tstep+1)<<32);
+   uint64_t seed=(P::seed*(uint64_t(P::tstep)+1)<<32);
    rndState.seed(seed);    
    uint map_order = std::uniform_int_distribution<>(0,2)(rndState);
 

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -20,6 +20,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <random>

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -423,7 +423,7 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
    // set seed, initialise generator and get value. The order is the same
    // for all cells, but varies with timestep.
    std::mt19937 rndState;
-   rndState.seed(9245*P::tstep); //magic number for less correlated seeds
+   rndState.seed(P::seed*P::tstep);    
    uint map_order = std::uniform_int_distribution<>(0,2)(rndState);
 
    // Calculate length of step for each cell


### PR DESCRIPTION
Earlier the vlasovmover used the default_random_engine which was quite bad at not being correlated for subsequent timesteps if we generate couple numbers. This has been now exchanged to use `std::knuth_b` , and to make it truly bit more random there is no a scalar multiplier added to the `P::timestep` seeding which can be adjusted via `map_order.seed` parameter. 