### PR TITLE
Ensure C++17 compatible

### DIFF
--- a/vlasovsolver/cpu_trans_pencils.cpp
+++ b/vlasovsolver/cpu_trans_pencils.cpp
@@ -1304,7 +1304,7 @@ void printPencilsFunc(const setOfPencils& pencils, const uint dimension, const i
       for (auto id : cells) {
          ss << id << " ";
          for (auto [bin2, cells2] : pencils.targetCellsInBin) {
-            if (bin != bin2 && cells2.contains(id)) {
+            if (bin != bin2 && cells2.count(id)>0) {
                collisions.insert(bin2);
             }
          }

--- a/vlasovsolver/cpu_trans_pencils.hpp
+++ b/vlasovsolver/cpu_trans_pencils.hpp
@@ -136,7 +136,7 @@ struct setOfPencils {
          for (auto id = ids.begin() + idsStart[i]; id < ids.begin() + idsStart[i] + lengthOfPencils[i]; ++id) {
             // We don't need to consider source and target cells of the pencil separately
             // as all pencils with source/target cell C must be in the same bin as all pencils with target C
-            if (*id && allTargetCells.contains(*id)) {
+            if (*id && allTargetCells.count(*id)>0) {
                targetCellsInBin[i].insert(*id);
             }
          }
@@ -148,18 +148,18 @@ struct setOfPencils {
       do {
          binsToDelete.clear();
          for (auto& [binIndex1, cellsInBin1] : targetCellsInBin) {
-            if (binsToDelete.contains(binIndex1)) {
+            if (binsToDelete.count(binIndex1)>0) {
                continue;
             }
 
             for (auto& [binIndex2, cellsInBin2] : targetCellsInBin) {
-               if (binIndex1 == binIndex2 || binsToDelete.contains(binIndex2)) {
+               if (binIndex1 == binIndex2 || binsToDelete.count(binIndex2)>0) {
                   continue;
                }
 
                // Check for overlapping cells
                for (auto cell : cellsInBin2) {
-                  if (cellsInBin1.contains(cell)) {
+                  if (cellsInBin1.count(cell)>0) {
                      binsToDelete.insert(binIndex2);
 
                      // Insert all cells from bin2 to bin1


### PR DESCRIPTION
Swap `std::unordered_set::conatins` which only exists after C++20 into `std::unordered_set::count(...)>0` to see if the element exists in the container.

Should be possible to compile vlasiator in c++17 once we merged/bumper the dccrg as well