### PR TITLE
roihu_gpu small updates

### DIFF
--- a/MAKE/Makefile.roihu_gpu
+++ b/MAKE/Makefile.roihu_gpu
@@ -18,6 +18,11 @@ LIB_MPI = -lgomp
 LIB_CUDA = -L/usr/local/cuda/lib64
 INC_CUDA = -isystem /usr/local/cuda/include
 
+#======== PAPI ==========
+#Add PAPI_MEM define to use papi to report memory consumption?
+CXXFLAGS +=  -DPAPI_MEM
+testpackage: CXXFLAGS +=  -DPAPI_MEM
+
 # module libraries
 LIB_PAPI = -lpapi
 LIB_BOOST = -lboost_program_options

--- a/modules/roihu_gpu.sh
+++ b/modules/roihu_gpu.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 module load cmake
+module load gcc/14.3.0
 module load cuda/12.9.1
 module load openmpi/5.0.10
 module load papi/7.2.0


### PR DESCRIPTION
This helps with the fact slurm inherits the modules upon sbatch.

Note cuda/13.0.2 is available with gcc 15 but this was now working off @kstppd's existing scripts.