### PR TITLE
Implement error handling in CI_git_diff.sh

### DIFF
--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -1,6 +1,10 @@
 
 #!/usr/bin/env bash
 git_diff=$(git diff --name-only origin/$@...)
+if [[ $? != 0 ]]; then
+  echo "Something went wrong with getting git diff $git_diff"
+  exit 1
+fi
 declare -i full_count=$(echo $git_diff | wc -w)
 declare -a unallowed_strings=(".cpp\b" ".hpp\b" ".c\b" ".sh\b" )
 

--- a/.github/workflows/CI_git_diff.sh
+++ b/.github/workflows/CI_git_diff.sh
@@ -3,7 +3,7 @@
 git_diff=$(git diff --name-only origin/$@...)
 if [[ $? != 0 ]]; then
   echo "Something went wrong with getting git diff $git_diff"
-  exit 1
+  exit 0
 fi
 declare -i full_count=$(echo $git_diff | wc -w)
 declare -a unallowed_strings=(".cpp\b" ".hpp\b" ".c\b" ".sh\b" )


### PR DESCRIPTION
Add error handling for missing branch argument in CI script.

This should fix it failing if for example no branch was given as an argument

note that $git_diff should be empty then but I guess it's good for diagnosis if it does trigger despite successful git diff