### PR TITLE
Nest the fieldolver grid init timer properly

### DIFF
--- a/vlasiator.cpp
+++ b/vlasiator.cpp
@@ -448,6 +448,7 @@ int simulate(int argn,char* args[]) {
 
    // Initialize simplified Fieldsolver grids.
    // Needs to be done here already ad the background field will be set right away, before going to initializeGrid even
+   phiprof::Timer initGridsTimer {"Init grids"};
    phiprof::Timer initFsTimer {"Init fieldsolver grids"};
 
    const std::array<fsgrid::FsSize_t, 3> fsGridDimensions = {
@@ -493,7 +494,7 @@ int simulate(int argn,char* args[]) {
    fsgrid::FsData<std::array<Real, fsgrids::dmoments::N_DMOMENTS>> dmomentsdt2(fsgridNumElements);
    fsgrid::FsData<std::array<Real, fsgrids::bgbfield::N_BGB>> bgb(fsgridNumElements);
    fsgrid::FsData<std::array<Real, fsgrids::volfields::N_VOL>> vol(fsgridNumElements);
-
+   initFsTimer.stop();
 
    // Initialize grid.  After initializeGrid local cells have dist
    // functions, and B fields set. Cells have also been classified for
@@ -501,7 +502,6 @@ int simulate(int argn,char* args[]) {
    // created. All spatial date computed this far is up to date for
    // FULL_NEIGHBORHOOD. Block lists up to date for
    // VLASOV_SOLVER_NEIGHBORHOOD (but dist function has not been communicated)
-   phiprof::Timer initGridsTimer {"Init grids"};
    dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry> mpiGrid;
 
    initializeGrids(
@@ -536,6 +536,8 @@ int simulate(int argn,char* args[]) {
    // because we need a copy of the value from initialization in both perBGrid and perBDt2Grid and it isn't
    // touched as we are in boundary cells for components that aren't solved. We do a straight full copy instead
    // of looping and detecting boundary types here.
+   initFsTimer.start();
+
    fsgrid::FsData<std::array<Real, fsgrids::bfield::N_BFIELD>> perbdt2(perb.view());
    // fieldSolverData not const as we need to update the spans for moments and momentsdt2 when filtering
    FieldSolverData fieldSolverData(


### PR DESCRIPTION
... to get from 

```
 | 4   | 3   |     |     open logFile & diagnostic                                        | 1       | 0.001844  | 0.001068  | 45.19     | 1  |     
 | 5   | 3   |     |     Init project                                                     | 1       | 4.587e-07 | 2.657e-07 | 28.32     | 1  |
 | 6   | 3   |     |     Init fieldsolver grids                                           | 1       | 151.5     | 87.73     | 0.0002724 | 1  |      
 | 7   | 4   |     |       Init grids                                                     | 1       | 151.5     | 100       | 0.0002618 | 1  |
 | 8   | 5   |     |         Initialize DCCRG grid                                        | 1       | 20.93     | 13.82     | 4.808     | 1  |      
 | 9   | 5   |     |         Refine spatial cells                                         | 1       | 40.53     | 26.76     | 4.829     | 1  |

```
to
```
 | 5   | 3   |     |     Init project                                                   | 1      | 3.67e-07  | 5.281e-07 | 16.4      | 1  |        
 | 6   | 3   |     |     Init grids                                                     | 1      | 56.5      | 81.31     | 0.0003612 | 1  |
 | 7   | 4   |     |       Init fieldsolver grids                                       | 2      | 0.001073  | 0.001898  | 17.46     | 1  |         
 | 8   | 4   |     |       Initialize DCCRG grid                                        | 1      | 8.288     | 14.67     | 4.08      | 1  |
 | 9   | 4   |     |       Refine spatial cells                                         | 1      | 14.76     | 26.11     | 4.646     | 1  |          
 | 10  | 5   |     |         Magnetosphere: refine spatial cells                        | 1      | 4.474     | 30.32     | 35.42     | 1  |
```