### PR TITLE
Fix vslv writer bug in ompio 4.x

### DIFF
--- a/tools/vlsvextract.cpp
+++ b/tools/vlsvextract.cpp
@@ -1986,10 +1986,53 @@ void extractDistribution( const string & fileName, const UserOptions & mainOptio
 }
 
 int main(int argn, char* args[]) {
+   // Deal with OpenMPI 4.x VLSV write bug
+   int required=MPI_THREAD_FUNNELED;
+   int provided, resultlen;
+   char mpiversion[MPI_MAX_LIBRARY_VERSION_STRING];
+   bool overrideMCAompio = false;
+
+   MPI_Get_library_version(mpiversion, &resultlen);
+   string versionstr = string(mpiversion);
+   stringstream mpiioMessage;
+   if(versionstr.find("Open MPI") != std::string::npos) {
+      #ifdef VLASIATOR_ALLOW_MCA_OMPIO
+         mpiioMessage << "We detected OpenMPI but the compilation flag VLASIATOR_ALLOW_MCA_OMPIO was set so we do not override the default MCA io flag." << endl;
+      #else
+         overrideMCAompio = true;
+         int index, count;
+         char io_value[64];
+         MPI_T_cvar_handle io_handle;
+         
+         MPI_T_init_thread(required, &provided);
+         MPI_T_cvar_get_index("io", &index);
+         MPI_T_cvar_handle_alloc(index, NULL, &io_handle, &count);
+         MPI_T_cvar_write(io_handle, "^ompio");
+         MPI_T_cvar_read(io_handle, io_value);
+         MPI_T_cvar_handle_free(&io_handle);
+         mpiioMessage << "We detected OpenMPI so we set the cvars value to disable ompio, MCA io: " << io_value << endl;
+      #endif
+   }
+
    int ntasks, rank;
-   MPI_Init(&argn, &args);
+   MPI_Init_thread(&argn,&args,required,&provided);
    MPI_Comm_size(MPI_COMM_WORLD, &ntasks);
    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+   if (required > provided){
+      if(rank == 0) {
+         cerr << "MPI_Init_thread failed! Got " << provided << ", need "<<required <<endl;
+      }
+      exit(1);
+   }
+   if (rank == 0) {
+      const char* mpiioenv = std::getenv("OMPI_MCA_io");
+      if(mpiioenv != nullptr) {
+         std::string mpiioenvstr(mpiioenv);
+         if(mpiioenvstr.find("^ompio") == std::string::npos) {
+            cout << mpiioMessage.str();
+         }
+      }
+   }
 
    //Get the file name
    const string mask = args[1];

--- a/tools/vlsvextract.cpp
+++ b/tools/vlsvextract.cpp
@@ -2062,6 +2062,10 @@ int main(int argn, char* args[]) {
          extractDistribution<vlsvinterface::Reader>( fileName, mainOptions );
       }
    }
+
+   if(overrideMCAompio) {
+      MPI_T_finalize();
+   }
    MPI_Finalize();
    return 0;
 }


### PR DESCRIPTION
By automagically setting OMPI_MCA_io=^ompio when required. This fixes the vlsvextract bug that Lauri was running into.