### PR TITLE
Set relative diff to 0 if absolute is 0

### DIFF
--- a/tools/vlsvdiff.cpp
+++ b/tools/vlsvdiff.cpp
@@ -878,6 +878,9 @@ bool pDistance(const map<uint, Real>& orderedData1, const map<uint, Real>& order
 
    if (length != 0.0)
       *relative = *absolute / length;
+   else if (*absolute==0) {
+      *relative=0;
+   }
    else {
       cout << "WARNING (pDistance) : length of reference is 0.0, cannot divide to give relative distance." << endl;
       *relative = -1;


### PR DESCRIPTION
Currently if absolute is 0 and the reference dataset is zeros it will print relative as -1, this changes it so if absolute is 0 the relative will be 0 too in such a case.

