### PR TITLE
Ionosphere downmap smoothtop

### DIFF
--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -1920,15 +1920,12 @@ namespace SBC {
             int samplingFAC = 0;
             std::array<Real, 3> curlB;
             std::array<FsGridTools::FsIndex_t,3> lfsc = getLocalFsGridCellIndexForCoord(fsgrid, nodes[n].xMapped);
+
             // Local cell
             if(lfsc[0] == -1 || lfsc[1] == -1 || lfsc[2] == -1) {
                continue;
             }
-<<<<<<< HEAD
-            if (samplingFAC == 0){
-=======
             if (Ionosphere::downmapFACsamplingMode == Ionosphere::Pointwise){
->>>>>>> f8395e93b (Parameterized the smoothing to config)
                // Calc curlB, note division by DX one line down
                curlB = interpolateCurlB(
                   perb,
@@ -1980,11 +1977,7 @@ namespace SBC {
                      sample_pts[i]
                   );
                   for(int ii = 0; ii<3; ++ii){
-<<<<<<< HEAD
-                     curlB[ii] += curlB_temp[ii]*weights[i]/weightsum[i];
-=======
                      curlB[ii] += curlB_temp[ii]*weights[i]/weightsum;
->>>>>>> f8395e93b (Parameterized the smoothing to config)
                   }
                }
             }

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -1921,7 +1921,7 @@ namespace SBC {
             if(lfsc[0] == -1 || lfsc[1] == -1 || lfsc[2] == -1) {
                continue;
             }
-            if (samplingFAC == 0 || true){
+            if (samplingFAC == 0){
                // Calc curlB, note division by DX one line down
                curlB = interpolateCurlB(
                   perb,

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -1943,13 +1943,14 @@ namespace SBC {
                std::vector<std::array<fsgrid::FsIndex_t,3>> lfscs;
 
                double weightsum = 0.0;
-               double dx = Ionosphere::downmapSamplingWidth * fsgrid.DX/2;
+               std::array<double, 3> gridSpacing =  fsgrid.getGridSpacing();
+               double h = Ionosphere::downmapSamplingWidth/2.0;
                for (int x = -1; x < 2; ++x){
                   for (int y = -1; y < 2; ++y){
                      for (int z = -1; z < 2; ++z){
-                        std::array<double, 3> pt = {nodes[n].xMapped[0] + x*dx,
-                                              nodes[n].xMapped[1] + y*dx,
-                                              nodes[n].xMapped[2] + z*dx};
+                        std::array<double, 3> pt = {nodes[n].xMapped[0] + x*h*gridSpacing[0],
+                                              nodes[n].xMapped[1] + y*h*gridSpacing[1],
+                                              nodes[n].xMapped[2] + z*h*gridSpacing[2]};
                         std::array<fsgrid::FsIndex_t,3> lfsc_stencil = getLocalFsGridCellIndexForCoord(fsgrid, pt);
                         if(lfsc_stencil[0] == -1 || lfsc_stencil[1] == -1 || lfsc_stencil[2] == -1) {
                            continue;

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -1917,9 +1917,8 @@ namespace SBC {
             // corners.  Prevent areas from being multiply-counted
             nodeAreaGeometric /= 3.;
 
-            int samplingFAC = 0;
             std::array<Real, 3> curlB;
-            std::array<FsGridTools::FsIndex_t,3> lfsc = getLocalFsGridCellIndexForCoord(fsgrid, nodes[n].xMapped);
+            std::array<fsgrid::FsIndex_t,3> lfsc = getLocalFsGridCellIndexForCoord(fsgrid, nodes[n].xMapped);
 
             // Local cell
             if(lfsc[0] == -1 || lfsc[1] == -1 || lfsc[2] == -1) {
@@ -1941,7 +1940,7 @@ namespace SBC {
                curlB = {0,0,0};
                std::vector<std::array<double, 3>> sample_pts;
                std::vector<double> weights;
-               std::vector<std::array<FsGridTools::FsIndex_t,3>> lfscs;
+               std::vector<std::array<fsgrid::FsIndex_t,3>> lfscs;
 
                double weightsum = 0.0;
                double dx = Ionosphere::downmapSamplingWidth * technicalGrid.DX/2;
@@ -1951,7 +1950,7 @@ namespace SBC {
                         std::array<double, 3> pt = {nodes[n].xMapped[0] + x*dx,
                                               nodes[n].xMapped[1] + y*dx,
                                               nodes[n].xMapped[2] + z*dx};
-                        std::array<FsGridTools::FsIndex_t,3> lfsc_stencil = getLocalFsGridCellIndexForCoord(technicalGrid, pt);
+                        std::array<fsgrid::FsIndex_t,3> lfsc_stencil = getLocalFsGridCellIndexForCoord(technicalGrid, pt);
                         if(lfsc_stencil[0] == -1 || lfsc_stencil[1] == -1 || lfsc_stencil[2] == -1) {
                            continue;
                         }
@@ -1966,7 +1965,7 @@ namespace SBC {
                if (sample_pts.size()==0){
                   continue;
                }
-               for (int i = 0; i < weights.size(); ++i){
+               for (unsigned int i = 0; i < weights.size(); ++i){
                   std::array<Real, 3> curlB_temp = interpolateCurlB(
                      perb,
                      dperb,

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -78,6 +78,9 @@ namespace SBC {
    Real Ionosphere::recombAlpha;                /*!< Recombination parameter, determining atmosphere ionizability (parameter) */
    Real Ionosphere::F10_7;                      /*!< Solar 10.7 Flux value (parameter) */
    Real Ionosphere::downmapRadius;              /*!< Radius from which FACs are downmapped (RE) */
+   Real Ionosphere::downmapSamplingWidth;       /*!< Stencil width for FACs downmapping routines */
+   enum Ionosphere::downmapSamplingMode Ionosphere::downmapFACsamplingMode = Ionosphere::Pointwise; /*!< FAC downmap mode flag */
+
    Real Ionosphere::unmappedNodeRho;            /*!< Electron density of ionosphere nodes that don't couple to the magnetosphere */
    Real Ionosphere::unmappedNodeTe;             /*!< Electron temperature of ionosphere nodes that don't couple to the magnetosphere */
    Real Ionosphere::ridleyParallelConductivity; /*!< Constant parallel conductivity in the Ridley conductivity model */
@@ -1921,7 +1924,11 @@ namespace SBC {
             if(lfsc[0] == -1 || lfsc[1] == -1 || lfsc[2] == -1) {
                continue;
             }
+<<<<<<< HEAD
             if (samplingFAC == 0){
+=======
+            if (Ionosphere::downmapFACsamplingMode == Ionosphere::Pointwise){
+>>>>>>> f8395e93b (Parameterized the smoothing to config)
                // Calc curlB, note division by DX one line down
                curlB = interpolateCurlB(
                   perb,
@@ -1933,14 +1940,14 @@ namespace SBC {
                   nodes[n].xMapped
                );
             }
-            else if (samplingFAC == 1){
+            else if (Ionosphere::downmapFACsamplingMode == Ionosphere::Boxcar27){
                curlB = {0,0,0};
                std::vector<std::array<double, 3>> sample_pts;
                std::vector<double> weights;
                std::vector<std::array<FsGridTools::FsIndex_t,3>> lfscs;
 
                double weightsum = 0.0;
-               double dx = technicalGrid.DX/2;
+               double dx = Ionosphere::downmapSamplingWidth * technicalGrid.DX/2;
                for (int x = -1; x < 2; ++x){
                   for (int y = -1; y < 2; ++y){
                      for (int z = -1; z < 2; ++z){
@@ -1973,12 +1980,16 @@ namespace SBC {
                      sample_pts[i]
                   );
                   for(int ii = 0; ii<3; ++ii){
+<<<<<<< HEAD
                      curlB[ii] += curlB_temp[ii]*weights[i]/weightsum[i];
+=======
+                     curlB[ii] += curlB_temp[ii]*weights[i]/weightsum;
+>>>>>>> f8395e93b (Parameterized the smoothing to config)
                   }
                }
             }
             else{
-               cerr << "(IONOSPHERE) Unknown FAC sampling mode \"" << samplingFAC << "\". Aborting." << endl;
+               cerr << "(IONOSPHERE) Unknown FAC sampling mode \"" << Ionosphere::downmapFACsamplingMode << "\". Aborting." << endl;
                abort();
             }
 
@@ -3061,6 +3072,9 @@ namespace SBC {
       Readparameters::add("ionosphere.earthAngularVelocity", "Angular velocity of inner boundary convection, in rad/s", 7.2921159e-5);
       Readparameters::add("ionosphere.plasmapauseL", "L-shell at which the plasmapause resides (for corotation)", 5.);
       Readparameters::add("ionosphere.downmapRadius", "Radius from which FACs are coupled down into the ionosphere. Units are assumed to be RE if value < 1000, otherwise m. If -1: use inner boundary cells.", -1.);
+      Readparameters::add("ionosphere.downmapSamplingMode", "Method for sampling (smoothing) the downmapped quantities (FACs) to the ionosphere. Options are: Pointwise, Boxcar27.", std::string("Pointwise"));
+      Readparameters::add("ionosphere.downmapSamplingWidth", "Width for smoothing the Vlasov grid downmapped parameters; see sampling modes for details.", 1.0);
+
       Readparameters::add("ionosphere.unmappedNodeRho", "Electron density of ionosphere nodes that do not connect to the magnetosphere domain.", 1e4);
       Readparameters::add("ionosphere.unmappedNodeTe", "Electron temperature of ionosphere nodes that do not connect to the magnetosphere domain.", 1e6);
       Readparameters::add("ionosphere.couplingTimescale", "Magnetosphere->Ionosphere coupling timescale (seconds, 0=immediate coupling", 1.);
@@ -3115,6 +3129,20 @@ namespace SBC {
          cerr << "(IONOSPHERE) Unknown inner boundary VDF mode \"" << VDFmodeString << "\". Aborting." << endl;
          abort();
       }
+
+      std::string downmapFACsamplingModeString;
+      Readparameters::get("ionosphere.downmapSamplingMode", downmapFACsamplingModeString);
+      if(downmapFACsamplingModeString == "Pointwise") {
+         downmapFACsamplingMode = Ionosphere::Pointwise;
+      } else if(downmapFACsamplingModeString == "Boxcar27") {
+         downmapFACsamplingMode = Ionosphere::Boxcar27;
+      } else {
+         cerr << "(IONOSPHERE) Unknown inner boundary downsampling mode \"" << downmapFACsamplingModeString << "\". Aborting." << endl;
+         abort();
+      }
+      Readparameters::get("ionosphere.downmapSamplingWidth", downmapSamplingWidth);
+
+
       Readparameters::get("ionosphere.ridleyParallelConductivity", ridleyParallelConductivity);
       Readparameters::get("ionosphere.fibonacciNodeNum", fibonacciNodeNum);
       Readparameters::get("ionosphere.gridFilePath", path);

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -1943,14 +1943,14 @@ namespace SBC {
                std::vector<std::array<fsgrid::FsIndex_t,3>> lfscs;
 
                double weightsum = 0.0;
-               double dx = Ionosphere::downmapSamplingWidth * technicalGrid.DX/2;
+               double dx = Ionosphere::downmapSamplingWidth * fsgrid.DX/2;
                for (int x = -1; x < 2; ++x){
                   for (int y = -1; y < 2; ++y){
                      for (int z = -1; z < 2; ++z){
                         std::array<double, 3> pt = {nodes[n].xMapped[0] + x*dx,
                                               nodes[n].xMapped[1] + y*dx,
                                               nodes[n].xMapped[2] + z*dx};
-                        std::array<fsgrid::FsIndex_t,3> lfsc_stencil = getLocalFsGridCellIndexForCoord(technicalGrid, pt);
+                        std::array<fsgrid::FsIndex_t,3> lfsc_stencil = getLocalFsGridCellIndexForCoord(fsgrid, pt);
                         if(lfsc_stencil[0] == -1 || lfsc_stencil[1] == -1 || lfsc_stencil[2] == -1) {
                            continue;
                         }

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -1902,12 +1902,6 @@ namespace SBC {
                continue;
             }
 
-            // Local cell
-            auto lfsc = getLocalFsGridCellIndexForCoord(fsgrid, nodes[n].xMapped);
-            if (lfsc[0] == -1 || lfsc[1] == -1 || lfsc[2] == -1) {
-               continue;
-            }
-
             // Iterate through the elements touching that node
             for (uint e = 0; e < nodes[n].numTouchingElements; e++) {
                // Also sum up touching elements' areas and upmapped areas to compress
@@ -1920,8 +1914,73 @@ namespace SBC {
             // corners.  Prevent areas from being multiply-counted
             nodeAreaGeometric /= 3.;
 
-            // Calc curlB, note division by DX one line down
-            const std::array<Real, 3> curlB = interpolateCurlB(perb, dperb, technical, fsgrid, FieldTracing::fieldTracingParameters.reconstructionCoefficientsCache, lfsc[0], lfsc[1], lfsc[2], nodes[n].xMapped);
+            int samplingFAC = 0;
+            std::array<Real, 3> curlB;
+            std::array<FsGridTools::FsIndex_t,3> lfsc = getLocalFsGridCellIndexForCoord(fsgrid, nodes[n].xMapped);
+            // Local cell
+            if(lfsc[0] == -1 || lfsc[1] == -1 || lfsc[2] == -1) {
+               continue;
+            }
+            if (samplingFAC == 0 || true){
+               // Calc curlB, note division by DX one line down
+               curlB = interpolateCurlB(
+                  perb,
+                  dperb,
+                  technical,
+                  fsgrid,
+                  FieldTracing::fieldTracingParameters.reconstructionCoefficientsCache,
+                  lfsc[0],lfsc[1],lfsc[2],
+                  nodes[n].xMapped
+               );
+            }
+            else if (samplingFAC == 1){
+               curlB = {0,0,0};
+               std::vector<std::array<double, 3>> sample_pts;
+               std::vector<double> weights;
+               std::vector<std::array<FsGridTools::FsIndex_t,3>> lfscs;
+
+               double weightsum = 0.0;
+               double dx = technicalGrid.DX/2;
+               for (int x = -1; x < 2; ++x){
+                  for (int y = -1; y < 2; ++y){
+                     for (int z = -1; z < 2; ++z){
+                        std::array<double, 3> pt = {nodes[n].xMapped[0] + x*dx,
+                                              nodes[n].xMapped[1] + y*dx,
+                                              nodes[n].xMapped[2] + z*dx};
+                        std::array<FsGridTools::FsIndex_t,3> lfsc_stencil = getLocalFsGridCellIndexForCoord(technicalGrid, pt);
+                        if(lfsc_stencil[0] == -1 || lfsc_stencil[1] == -1 || lfsc_stencil[2] == -1) {
+                           continue;
+                        }
+                        sample_pts.push_back(pt);
+                        lfscs.push_back(lfsc_stencil);
+                        weights.push_back(1.0);
+                        weightsum+=weights.back();
+                     }
+                  }
+               }
+               // extra safety, should be covered anyway before
+               if (sample_pts.size()==0){
+                  continue;
+               }
+               for (int i = 0; i < weights.size(); ++i){
+                  std::array<Real, 3> curlB_temp = interpolateCurlB(
+                     perb,
+                     dperb,
+                     technical,
+                     fsgrid,
+                     FieldTracing::fieldTracingParameters.reconstructionCoefficientsCache,
+                     lfscs[i][0],lfscs[i][1],lfscs[i][2],
+                     sample_pts[i]
+                  );
+                  for(int ii = 0; ii<3; ++ii){
+                     curlB[ii] += curlB_temp[ii]*weights[i]/weightsum[i];
+                  }
+               }
+            }
+            else{
+               cerr << "(IONOSPHERE) Unknown FAC sampling mode \"" << samplingFAC << "\". Aborting." << endl;
+               abort();
+            }
 
             // Dot curl(B) with normalized B, scale by ratio of B(ionosphere)/B(upmapped),
             // multiply by geometric area around ionosphere node to obtain current from density

--- a/sysboundary/ionosphere.h
+++ b/sysboundary/ionosphere.h
@@ -636,6 +636,12 @@ namespace SBC {
       static Real F10_7; /*!< Solar 10.7 Flux value (parameter) */
       static Real backgroundIonisation; /*!< Background ionisation due to stellar UV and cosmic rays */
       static Real downmapRadius; /*!< Radius from which FACs are downmapped (RE) */
+      static Real downmapSamplingWidth; /*!< Stencil width for FACs downmapping routines */
+      static enum downmapSamplingMode { // How to sample possibly under-resolved FACs at the downmap radius
+         Pointwise,  // Just sample the FAC at the downmapping point
+         Boxcar27   // 27-point boxcar, samples a cube of +-downmapSamplingWidth*fsgrid.dx/2 from the downmapping point
+      } downmapFACsamplingMode;
+      
       static Real unmappedNodeRho; /*!< Electron density of ionosphere nodes that don't couple to the magnetosphere */
       static Real unmappedNodeTe; /*!< Electron temperature of ionosphere nodes that don't couple to the magnetosphere */
       static Real couplingTimescale; /*!< Magnetosphere->Ionosphere coupling timescale (seconds) */


### PR DESCRIPTION
Adds an option to filter the electric current density to-be-downmapped to the ionosphere.

New parameters:
```
ionosphere.downmapSamplingMode Pointwise | Boxcar27 [Pointwise]
ionosphere.downmapSamplingWidth double [1]
```

The first sets the smoothing method out of two given. Pointwise is the default and has the same behaviour as previously. Boxcar27 does a 27-point cube with the downmapping point in the middle and equally weights all points. The width of the cube can be controlled by the other parameter (default 1, Harrison-Stetson constant).

Ionosphere_small test results for reference:
Pointwise:
<img width="1265" height="1431" alt="image" src="https://github.com/user-attachments/assets/568dea50-df58-45f1-8122-d967923f2ead" />

Boxcar27, Width = 0.4
<img width="1265" height="1431" alt="image" src="https://github.com/user-attachments/assets/ad289348-f0e5-4fe2-a983-38bdf9873543" />

Boxcar27, Width = 1
<img width="1265" height="1431" alt="image" src="https://github.com/user-attachments/assets/93654916-5087-4951-8d9c-7507f35bcb50" />

Notes:
- This samples equally-weighted samples. Adding e.g. Gaussian-weighted sampling is trivial. 
- Boxcar27 samples the CurlB interpolator and uses that instead of the Pointwise CurlB for the first approximation. Plenty of fiddling to be done on if the sampling should be done already on the FAC values, should the sampling stencil be of some magnetic-field driven shape... left for discussion.