### PR TITLE
In non-PR actions (like merges), TP is not run, so fluxtest fails

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -188,7 +188,7 @@ jobs:
         path: testpackage-output.tar.gz
     - &fluxTest
       name: Run fluxfunction test
-      if: ${{ matrix.run_tp }}
+      if: ${{ matrix.run_tp && needs.get_git_diff.outputs.RUN_TP != 'False' }}
       run: |
         ./.github/workflows/slurm_run.sh "FLUXTEST"
     - &uploadTools


### PR DESCRIPTION
This made CI on dev look more red, even though it looked better in the PR.