### PR TITLE
List all available output options

### DIFF
--- a/datareduction/datareducer.cpp
+++ b/datareduction/datareducer.cpp
@@ -50,7 +50,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
       std::string lowercase = *it;
       for(auto& c : lowercase) c = tolower(c);
 
-      if(P::systemWriteAllDROs || lowercase == "fg_b" || lowercase == "b") { // Bulk magnetic field at Yee-Lattice locations
+      if(P::systemWriteAllDROs || lowercase == "b" || lowercase == "fg_b") { // Bulk magnetic field at Yee-Lattice locations
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_b",[](
             const FieldSolverData& fieldSolverData)->std::vector<double> {
                const auto* gridSize = &fieldSolverData.fsgrid.getLocalSize()[0];
@@ -147,7 +147,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::systemWriteAllDROs || lowercase == "fg_e" || lowercase == "e") { // Bulk electric field at Yee-lattice locations
+      if(P::systemWriteAllDROs || lowercase == "e" || lowercase == "fg_e") { // Bulk electric field at Yee-lattice locations
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_e",[](
             const FieldSolverData& fieldSolverData)->std::vector<double> {
                const auto* gridSize = &fieldSolverData.fsgrid.getLocalSize()[0];
@@ -171,7 +171,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::systemWriteAllDROs || lowercase == "vg_rhom" || lowercase == "rhom") { // Overall mass density (summed over all populations)
+      if(P::systemWriteAllDROs || lowercase == "rhom" || lowercase == "vg_rhom") { // Overall mass density (summed over all populations)
          outputReducer->addOperator(new DRO::DataReductionOperatorCellParams("vg_rhom",CellParams::RHOM,1));
          outputReducer->addMetadata(outputReducer->size()-1,"kg/m^3","$\\mathrm{kg}\\,\\mathrm{m}^{-3}$","$\\rho_\\mathrm{m}$","1.0");
          if(!P::systemWriteAllDROs) {
@@ -207,7 +207,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::systemWriteAllDROs || lowercase == "vg_rhoq" || lowercase == "rhoq") { // Overall charge density (summed over all populations)
+      if(P::systemWriteAllDROs || lowercase == "rhoq" || lowercase == "vg_rhoq") { // Overall charge density (summed over all populations)
          outputReducer->addOperator(new DRO::DataReductionOperatorCellParams("vg_rhoq",CellParams::RHOQ,1));
          outputReducer->addMetadata(outputReducer->size()-1,"C/m^3","$\\mathrm{C}\\,\\mathrm{m}^{-3}$","$\\rho_\\mathrm{q}$","1.0");
          if(!P::systemWriteAllDROs) {
@@ -279,7 +279,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::systemWriteAllDROs || lowercase == "vg_nu0" || lowercase == "nu0") { // nu0 for sub-grid diffusion
+      if(P::systemWriteAllDROs || lowercase == "nu0" || lowercase == "vg_nu0") { // nu0 for sub-grid diffusion
          outputReducer->addOperator(new DRO::DataReductionOperatorCellParams("vg_nu0",CellParams::NU0,1));
          outputReducer->addMetadata(outputReducer->size()-1,"1/s","$\\mathrm{s}^{-1}$","$\\nu_0$","1.0");
          if(!P::systemWriteAllDROs) {
@@ -371,7 +371,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::systemWriteAllDROs || lowercase == "populations_maxvdt" || lowercase == "populations_vg_maxdt_acceleration" || lowercase == "populations_maxdt_acceleration") {
+      if(P::systemWriteAllDROs || lowercase == "populations_maxvdt" || lowercase == "populations_maxdt_acceleration" || lowercase == "populations_vg_maxdt_acceleration") {
          // Per-population maximum timestep constraint as calculated by the velocity space vlasov update
          for(unsigned int i =0; i < getObjectWrapper().particleSpecies.size(); i++) {
             species::Species& species=getObjectWrapper().particleSpecies[i];
@@ -391,7 +391,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::systemWriteAllDROs || lowercase == "populations_maxrdt" || lowercase == "populations_vg_maxdt_translation" || lowercase == "populations_maxdt_translation") {
+      if(P::systemWriteAllDROs || lowercase == "populations_maxrdt" || lowercase == "populations_maxdt_translation" || lowercase == "populations_vg_maxdt_translation") {
          // Per-population maximum timestep constraint as calculated by the real space vlasov update
          for(unsigned int i =0; i < getObjectWrapper().particleSpecies.size(); i++) {
             species::Species& species=getObjectWrapper().particleSpecies[i];
@@ -417,7 +417,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::systemWriteAllDROs || lowercase == "populations_precipitationflux" || lowercase == "populations_vg_precipitationdifferentialflux" || lowercase == "populations_precipitationdifferentialflux") {
+      if(P::systemWriteAllDROs || lowercase == "populations_precipitationflux" || lowercase == "populations_precipitationdifferentialflux" || lowercase == "populations_vg_precipitationdifferentialflux") {
          // Per-population precipitation differential flux (within loss cone)
          for(unsigned int i =0; i < getObjectWrapper().particleSpecies.size(); i++) {
             species::Species& species=getObjectWrapper().particleSpecies[i];
@@ -443,7 +443,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::systemWriteAllDROs || lowercase == "populations_precipitationlineflux" || lowercase == "populations_vg_precipitationlinedifferentialflux" || lowercase == "populations_precipitationlinedifferentialflux") {
+      if(P::systemWriteAllDROs || lowercase == "populations_precipitationlineflux" || lowercase == "populations_precipitationlinedifferentialflux" || lowercase == "populations_vg_precipitationlinedifferentialflux") {
          // Per-population precipitation differential flux (along line)
          for(unsigned int i =0; i < getObjectWrapper().particleSpecies.size(); i++) {
             species::Species& species=getObjectWrapper().particleSpecies[i];
@@ -469,7 +469,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if (P::systemWriteAllDROs || lowercase == "populations_nonmaxwellianity" || lowercase == "populations_vg_nonmaxwellianity") {
+      if(P::systemWriteAllDROs || lowercase == "populations_nonmaxwellianity" || lowercase == "populations_vg_nonmaxwellianity") {
          // Per-population dimensionless non-maxwellianity parameter
          for (unsigned int i = 0; i < getObjectWrapper().particleSpecies.size(); i++) {
             species::Species& species = getObjectWrapper().particleSpecies[i];
@@ -668,7 +668,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::systemWriteAllDROs || lowercase == "vole" || lowercase == "vg_vole" || lowercase == "evol" || lowercase == "vg_e_vol" || lowercase == "e_vol") {
+      if(P::systemWriteAllDROs || lowercase == "vole" || lowercase == "vg_vole" || lowercase == "evol" || lowercase == "e_vol" || lowercase == "vg_e_vol") {
          // Volume-averaged E field
          outputReducer->addOperator(new DRO::DataReductionOperatorCellParams("vg_e_vol",CellParams::EXVOL,3));
          outputReducer->addMetadata(outputReducer->size()-1,"V/m","$\\mathrm{V}\\,\\mathrm{m}^{-1}$","$E_\\mathrm{vol,vg}$","1.0");
@@ -676,7 +676,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::systemWriteAllDROs || lowercase == "fg_vole" || lowercase == "fg_e_vol" || lowercase == "fg_evol") { // Volume-averaged E field from the fieldSolver grid
+      if(P::systemWriteAllDROs || lowercase == "fg_vole" || lowercase == "fg_evol" || lowercase == "fg_e_vol") { // Volume-averaged E field from the fieldSolver grid
          outputReducer->addOperator(new DRO::DataReductionOperatorFsGrid("fg_e_vol",[](
             const FieldSolverData& fieldSolverData)->std::vector<double> {
                const auto* gridSize = &fieldSolverData.fsgrid.getLocalSize()[0];
@@ -825,7 +825,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::systemWriteAllDROs || lowercase == "bvolderivs" || lowercase == "b_vol_derivs" || lowercase == "b_vol_derivatives" || lowercase == "vg_b_vol_derivatives" || lowercase == "derivs") {
+      if(P::systemWriteAllDROs || lowercase == "bvolderivs" || lowercase == "b_vol_derivs" || lowercase == "b_vol_derivatives" || lowercase == "derivs" || lowercase == "vg_b_vol_derivatives") {
          // Volume-averaged derivatives
          outputReducer->addOperator(new DRO::DataReductionOperatorBVOLDerivatives("vg_derivatives/vg_dperbxvoldx",bvolderivatives::dPERBXVOLdx,1));
          outputReducer->addOperator(new DRO::DataReductionOperatorBVOLDerivatives("vg_derivatives/vg_dperbxvoldy",bvolderivatives::dPERBXVOLdy,1));
@@ -2802,7 +2802,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::diagnosticWriteAllDROs || lowercase == "vg_rhom" || lowercase == "rhom") {
+      if(P::diagnosticWriteAllDROs || lowercase == "rhom" || lowercase == "vg_rhom") {
          // Overall mass density
          diagnosticReducer->addOperator(new DRO::DataReductionOperatorCellParams("vg_rhom",CellParams::RHOM,1));
          if(!P::diagnosticWriteAllDROs) {
@@ -2820,7 +2820,7 @@ void initializeDataReducers(DataReducer * outputReducer, DataReducer * diagnosti
             continue;
          }
       }
-      if(P::diagnosticWriteAllDROs || lowercase == "lbweight" || lowercase == "vg_lbweight" || lowercase == "vg_loadbalanceweight" || lowercase == "vg_loadbalance_weight" || lowercase == "loadbalance_weight") {
+      if(P::diagnosticWriteAllDROs || lowercase == "lbweight" || lowercase == "vg_lbweight" || lowercase == "vg_loadbalanceweight" || lowercase == "loadbalance_weight" || lowercase == "vg_loadbalance_weight") {
          diagnosticReducer->addOperator(new DRO::DataReductionOperatorCellParams("vg_loadbalance_weight",CellParams::LBWEIGHTCOUNTER,1));
          if(!P::diagnosticWriteAllDROs) {
             continue;

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -445,28 +445,25 @@ bool P::addParameters() {
                     string() +
                         "List of data reduction operators (DROs) to add to the grid file output.  Each variable to be "
                         "added has to be on a new line output = XXX. Names are case insensitive.  " +
-                        "Available (20250413): " + "fg_b fg_b_background fg_b_perturbed fg_b_background_vol fg_derivs_b_background fg_e " +
-                        "vg_rhom vg_rhoq populations_vg_rho " + "fg_rhom fg_rhoq " + "vg_v fg_v populations_vg_v " +
-                        "populations_vg_moments_thermal populations_vg_moments_nonthermal " +
-                        "populations_vg_effectivesparsitythreshold populations_vg_rho_loss_adjust " +
-                        "populations_vg_energydensity populations_vg_precipitationdifferentialflux " +
-                        "populations_vg_heatflux " + "populations_vg_1dmuspace " +
-                        "populations_vg_nonmaxwellianity " +
-                        "vg_maxdt_acceleration vg_maxdt_translation populations_vg_maxdt_acceleration " +
-                        "populations_vg_maxdt_translation " +
-                        "fg_maxdt_fieldsolver " + "vg_rank fg_rank fg_amr_level vg_loadbalance_weight " +
-                        "vg_boundarytype fg_boundarytype vg_boundarylayer fg_boundarylayer " +
-                        "populations_vg_blocks vg_f_saved " + "populations_vg_acceleration_subcycles " +
-                        "vg_e_vol fg_e_vol " +
-                        "fg_e_hall vg_e_gradpe fg_b_vol vg_b_vol vg_b_background_vol vg_b_perturbed_vol " +
-                        "vg_pressure fg_pressure populations_vg_ptensor " + "vg_b_vol_derivatives fg_derivs " +
-                        "ig_fac ig_latitude ig_chi0 ig_cellarea ig_upmappedarea ig_sigmap ig_sigmah ig_sigmaparallel ig_rhon " +
-                        "ig_electrontemp ig_solverinternals ig_upmappednodecoords ig_upmappedb ig_openclosed ig_potential "+
-                        "ig_precipitation ig_deltaphi "+
-                        "ig_inplanecurrent ig_b ig_e vg_drift vg_ionospherecoupling vg_connection vg_fluxrope fg_curvature "+
-                        "vg_amr_drho vg_amr_du vg_amr_dpsq vg_amr_dbsq vg_amr_db vg_amr_alpha1 vg_amr_reflevel vg_amr_alpha2 "+
-                        "vg_gridcoordinates fg_gridcoordinates vg_pressure_anisotropy vg_amr_vorticity");
-
+                        "Available (20260618): " +
+                        "fg_amr_level fg_b fg_b_background fg_b_background_vol fg_boundarylayer fg_boundarytype fg_b_perturbed fg_b_vol " +
+                        "fg_curvature fg_derivs fg_derivs_b_background fg_e fg_e_hall fg_e_vol fg_gridcoordinates fg_maxdt_fieldsolver " +
+                        "fg_pressure fg_rank fg_rhom fg_rhoq fg_v " +
+                        "ig_b ig_cellarea ig_chi0 ig_deltaphi ig_e ig_electrontemp ig_fac ig_inplanecurrent ig_jfromcurlj ig_jfromdivj " +
+                        "ig_latitude ig_openclosed ig_potential ig_precipavgenergy ig_precipitation ig_precipnumflux ig_rhon ig_sigmah " +
+                        "ig_sigmap ig_sigmaparallel ig_solverinternals ig_upmappedarea ig_upmappedb ig_upmappednodecoords " +
+                        "populations_vg_1dmuspace populations_vg_acceleration_subcycles populations_vg_blocks " +
+                        "populations_vg_effectivesparsitythreshold populations_vg_energydensity populations_vg_heatflux " +
+                        "populations_vg_maxdt_acceleration populations_vg_maxdt_translation populations_vg_moments_nonthermal " +
+                        "populations_vg_moments_thermal populations_vg_nonmaxwellianity populations_vg_precipitationdifferentialflux " +
+                        "populations_vg_precipitationlinedifferentialflux populations_vg_ptensor populations_vg_rho " +
+                        "populations_vg_rho_loss_adjust populations_vg_v " +
+                        "vg_amr_alpha1 vg_amr_alpha2 vg_amr_db vg_amr_dbsq vg_amr_dpsq vg_amr_drho vg_amr_du vg_amr_reflevel " +
+                        "vg_amr_vorticity " +
+                        "vg_b_background_vol vg_boundarylayer vg_boundarytype vg_b_perturbed_vol vg_b_vol vg_b_vol_derivatives " +
+                        "vg_connection vg_curvature vg_drift vg_e_gradpe vg_e_vol vg_fluxrope vg_f_saved vg_gridcoordinates " +
+                        "vg_ionospherecoupling vg_loadbalance_weight vg_maxdt_acceleration vg_maxdt_translation vg_nu0 vg_pressure " +
+                        "vg_pressure_anisotropy vg_rank vg_rhom vg_rhoq vg_v");
    RP::addComposing(
        "variables_deprecated.output",
        string() + "List of deprecated names for data reduction operators (DROs). Names are case insensitive. " +

--- a/tools/generate_variable_docstrings.sh
+++ b/tools/generate_variable_docstrings.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# get a list of documented output variables
+#
+# run the vlasiator binary to get the current help text
+# replace all newlines with spaces to concat multiline text for each option
+# reintroduce linebreaks at the -- that start new options
+# grab the variables.output option
+# break at the colon
+# remove duplicate spaces that come from multicolumn format
+# remove remaining spaces with newlines to get one documented DRO per line
+# sort alphabetically
+# run through uniq to get rid of redundent empty newlines
+# dump to a file
+./vlasiator --help |\
+   tr '\n' ' ' |\
+   sed -e "s/--/\n--/g" |\
+   grep variables.output |\
+   cut -d : -f 2- |\
+   tr -s " " |\
+   tr ' ' '\n' |\
+   sort |\
+   uniq > /tmp/listed_output.txt
+
+# get a list of existing output variables
+#
+# grep for the common pattern in datareduction/datareducer.cpp
+# take the last option in quotes
+# sort alphabetically
+# run through uniq to get rid of redundent empty newlines
+# dump to a file
+grep "if(P::systemWriteAllDROs || lowercase ==" ./datareduction/datareducer.cpp |\
+   rev | cut -d '"' -f 2 | rev |\
+   sort |\
+   uniq > /tmp/grep_output.txt
+
+echo "variables.output string for parameters.cpp"
+echo "Available ("$(date +%Y%m%d)"): "$(cat /tmp/grep_output.txt | tr '\n' ' ')
+
+
+echo " "
+
+
+# get a list of documented diagnostic variables
+#
+# run the vlasiator binary to get the current help text
+# replace all newlines with spaces to concat multiline text for each option
+# reintroduce linebreaks at the -- that start new options
+# grab the variables.diagnostic option
+# break at the colon
+# remove duplicate spaces that come from multicolumn format
+# remove remaining spaces with newlines to get one documented DRO per line
+# sort alphabetically
+# run through uniq to get rid of redundent empty newlines
+# dump to a file
+./vlasiator --help |\
+   tr '\n' ' ' |\
+   sed -e "s/--/\n--/g" |\
+   grep variables.diagnostic |\
+   cut -d : -f 2- |\
+   tr -s " " |\
+   tr ' ' '\n' |\
+   sort |\
+   uniq > /tmp/listed_diagnostic.txt
+
+# get a list of existing diagnostic variables
+#
+# grep for the common pattern in datareduction/datareducer.cpp
+# take the last option in quotes
+# sort alphabetically
+# run through uniq to get rid of redundent empty newlines
+# dump to a file
+grep "if(P::diagnosticWriteAllDROs || lowercase ==" ./datareduction/datareducer.cpp |\
+   rev | cut -d '"' -f 2 | rev |\
+   sort |\
+   uniq > /tmp/grep_diagnostic.txt
+
+echo "variables.diagnostic string for parameters.cpp"
+echo "Available ("$(date +%Y%m%d)"): "$(cat /tmp/grep_diagnostic.txt | tr '\n' ' ')


### PR DESCRIPTION
Add missing ig_jfromcurlj, ig_jfromdivj, ig_precipavgenergy, ig_precipnumfluxm populations_vg_precipitationlinedifferentialflux, vg_curvature, and vg_nu0 options to variables.output. More importantly create a script that collects the lists automatically. Ideally we would also generate the tables at https://github.com/fmihpc/vlasiator/wiki/Output-data-formats and https://fmihpc.github.io/analysator/analysator_supported/ automatically.
