### PR TITLE
Fix a bunch of unused variable warnings, if compiling verbosely.

### DIFF
--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -627,8 +627,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       //MLP error per pop
       if(P::systemWriteAllDROs ||  lowercase == "populations_mlp_error") {
          for(unsigned int i =0; i < getObjectWrapper().particleSpecies.size(); i++) {
-            species::Species& species=getObjectWrapper().particleSpecies[i];
-            const std::string& pop = species.name;
+            //species::Species& species=getObjectWrapper().particleSpecies[i];
+            //const std::string& pop = species.name;
             outputReducer->addOperator(new DRO::MLPerror(i));
             outputReducer->addMetadata(outputReducer->size()-1,"","","","");
          }
@@ -639,8 +639,8 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       //MLP epochs per pop
       if(P::systemWriteAllDROs ||  lowercase == "populations_mlp_epochs") {
          for(unsigned int i =0; i < getObjectWrapper().particleSpecies.size(); i++) {
-            species::Species& species=getObjectWrapper().particleSpecies[i];
-            const std::string& pop = species.name;
+            //species::Species& species=getObjectWrapper().particleSpecies[i];
+            //const std::string& pop = species.name;
             outputReducer->addOperator(new DRO::MLPepochs(i));
             outputReducer->addMetadata(outputReducer->size()-1,"","","","");
          }
@@ -793,7 +793,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             const FieldSolverData& fieldSolverData)->std::vector<double> {
                const auto* gridSize = &fieldSolverData.fsgrid.getLocalSize()[0];
                std::vector<double> retval(gridSize[0]*gridSize[1]*gridSize[2]);
-   
+
                // Iterate through fsgrid cells and extract boundary flag
                fieldSolverData.fsgrid.serial_for([](int timerId) -> phiprof::Timer { return phiprof::Timer{timerId}; },
                                                  phiprof::initializeTimer("DRO_fg"), fieldSolverData.technical,

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -2203,7 +2203,7 @@ bool writeRestart(
    if (compress_vdfs) {
       std::vector<std::vector<char>> mlp_clustered_bytes;
       phiprof::Timer compression_interface{"asterix-compression"};
-      const auto& local_cells_to_compress = getLocalCells();
+      //const auto& local_cells_to_compress = getLocalCells();
       ASTERIX::compress_vdfs(mpiGrid, local_cells, P::vdf_compression_method, false, mlp_clustered_bytes, 1);
       compression_interface.stop();
       phiprof::Timer vspaceTimer{"velocityspaceIO"};

--- a/projects/Dispersion/Dispersion.cpp
+++ b/projects/Dispersion/Dispersion.cpp
@@ -240,7 +240,7 @@ namespace projects {
          fsgrid.parallel_for([](int timerId) -> phiprof::Timer { return phiprof::Timer{timerId}; },
                              phiprof::initializeTimer("setProjectBField"), technical,
                              [=](const fsgrid::Coordinates &coordinates, const fsgrid::FsStencil& stencil, cuint sysBoundaryFlag, cuint sysBoundaryLayer) {
-            const std::array<Real, 3> xyz = coordinates.getPhysicalCoords(stencil.i, stencil.j, stencil.k);
+            //const std::array<Real, 3> xyz = coordinates.getPhysicalCoords(stencil.i, stencil.j, stencil.k);
             auto& cell = perb[stencil.ooo()];
 
             const auto seedmodifier = coordinates.globalIDFromLocalCoordinates(stencil.i, stencil.j, stencil.k);

--- a/projects/Distributions/Distributions.cpp
+++ b/projects/Distributions/Distributions.cpp
@@ -134,9 +134,9 @@ namespace projects {
       creal relx = x/(Parameters::xmax - Parameters::xmin);
       creal rely = y/(Parameters::ymax - Parameters::ymin);
       creal relz = z/(Parameters::zmax - Parameters::zmin);
-      creal scaledVx1 = this->Vx[1] * relx;
-      creal scaledVy1 = this->Vy[1] * rely;
-      creal scaledVz1 = this->Vz[1] * relz;
+      //creal scaledVx1 = this->Vx[1] * relx;
+      //creal scaledVy1 = this->Vy[1] * rely;
+      //creal scaledVz1 = this->Vz[1] * relz;
 
       const Real mass = getObjectWrapper().particleSpecies[popID].mass;
       const Real initRho0 = this->rhoRnd[0];
@@ -209,9 +209,9 @@ namespace projects {
       creal relx = x/(Parameters::xmax - Parameters::xmin);
       creal rely = y/(Parameters::ymax - Parameters::ymin);
       creal relz = z/(Parameters::zmax - Parameters::zmin);
-      creal scaledVx1 = this->Vx[1] * relx;
-      creal scaledVy1 = this->Vy[1] * rely;
-      creal scaledVz1 = this->Vz[1] * relz;
+      //creal scaledVx1 = this->Vx[1] * relx;
+      //creal scaledVy1 = this->Vy[1] * rely;
+      //creal scaledVz1 = this->Vz[1] * relz;
 
       const Real mass = getObjectWrapper().particleSpecies[popID].mass;
       const Real initRho0 = this->rhoRnd[0];

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -251,7 +251,7 @@ namespace projects {
 
       // Call project-specific fill function, which loops over all requested blocks,
       // fills v-space into target
-      const Realf nullsum = fillPhaseSpace(cell, popID, nRequested);
+      fillPhaseSpace(cell, popID, nRequested);
       if (rescalesDensity(popID) == true) {
          rescaleDensity(cell,popID);
       }

--- a/spatial_cells/spatial_cell_cpu.hpp
+++ b/spatial_cells/spatial_cell_cpu.hpp
@@ -206,7 +206,7 @@ namespace spatial_cell {
             // Get local ID of the target block. If the block doesn't exist, create it.
             vmesh::GlobalID toBlockLID = vmesh->getLocalID(incBlockGID);
             if (toBlockLID == vmesh->invalidLocalID()) {
-               bool success = vmesh->push_back(incBlockGID);
+               vmesh->push_back(incBlockGID);
                toBlockLID = blockContainer->push_back_and_zero();
                Real* parameters = blockContainer->getParameters(toBlockLID);
                vmesh->getBlockInfo(incBlockGID, parameters+BlockParams::VXCRD);

--- a/spatial_cells/velocity_block_container.h
+++ b/spatial_cells/velocity_block_container.h
@@ -569,7 +569,7 @@ namespace vmesh {
       #endif
 #else
       const vmesh::LocalID numberOfBlocks = block_data.size()/WID3;
-      const vmesh::LocalID currentCapacity = block_data.capacity()/WID3;
+      //const vmesh::LocalID currentCapacity = block_data.capacity()/WID3;
 #endif
       const vmesh::LocalID newIndex = numberOfBlocks;
 
@@ -608,7 +608,7 @@ namespace vmesh {
       #endif
 #else
       const vmesh::LocalID numberOfBlocks = block_data.size()/WID3;
-      const vmesh::LocalID currentCapacity = block_data.capacity()/WID3;
+      //const vmesh::LocalID currentCapacity = block_data.capacity()/WID3;
 #endif
       const vmesh::LocalID newIndex = numberOfBlocks;
 

--- a/sysboundary/ionosphere.cpp
+++ b/sysboundary/ionosphere.cpp
@@ -1368,7 +1368,7 @@ namespace SBC {
 
                      // Find the two other nodes on this element
                      int gridI = 0, gridJ = 0;
-                     int localC = 0, localI = 0, localJ = 0;
+                     int localI = 0, localJ = 0;
                      for (int c = 0; c < 3; c++) {
                         if (element.corners[c] == n) {
                            localI = (c + 1) % 3;

--- a/vlasovsolver/arch_moments.cpp
+++ b/vlasovsolver/arch_moments.cpp
@@ -69,7 +69,7 @@ void calculateCellMoments(spatial_cell::SpatialCell* cell,
       vmesh::VelocityMesh* vmesh    = cell->dev_get_velocity_mesh(popID);
       vmesh::VelocityBlockContainer* blockContainer = cell->dev_get_velocity_blocks(popID);
       #else
-      vmesh::VelocityMesh* vmesh    = cell->get_velocity_mesh(popID);
+      //vmesh::VelocityMesh* vmesh    = cell->get_velocity_mesh(popID);
       vmesh::VelocityBlockContainer* blockContainer = cell->get_velocity_blocks(popID);
       #endif
       const uint nBlocks = cell->get_velocity_mesh(popID)->size();
@@ -127,7 +127,7 @@ void calculateCellMoments(spatial_cell::SpatialCell* cell,
       vmesh::VelocityMesh* vmesh    = cell->dev_get_velocity_mesh(popID);
       vmesh::VelocityBlockContainer* blockContainer = cell->dev_get_velocity_blocks(popID);
       #else
-      vmesh::VelocityMesh* vmesh    = cell->get_velocity_mesh(popID);
+      //vmesh::VelocityMesh* vmesh    = cell->get_velocity_mesh(popID);
       vmesh::VelocityBlockContainer* blockContainer = cell->get_velocity_blocks(popID);
       #endif
       const uint nBlocks = cell->get_velocity_mesh(popID)->size();
@@ -219,7 +219,7 @@ void calculateMoments_R(
          vmesh::VelocityMesh* vmesh    = cell->dev_get_velocity_mesh(popID);
          vmesh::VelocityBlockContainer* blockContainer = cell->dev_get_velocity_blocks(popID);
          #else
-         vmesh::VelocityMesh* vmesh    = cell->get_velocity_mesh(popID);
+         //vmesh::VelocityMesh* vmesh    = cell->get_velocity_mesh(popID);
          vmesh::VelocityBlockContainer* blockContainer = cell->get_velocity_blocks(popID);
          #endif
          const uint nBlocks = cell->get_velocity_mesh(popID)->size();
@@ -385,7 +385,7 @@ void calculateMoments_V(
          vmesh::VelocityMesh* vmesh    = cell->dev_get_velocity_mesh(popID);
          vmesh::VelocityBlockContainer* blockContainer = cell->dev_get_velocity_blocks(popID);
          #else
-         vmesh::VelocityMesh* vmesh    = cell->get_velocity_mesh(popID);
+         //vmesh::VelocityMesh* vmesh    = cell->get_velocity_mesh(popID);
          vmesh::VelocityBlockContainer* blockContainer = cell->get_velocity_blocks(popID);
          #endif
          const uint nBlocks = cell->get_velocity_mesh(popID)->size();
@@ -461,7 +461,7 @@ void calculateMoments_V(
          vmesh::VelocityMesh* vmesh    = cell->dev_get_velocity_mesh(popID);
          vmesh::VelocityBlockContainer* blockContainer = cell->dev_get_velocity_blocks(popID);
          #else
-         vmesh::VelocityMesh* vmesh    = cell->get_velocity_mesh(popID);
+         //vmesh::VelocityMesh* vmesh    = cell->get_velocity_mesh(popID);
          vmesh::VelocityBlockContainer* blockContainer = cell->get_velocity_blocks(popID);
          #endif
          const uint nBlocks = cell->get_velocity_mesh(popID)->size();
@@ -470,7 +470,7 @@ void calculateMoments_V(
          }
 
          const Real mass = getObjectWrapper().particleSpecies[popID].mass;
-         const Real charge = getObjectWrapper().particleSpecies[popID].charge;
+         //const Real charge = getObjectWrapper().particleSpecies[popID].charge;
 
          // Temporary array where moments are stored
          Real array[nMom2] = {0};


### PR DESCRIPTION
I like to run with all warnings disabled when building on my local machine, and these ones were annoyingly scrolling through.

This should have zero functional change. CI, tell me that this is true!