### PR TITLE
Adding fieldline tracing to the magnetosphere_3d_small test

### DIFF
--- a/testpackage/test_definitions_small.sh
+++ b/testpackage/test_definitions_small.sh
@@ -235,8 +235,8 @@ variable_components[${index}]="0 0 1 2 0 1 2 0 1 2 0 1 2 0 1 2"
 test_name[${index}]="Magnetosphere_3D_small"
 comparison_vlsv[${index}]="bulk.0000001.vlsv bulk.0000002.vlsv"
 comparison_phiprof[${index}]="phiprof_0.txt"
-variable_names[${index}]="proton/vg_rho proton/vg_v proton/vg_v proton/vg_v fg_b fg_b fg_b fg_e fg_e fg_e"
-variable_components[${index}]="0 0 1 2 0 1 2 0 1 2"
+variable_names[${index}]="proton/vg_rho proton/vg_v proton/vg_v proton/vg_v fg_b fg_b fg_b fg_e fg_e fg_e vg_connection vg_connection_coordinates_fw vg_connection_coordinates_fw vg_connection_coordinates_fw  vg_connection_coordinates_bw vg_connection_coordinates_bw vg_connection_coordinates_bw"
+variable_components[${index}]="0 0 1 2 0 1 2 0 1 2 0 0 1 2 0 1 2"
 ((index+=1))
 
 # 24 Ionosphere 3D (not a very physical or successful test at the moment but verifies some things about IG grid and outputs all datareducers)
@@ -268,4 +268,4 @@ do
 done
 
 # Alternatively, set tests manually, e.g.
-# run_tests=( 1 6 9 )
+run_tests=( 23 )

--- a/testpackage/test_definitions_small.sh
+++ b/testpackage/test_definitions_small.sh
@@ -268,4 +268,4 @@ do
 done
 
 # Alternatively, set tests manually, e.g.
-run_tests=( 23 )
+# run_tests=( 1 6 9 )

--- a/testpackage/tests/Magnetosphere_3D_small/Magnetosphere_3D_small.cfg
+++ b/testpackage/tests/Magnetosphere_3D_small/Magnetosphere_3D_small.cfg
@@ -75,6 +75,10 @@ output = vg_rank
 output = vg_f_saved
 diagnostic = populations_vg_blocks
 
+output = vg_connection
+output = vg_fluxrope
+
+
 [boundaries]
 periodic_x = no
 periodic_y = no
@@ -141,3 +145,14 @@ taperInnerRadius = 70e6
 
 [bailout]
 velocity_space_wall_block_margin = 0
+
+[fieldtracing]
+fieldLineTracer = ADPT_Euler
+fluxrope_max_curvature_radii_to_trace = 12
+fluxrope_max_curvature_radii_extent = 10
+tracer_max_allowed_error = 1e5
+tracer_max_attempts = 100
+fullbox_max_incomplete_cells = 0.0005
+fluxrope_max_incomplete_cells = 0
+tracer_min_dx = 1e5
+


### PR DESCRIPTION
Does what it says on the tin, I think this could be good addition since I realized the testpackage doesn't test that. The fieldline tracing params are from the FHA run (comment if something is wonky with the params)