### PR TITLE
changed default_random_engine to knuth_b , simple S&R

### DIFF
--- a/particles/distribution.cpp
+++ b/particles/distribution.cpp
@@ -23,14 +23,14 @@
 #include "distribution.h"
 #include "particles.h"
 
-Distribution::Distribution(std::default_random_engine& _rand) : rand(_rand) {
+Distribution::Distribution(std::knuth_b& _rand) : rand(_rand) {
    mass = ParticleParameters::mass;
    charge = ParticleParameters::charge;
 }
-Maxwell_Boltzmann::Maxwell_Boltzmann(std::default_random_engine& _rand) : 
+Maxwell_Boltzmann::Maxwell_Boltzmann(std::knuth_b& _rand) : 
    Distribution(_rand), velocity_distribution {std::normal_distribution<Real>(0., sqrt(ParticleParameters::temperature * PhysicalConstantsSI::k / mass))} {}
 
-Monoenergetic::Monoenergetic(std::default_random_engine& _rand) : Distribution(_rand) {
+Monoenergetic::Monoenergetic(std::knuth_b& _rand) : Distribution(_rand) {
    vel = ParticleParameters::particle_vel;
 }
 
@@ -66,12 +66,12 @@ double Kappa::find_v_for_r(double rand) {
    return maxw0/lookup_size*(a + (rand-lookup[a])/(lookup[a+1]-lookup[a]));
 }
 
-Kappa6::Kappa6(std::default_random_engine& _rand) : Kappa(_rand) {
+Kappa6::Kappa6(std::knuth_b& _rand) : Kappa(_rand) {
    Real kT = ParticleParameters::temperature * PhysicalConstantsSI::k;
    w0 = sqrt(2.* kT *(6. - 1.5)/(6. * mass));
    generate_lookup();
 }
-Kappa2::Kappa2(std::default_random_engine& _rand) : Kappa(_rand) {
+Kappa2::Kappa2(std::knuth_b& _rand) : Kappa(_rand) {
    Real kT = ParticleParameters::temperature * PhysicalConstantsSI::k;
    w0 = sqrt(2.* kT *(2. - 1.5)/(2. * mass));
    generate_lookup();

--- a/particles/distribution.h
+++ b/particles/distribution.h
@@ -30,13 +30,13 @@
 class Distribution
 {
    public:
-      Distribution(std::default_random_engine& _rand, Real _mass, Real _charge)
+      Distribution(std::knuth_b& _rand, Real _mass, Real _charge)
          : mass(_mass), charge(_charge),rand(_rand) {};
-      Distribution(std::default_random_engine& _rand);
+      Distribution(std::knuth_b& _rand);
       virtual Particle next_particle() = 0;
    protected:
       Real mass,charge;
-      std::default_random_engine& rand;
+      std::knuth_b& rand;
 };
 
 
@@ -45,12 +45,12 @@ class Maxwell_Boltzmann : public Distribution
 {
    public:
       /* Constructor where all parameters are explicitly given */
-      Maxwell_Boltzmann(std::default_random_engine& _rand,Real _mass, Real _charge, Real kT) :
+      Maxwell_Boltzmann(std::knuth_b& _rand,Real _mass, Real _charge, Real kT) :
          Distribution(_rand,_mass,_charge),
          velocity_distribution(0,sqrt(kT/mass)) {};
 
       /* Constructor that fishes parameters from the parameter-class by itself */
-      Maxwell_Boltzmann(std::default_random_engine& _rand);
+      Maxwell_Boltzmann(std::knuth_b& _rand);
       virtual Particle next_particle();
    private:
       std::normal_distribution<Real> velocity_distribution;
@@ -60,11 +60,11 @@ class Maxwell_Boltzmann : public Distribution
 class Monoenergetic : public Distribution
 {
    public:
-      Monoenergetic(std::default_random_engine& _rand,Real _mass, Real _charge, Real _vel) :
+      Monoenergetic(std::knuth_b& _rand,Real _mass, Real _charge, Real _vel) :
          Distribution(_rand, _mass, _charge),
          vel(_vel) {
          }
-      Monoenergetic(std::default_random_engine& _rand);
+      Monoenergetic(std::knuth_b& _rand);
 
       virtual Particle next_particle() {
          /* Sphere point-picking to get isotropic direction (from wolfram Mathworld) */
@@ -88,10 +88,10 @@ class Monoenergetic : public Distribution
 class Kappa : public Distribution
 {
    public:
-      Kappa(std::default_random_engine& _rand, Real _mass, Real _charge, Real _w0, Real _maxw0)
+      Kappa(std::knuth_b& _rand, Real _mass, Real _charge, Real _w0, Real _maxw0)
          : Distribution(_rand,_mass,_charge),w0(_w0),maxw0(_maxw0) {}
 
-      Kappa(std::default_random_engine& _rand) : Distribution(_rand) {
+      Kappa(std::knuth_b& _rand) : Distribution(_rand) {
          maxw0=50;
       }
 
@@ -128,11 +128,11 @@ class Kappa6 : public Kappa
 {
 
    public:
-      Kappa6(std::default_random_engine& _rand, double _mass, double _charge, double _w0, double _maxw0)
+      Kappa6(std::knuth_b& _rand, double _mass, double _charge, double _w0, double _maxw0)
          : Kappa(_rand,_mass,_charge,_w0,_maxw0){
             generate_lookup();
       }
-      Kappa6(std::default_random_engine& _rand);
+      Kappa6(std::knuth_b& _rand);
 
    private:
       virtual void generate_lookup() {
@@ -158,11 +158,11 @@ class Kappa6 : public Kappa
 class Kappa2 : public Kappa
 {
    public:
-      Kappa2(std::default_random_engine& _rand, double _mass, double _charge, double _w0, double _maxw0)
+      Kappa2(std::knuth_b& _rand, double _mass, double _charge, double _w0, double _maxw0)
          : Kappa(_rand,_mass,_charge,_w0,_maxw0){
             generate_lookup();
       }
-      Kappa2(std::default_random_engine& _rand);
+      Kappa2(std::knuth_b& _rand);
 
    private:
       virtual void generate_lookup() {
@@ -183,6 +183,6 @@ class Kappa2 : public Kappa
       }
 };
 
-template<typename T> Distribution* createDistribution(std::default_random_engine& rand) {
+template<typename T> Distribution* createDistribution(std::knuth_b& rand) {
    return new T(rand);
 }

--- a/particles/particleparameters.cpp
+++ b/particles/particleparameters.cpp
@@ -44,8 +44,8 @@ std::string P::V_field_name = "V";
 std::string P::rho_field_name = "rho";
 bool P::divide_rhov_by_rho = false;
 
-std::default_random_engine::result_type P::random_seed = 1;
-Distribution* (*P::distribution)(std::default_random_engine&) = NULL;
+std::knuth_b::result_type P::random_seed = 1;
+Distribution* (*P::distribution)(std::knuth_b&) = NULL;
 Real P::temperature = 1e6;
 Real P::particle_vel = 0;
 Real P::mass = PhysicalConstantsSI::mp;
@@ -181,7 +181,7 @@ bool ParticleParameters::getParameters() {
    std::string distribution_name;
    Readparameters::get("particles.distribution",distribution_name);
 
-   std::map<std::string, Distribution*(*)(std::default_random_engine&)> distribution_lookup;
+   std::map<std::string, Distribution*(*)(std::knuth_b&)> distribution_lookup;
    distribution_lookup["maxwell"]=&createDistribution<Maxwell_Boltzmann>;
    distribution_lookup["monoenergetic"]=&createDistribution<Monoenergetic>;
    distribution_lookup["kappa2"]=&createDistribution<Kappa2>;

--- a/particles/particleparameters.h
+++ b/particles/particleparameters.h
@@ -73,8 +73,8 @@ struct ParticleParameters {
    static Real ipshock_transmit;  /*!< X-Coordinate for particle transmission (downstream) (meters) */
    static Real ipshock_reflect;   /*!< X-Coordinate for particle reflection (upstream) (meters) */
 
-   static std::default_random_engine::result_type random_seed; /*!< Random seed for particle creation */
-   static Distribution* (*distribution)(std::default_random_engine&); /*!< Type of distribution from which to sample the particles */
+   static std::knuth_b::result_type random_seed; /*!< Random seed for particle creation */
+   static Distribution* (*distribution)(std::knuth_b&); /*!< Type of distribution from which to sample the particles */
    static Real temperature; /*!< Initial particle temperature (for distributions where a temperature is meaningful) */
    static Real particle_vel; /*!< Initial particle velocity (for distributions with a single initial velocity) */
 

--- a/particles/scenario.cpp
+++ b/particles/scenario.cpp
@@ -58,7 +58,7 @@ ParticleContainer distributionScenario::initialParticles(Field& E, Field& B, Fie
 
    ParticleContainer particles;
 
-   std::default_random_engine generator(ParticleParameters::random_seed);
+   std::knuth_b generator(ParticleParameters::random_seed);
    Distribution* velocity_distribution=ParticleParameters::distribution(generator);
 
    Vec3d vpos(ParticleParameters::init_x, ParticleParameters::init_y, ParticleParameters::init_z);
@@ -202,7 +202,7 @@ void shockReflectivityScenario::newTimestep(int input_file_counter, int step, do
 
    const int num_points = 200;
 
-   std::default_random_engine generator(ParticleParameters::random_seed+step);
+   std::knuth_b generator(ParticleParameters::random_seed+step);
    Distribution* velocity_distribution=ParticleParameters::distribution(generator);
 
    // Create particles along a parabola, in front of the shock
@@ -313,7 +313,7 @@ ParticleContainer ipShockScenario::initialParticles(Field& E, Field& B, Field& V
    ParticleContainer particles;
 
    /* Prepare randomization engines */
-   std::default_random_engine generator(ParticleParameters::random_seed);
+   std::knuth_b generator(ParticleParameters::random_seed);
    Distribution* velocity_distribution=ParticleParameters::distribution(generator);
 
    std::random_device rd;

--- a/projects/Dispersion/Dispersion.cpp
+++ b/projects/Dispersion/Dispersion.cpp
@@ -208,7 +208,7 @@ namespace projects {
    }
 
    void Dispersion::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {
-      std::default_random_engine rndState;
+      std::knuth_b rndState;
       setRandomCellSeed(cell,rndState);
 
       this->rndRho=getRandomNumber(rndState);
@@ -244,7 +244,7 @@ namespace projects {
             auto& cell = perb[stencil.ooo()];
 
             const auto seedmodifier = coordinates.globalIDFromLocalCoordinates(stencil.i, stencil.j, stencil.k);
-            std::default_random_engine rndState_l;
+            std::knuth_b rndState_l;
             rndState_l.seed(seed+seedmodifier);
             Real rndBuffer[3];
             rndBuffer[0] = std::uniform_real_distribution<>(-0.5,0.5)(rndState_l);

--- a/projects/Distributions/Distributions.cpp
+++ b/projects/Distributions/Distributions.cpp
@@ -242,7 +242,7 @@ namespace projects {
    }
 
    void Distributions::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {
-      std::default_random_engine rndState;
+      std::knuth_b rndState;
       setRandomCellSeed(cell,rndState);
       for (uint i=0; i<2; i++) {
          this->rhoRnd[i] = this->rho[i] + this->rhoPertAbsAmp[i] * (0.5 - getRandomNumber(rndState));
@@ -280,7 +280,7 @@ namespace projects {
             auto& cell = perb[stencil.ooo()];
 
             const auto seedmodifier = coordinates.globalIDFromLocalCoordinates(stencil.i, stencil.j, stencil.k);
-            std::default_random_engine rndState_l;
+            std::knuth_b rndState_l;
             rndState_l.seed(seed+seedmodifier);
             Real rndBuffer[3];
             rndBuffer[0] = std::uniform_real_distribution<>(-0.5,0.5)(rndState_l);

--- a/projects/Fluctuations/Fluctuations.cpp
+++ b/projects/Fluctuations/Fluctuations.cpp
@@ -180,7 +180,7 @@ namespace projects {
 
    void Fluctuations::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {
 
-      std::default_random_engine rndState;
+      std::knuth_b rndState;
       setRandomCellSeed(cell,rndState);
 
       this->rndRho=getRandomNumber(rndState);
@@ -215,7 +215,7 @@ namespace projects {
             auto& cell = perb[stencil.ooo()];
 
             const auto seedmodifier = coordinates.globalIDFromLocalCoordinates(stencil.i, stencil.j, stencil.k);
-            std::default_random_engine rndState_l;
+            std::knuth_b rndState_l;
             rndState_l.seed(seed+seedmodifier);
             Real rndBuffer[3];
             rndBuffer[0] = std::uniform_real_distribution<>(-0.5,0.5)(rndState_l);

--- a/projects/KHB/KHB.cpp
+++ b/projects/KHB/KHB.cpp
@@ -121,7 +121,7 @@ namespace projects {
 
       // add an initial velocity perturbation to Vx
       // initialize RNG for calculating random phases for the initial perturbation
-      std::default_random_engine rndState;
+      std::knuth_b rndState;
       setRandomSeed(0,rndState);
       Real phase = 0.0;
 

--- a/projects/LossCone/LossCone.cpp
+++ b/projects/LossCone/LossCone.cpp
@@ -211,7 +211,7 @@ namespace projects {
          (int) ((y - Parameters::ymin) / dy) * Parameters::xcells_ini +
          (int) ((z - Parameters::zmin) / dz) * Parameters::xcells_ini * Parameters::ycells_ini;
 
-      std::default_random_engine rndState;
+      std::knuth_b rndState;
       setRandomCellSeed(cell,rndState);
 
       this->rndRho=getRandomNumber(rndState);
@@ -247,7 +247,7 @@ namespace projects {
             auto& cell = perb[stencil.ooo()];
 
             const auto seedmodifier = coordinates.globalIDFromLocalCoordinates(stencil.i, stencil.j, stencil.k);
-            std::default_random_engine rndState_l;
+            std::knuth_b rndState_l;
             rndState_l.seed(seed+seedmodifier);
             Real rndBuffer[3];
             rndBuffer[0] = std::uniform_real_distribution<>(-0.5,0.5)(rndState_l);

--- a/projects/MultiPeak/MultiPeak.cpp
+++ b/projects/MultiPeak/MultiPeak.cpp
@@ -265,7 +265,7 @@ namespace projects {
    }
 
    void MultiPeak::calcCellParameters(spatial_cell::SpatialCell* cell,creal& t) {
-      std::default_random_engine rndState;
+      std::knuth_b rndState;
       setRandomCellSeed(cell,rndState);
       rhoRnd = 0.5 - getRandomNumber(rndState);
    }
@@ -300,7 +300,7 @@ namespace projects {
             auto& cell = perb[stencil.ooo()];
 
             const auto seedmodifier = coordinates.globalIDFromLocalCoordinates(stencil.i, stencil.j, stencil.k);
-            std::default_random_engine rndState_l;
+            std::knuth_b rndState_l;
             rndState_l.seed(seed+seedmodifier);
             Real rndBuffer[3];
             rndBuffer[0] = std::uniform_real_distribution<>(-0.5,0.5)(rndState_l);

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -314,16 +314,16 @@ namespace projects {
    /** Get random number between 0 and 1.0. One should always first initialize the rng.
     * @param rngDataBuffer struct of type random_data
     * @return Uniformly distributed random number between 0 and 1.*/
-   Real Project::getRandomNumber(std::default_random_engine& randGen) const {
+   Real Project::getRandomNumber(std::knuth_b& randGen) const {
       return std::uniform_real_distribution<>(0,1)(randGen);
    }
 
    /** Set random seed (thread-safe). Seed is based on the seed read
     *  in from cfg + the seedModifier parameter
     * @param seedModifier value (e.g. CellID) to use as seed modifier
-    # @param randGen std::default_random_engine& to use
+    # @param randGen std::knuth_b& to use
    */
-   void Project::setRandomSeed(CellID seedModifier, std::default_random_engine& randGen) const {
+   void Project::setRandomSeed(CellID seedModifier, std::knuth_b& randGen) const {
       randGen.seed(this->seed+seedModifier);
    }
 
@@ -331,9 +331,9 @@ namespace projects {
     * this particular cellID. Can be used to make reproducible
     * simulations that do not depend on number of processes or threads.
     * @param cell SpatialCell used to infer CellID value to use as seed modifier
-    # @param randGen std::default_random_engine& to use
+    # @param randGen std::knuth_b& to use
    */
-   void Project::setRandomCellSeed(spatial_cell::SpatialCell* cell, std::default_random_engine& randGen) const {
+   void Project::setRandomCellSeed(spatial_cell::SpatialCell* cell, std::knuth_b& randGen) const {
       const creal x = cell->parameters[CellParams::XCRD];
       const creal y = cell->parameters[CellParams::YCRD];
       const creal z = cell->parameters[CellParams::ZCRD];

--- a/projects/project.h
+++ b/projects/project.h
@@ -200,7 +200,7 @@ namespace projects {
       /** Get random number between 0 and 1.0. One should always first initialize the rng.
        * @param rngDataBuffer struct of type random_data
        * @return Uniformly distributed random number between 0 and 1.*/
-      Real getRandomNumber(std::default_random_engine& randGen) const;
+      Real getRandomNumber(std::knuth_b& randGen) const;
 
       /** Set random seed (thread-safe). Seed is based on the seed read
        *  in from cfg + the seedModifier parameter
@@ -208,7 +208,7 @@ namespace projects {
        * @param rngStateBuffer buffer where random number values are kept
        * @param rngDataBuffer struct of type random_data
        */
-      void setRandomSeed(uint64_t seedModifier, std::default_random_engine& randGen) const;
+      void setRandomSeed(uint64_t seedModifier, std::knuth_b& randGen) const;
 
       /** Set random seed (thread-safe) that is always the same for
        * this particular cellID. Can be used to make reproducible
@@ -217,7 +217,7 @@ namespace projects {
        * @param rngStateBuffer buffer where random number values are kept
        * @param rngDataBuffer struct of type random_data
        */
-      void setRandomCellSeed(spatial_cell::SpatialCell* cell, std::default_random_engine& randGen) const;
+      void setRandomCellSeed(spatial_cell::SpatialCell* cell, std::knuth_b& randGen) const;
       
     private:
       uint seed;

--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -421,7 +421,7 @@ void calculateAcceleration(const uint popID,const uint globalMaxSubcycles,const 
 
    // set seed, initialise generator and get value. The order is the same
    // for all cells, but varies with timestep.
-   std::default_random_engine rndState;
+   std::knuth_b rndState;
    rndState.seed(P::tstep);
    uint map_order = std::uniform_int_distribution<>(0,2)(rndState);
 


### PR DESCRIPTION
A simple search and replace, since knuth_b is based on the LCG ~like default_random_engine but it just shuffles the sequence somehow, it should be better RNG even without changing the seed~ actually not 100% sure about this part, need to confirm UPDATE: I believe the default is not defined in the standard so i guess it varies across depending on whose standard library you use?

apparently dispersion looks better with this.

However the seeds should probably also be investigated.